### PR TITLE
Send room state immediately on room creation

### DIFF
--- a/multiplayer-server.ts
+++ b/multiplayer-server.ts
@@ -175,10 +175,13 @@ function handleMessage(playerId: string, raw: string): void {
 
       const reconnectToken = issueReconnectToken(playerId);
 
+      const roomState = roomManager.getRoomState(roomCode);
+
       sendToPlayer(playerId, {
         type: 'room_created',
         roomCode,
         playerId: player.id,
+        roomState: roomState!,
         reconnectToken,
       });
 

--- a/src/components/rhythmia/MultiplayerGame.tsx
+++ b/src/components/rhythmia/MultiplayerGame.tsx
@@ -90,6 +90,9 @@ export default function MultiplayerGame() {
       case 'room_created':
         playerIdRef.current = msg.playerId;
         reconnectTokenRef.current = msg.reconnectToken;
+        setRoomState(msg.roomState);
+        setMode('waiting-room');
+        setError(null);
         break;
 
       case 'joined_room':
@@ -217,7 +220,6 @@ export default function MultiplayerGame() {
       roomName: newRoomName.trim() || undefined,
       isPublic: true,
     });
-    setMode('waiting-room');
   }, [send, playerName, newRoomName]);
 
   const joinRoomByCode = useCallback(() => {

--- a/src/types/multiplayer.ts
+++ b/src/types/multiplayer.ts
@@ -107,6 +107,7 @@ export interface RoomCreatedMessage {
   type: 'room_created';
   roomCode: string;
   playerId: string;
+  roomState: RoomState;
   reconnectToken: string;
 }
 


### PR DESCRIPTION
## Summary
This PR ensures that the room state is sent to the client immediately when a room is created, allowing the client to initialize with the correct state without waiting for additional messages.

## Key Changes
- **Server**: Modified `handleMessage` to fetch and include the room state in the `room_created` response
- **Client**: Updated the `room_created` message handler to set the room state and transition to waiting-room mode upon receiving the message
- **Types**: Added `roomState: RoomState` field to the `RoomCreatedMessage` interface
- **Removed redundant state transition**: Moved `setMode('waiting-room')` from the `createRoom` callback to the message handler, eliminating the race condition where mode was set before state was available

## Implementation Details
- The room state is now fetched from `roomManager.getRoomState()` on the server side before sending the response
- Client-side initialization is now consolidated in the message handler, ensuring state and mode are set together atomically
- This prevents the UI from rendering an incomplete state during the room creation flow

https://claude.ai/code/session_01D8DfDmiW51Pyd3tusfy8Ga