### PR TITLE
Improve multiplayer reconnection and timeout handling

### DIFF
--- a/src/lib/multiplayer/RoomManager.ts
+++ b/src/lib/multiplayer/RoomManager.ts
@@ -232,7 +232,27 @@ export class MultiplayerRoomManager {
       player.connected = false;
     }
 
-    return this.removePlayerFromRoom(playerId);
+    // End game if not enough connected players during gameplay
+    if (room.status === 'playing' && room.players.filter(p => p.connected).length < 2) {
+      room.status = 'finished';
+    }
+
+    return { roomCode, room };
+  }
+
+  reconnectPlayer(playerId: string): { roomCode?: string; room?: Room } {
+    const roomCode = this.playerToRoom.get(playerId);
+    if (!roomCode) return {};
+
+    const room = this.rooms.get(roomCode);
+    if (!room) return {};
+
+    const player = room.players.find(p => p.id === playerId);
+    if (player) {
+      player.connected = true;
+    }
+
+    return { roomCode, room };
   }
 
   setPlayerReady(playerId: string, ready: boolean): { success: boolean; error?: string } {


### PR DESCRIPTION
## Summary
This PR enhances the multiplayer server and client to provide more robust reconnection handling, better timeout detection, and improved grace period management for disconnected players.

## Key Changes

### Server-side (`multiplayer-server.ts`)
- **Reduced heartbeat interval** from 30s to 15s for faster timeout detection
- **Replaced ping-based liveness with activity tracking**: Changed from `isAlive` flag to `lastActivity` timestamp, enabling more accurate timeout detection based on actual inactivity duration
- **Implemented grace period for disconnections**: Players now have a configurable grace period (60s) before being permanently removed from rooms, allowing reconnection attempts
- **Added disconnect timer management**: New `disconnectTimers` map tracks grace period timeouts per player
- **Enhanced reconnection flow**: 
  - Cancel grace period timers when players explicitly reconnect or leave
  - Call `roomManager.reconnectPlayer()` to restore player's connected status
  - Broadcast updated room state on reconnection
- **Improved error handling**: Terminate WebSocket and trigger disconnect handler on send failures
- **Better shutdown cleanup**: Clear all grace period timers during server shutdown

### Client-side (`MultiplayerGame.tsx`)
- **Added exponential backoff reconnection**: Implements up to 5 reconnection attempts with exponential backoff (max 15s delay)
- **Client-side ping timeout detection**: Added 60s ping timeout check to detect server unreachability independently
- **Automatic reconnection on disconnect**: Automatically attempts to rejoin if a reconnect token exists
- **Session storage for tokens**: Persist reconnect tokens in sessionStorage for page reload resilience
- **Improved UI feedback**: 
  - Show "Reconnecting..." status for disconnected players
  - Reduce opacity of disconnected players in waiting room
  - Better error messaging for connection issues
- **Cleanup on unmount**: Properly clear reconnect timers and ping check intervals

### Room Manager (`RoomManager.ts`)
- **Added `reconnectPlayer()` method**: Restores a player's connected status when they successfully reconnect
- **Game state handling**: End game if fewer than 2 connected players remain during gameplay

## Implementation Details
- The grace period allows players to reconnect without losing their room position, improving UX for temporary network issues
- Activity-based timeout is more reliable than ping-pong flags, reducing false disconnects
- Client-side ping timeout detection provides defense-in-depth against server connectivity issues
- Exponential backoff prevents overwhelming the server with reconnection attempts
- Session storage enables reconnection even after page reloads within the grace period

https://claude.ai/code/session_01NsmdtQL3sqF15yuJwipyjw