### PR TITLE
Add Firestore persistence for multiplayer room management

### DIFF
--- a/src/lib/multiplayer/FirestoreRoomService.ts
+++ b/src/lib/multiplayer/FirestoreRoomService.ts
@@ -1,141 +1,15 @@
 /**
  * Firestore Room Service
- * Manages room persistence in Google Firestore
+ *
+ * Room persistence is now handled directly by MultiplayerRoomManager
+ * via its Firestore write-through layer. Pass a Firestore instance to
+ * the RoomManager constructor and call loadFromFirestore() on startup.
+ *
+ * Collection: "multiplayer_rooms"
+ * Document ID: Room code (e.g., "ABCD")
+ *
+ * See RoomManager.ts for implementation details.
  */
 
-import { Firestore } from 'firebase-admin/firestore';
-import { RoomState, Player } from '@/types/multiplayer';
-
-export interface FirestoreRoomDocument {
-  name: string;
-  code: string;
-  createdAt: number;
-  updatedAt: number;
-  status: 'open' | 'in_game';
-  maxPlayers: number;
-  hostId: string;
-  players: {
-    id: string;
-    name: string;
-    isHost: boolean;
-    joinedAt: number;
-  }[];
-}
-
-export class FirestoreRoomService {
-  private db: Firestore;
-  private roomsCollection = 'rhythmia_rooms';
-  private roomTTL = 3600000; // 1 hour in milliseconds
-
-  constructor(firestore: Firestore) {
-    this.db = firestore;
-  }
-
-  /**
-   * Save or update a room in Firestore
-   */
-  async saveRoom(roomState: RoomState & { createdAt?: number; maxPlayers?: number }): Promise<void> {
-    const now = Date.now();
-    const doc: FirestoreRoomDocument = {
-      name: roomState.name || `Room ${roomState.code}`,
-      code: roomState.code,
-      createdAt: roomState.createdAt || now,
-      updatedAt: now,
-      status: roomState.status === 'playing' ? 'in_game' : 'open',
-      maxPlayers: roomState.maxPlayers || 8,
-      hostId: roomState.hostId,
-      players: roomState.players.map((p) => ({
-        id: p.id,
-        name: p.name,
-        isHost: p.id === roomState.hostId,
-        joinedAt: now,
-      })),
-    };
-
-    await this.db
-      .collection(this.roomsCollection)
-      .doc(roomState.code)
-      .set(doc, { merge: true });
-
-    console.log(`Room ${roomState.code} saved to Firestore`);
-  }
-
-  /**
-   * Get a room from Firestore
-   */
-  async getRoom(roomCode: string): Promise<FirestoreRoomDocument | null> {
-    const doc = await this.db
-      .collection(this.roomsCollection)
-      .doc(roomCode)
-      .get();
-
-    if (!doc.exists) {
-      return null;
-    }
-
-    return doc.data() as FirestoreRoomDocument;
-  }
-
-  /**
-   * List all open rooms
-   */
-  async listOpenRooms(): Promise<FirestoreRoomDocument[]> {
-    const snapshot = await this.db
-      .collection(this.roomsCollection)
-      .where('status', '==', 'open')
-      .orderBy('createdAt', 'desc')
-      .limit(50)
-      .get();
-
-    return snapshot.docs.map((doc) => doc.data() as FirestoreRoomDocument);
-  }
-
-  /**
-   * Delete a room from Firestore
-   */
-  async deleteRoom(roomCode: string): Promise<void> {
-    await this.db.collection(this.roomsCollection).doc(roomCode).delete();
-    console.log(`Room ${roomCode} deleted from Firestore`);
-  }
-
-  /**
-   * Clean up stale rooms (older than TTL)
-   */
-  async cleanupStaleRooms(): Promise<number> {
-    const cutoffTime = Date.now() - this.roomTTL;
-    const snapshot = await this.db
-      .collection(this.roomsCollection)
-      .where('updatedAt', '<', cutoffTime)
-      .get();
-
-    const batch = this.db.batch();
-    snapshot.docs.forEach((doc) => {
-      batch.delete(doc.ref);
-    });
-
-    await batch.commit();
-    const count = snapshot.docs.length;
-    
-    if (count > 0) {
-      console.log(`Cleaned up ${count} stale rooms from Firestore`);
-    }
-    
-    return count;
-  }
-
-  /**
-   * Update room status
-   */
-  async updateRoomStatus(
-    roomCode: string,
-    status: 'open' | 'in_game'
-  ): Promise<void> {
-    await this.db
-      .collection(this.roomsCollection)
-      .doc(roomCode)
-      .update({
-        status,
-        updatedAt: Date.now(),
-      });
-  }
-}
+export { MultiplayerRoomManager } from './RoomManager';
+export type { Room } from './RoomManager';

--- a/src/lib/multiplayer/firebase-admin.ts
+++ b/src/lib/multiplayer/firebase-admin.ts
@@ -1,0 +1,51 @@
+import { initializeApp, getApps, cert, App } from 'firebase-admin/app';
+import { getFirestore, Firestore } from 'firebase-admin/firestore';
+
+let adminApp: App | null = null;
+let adminDb: Firestore | null = null;
+
+export function getMultiplayerAdminApp(): App {
+  if (adminApp) {
+    return adminApp;
+  }
+
+  const apps = getApps();
+  if (apps.length > 0) {
+    adminApp = apps[0];
+    return adminApp;
+  }
+
+  const serviceAccountJson = process.env.FIREBASE_SERVICE_ACCOUNT_JSON;
+
+  if (!serviceAccountJson) {
+    throw new Error(
+      'FIREBASE_SERVICE_ACCOUNT_JSON environment variable is not set. ' +
+      'Firestore room persistence will not be available.'
+    );
+  }
+
+  try {
+    const serviceAccount = JSON.parse(serviceAccountJson);
+
+    adminApp = initializeApp({
+      credential: cert(serviceAccount),
+    });
+
+    return adminApp;
+  } catch (error) {
+    throw new Error(
+      `Failed to initialize Firebase Admin: ${error instanceof Error ? error.message : 'Unknown error'}`
+    );
+  }
+}
+
+export function getMultiplayerDb(): Firestore {
+  if (adminDb) {
+    return adminDb;
+  }
+
+  const app = getMultiplayerAdminApp();
+  adminDb = getFirestore(app);
+
+  return adminDb;
+}


### PR DESCRIPTION
Integrate Firestore as a write-through backing store for the MultiplayerRoomManager. The approach uses a hybrid architecture: in-memory Maps for fast reads during gameplay, with async Firestore writes on every mutation for persistence.

Key changes:
- RoomManager now accepts an optional Firestore instance; all room mutations (create, join, leave, ready, start, etc.) write through to a "multiplayer_rooms" collection
- On server startup, loadFromFirestore() restores active rooms so the server can recover after restarts
- Stale room cleanup also deletes Firestore documents
- multiplayer-server.ts initializes Firebase Admin from FIREBASE_SERVICE_ACCOUNT_JSON and passes the Firestore db to the room manager; gracefully falls back to in-memory only if the env var is not set
- New firebase-admin.ts in the multiplayer lib provides the Admin SDK initialization following existing project patterns
- Replaced the unused FirestoreRoomService with a re-export pointing to the integrated implementation

https://claude.ai/code/session_01D8DfDmiW51Pyd3tusfy8Ga