### PR TITLE
Add real-time online player count broadcast via Socket.IO

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { io } from 'socket.io-client';
+import type { ServerToClientEvents, ClientToServerEvents } from '@/types/game';
 import styles from '../components/rhythmia/rhythmia.module.css';
 import VanillaGame from '../components/rhythmia/tetris';
 import MultiplayerGame from '../components/rhythmia/MultiplayerGame';
@@ -11,7 +13,7 @@ type GameMode = 'lobby' | 'vanilla' | 'multiplayer';
 export default function RhythmiaPage() {
   const [gameMode, setGameMode] = useState<GameMode>('lobby');
   const [isLoading, setIsLoading] = useState(true);
-  const [onlineCount, setOnlineCount] = useState(127);
+  const [onlineCount, setOnlineCount] = useState(0);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -21,12 +23,15 @@ export default function RhythmiaPage() {
   }, []);
 
   useEffect(() => {
-    const interval = setInterval(() => {
-      const base = 120;
-      const variance = Math.floor(Math.random() * 30) - 15;
-      setOnlineCount(base + variance);
-    }, 5000);
-    return () => clearInterval(interval);
+    const socket = io({ path: '/socket.io' }) as import('socket.io-client').Socket<ServerToClientEvents, ClientToServerEvents>;
+
+    socket.on('online:count', (count) => {
+      setOnlineCount(count);
+    });
+
+    return () => {
+      socket.disconnect();
+    };
   }, []);
 
   const launchGame = (mode: GameMode) => {

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -58,6 +58,9 @@ export interface ServerToClientEvents {
   // Connection events
   'connect': () => void;
   'disconnect': () => void;
+
+  // Online count
+  'online:count': (count: number) => void;
 }
 
 export interface ClientToServerEvents {


### PR DESCRIPTION
## Summary
This PR implements real-time online player count tracking and broadcasting to all connected clients. The online count is now dynamically updated based on actual socket connections rather than using a simulated random value.

## Key Changes
- **Server-side (`server.ts`)**:
  - Added `broadcastOnlineCount()` function that emits the current client count to all connected clients
  - Broadcast online count when a new client connects
  - Broadcast updated online count when a client disconnects
  - Fixed whitespace inconsistencies in disconnect handler

- **Client-side (`src/app/page.tsx`)**:
  - Replaced mock online count (random value between 105-135) with real Socket.IO listener
  - Initialize online count to 0 instead of 127
  - Added Socket.IO client import and type definitions
  - Listen for `online:count` events from server and update state accordingly
  - Properly disconnect socket on component unmount

- **Type definitions (`src/types/game.ts`)**:
  - Added `online:count` event to `ServerToClientEvents` interface

## Implementation Details
- Uses `io.engine.clientsCount` to get the actual number of connected clients
- Broadcasts to all clients (including the newly connected one) to ensure consistency
- Socket is properly cleaned up on component unmount to prevent memory leaks
- Maintains type safety with existing Socket.IO event type definitions

https://claude.ai/code/session_018AJ3xk6p8W7Ybcmp4rj68P