### PR TITLE
Fix grid layout sizing in multiplayer battle component

### DIFF
--- a/src/components/rhythmia/MultiplayerBattle.module.css
+++ b/src/components/rhythmia/MultiplayerBattle.module.css
@@ -154,7 +154,6 @@
   display: grid;
   gap: 1px;
   position: relative;
-  padding: 2px;
   image-rendering: pixelated;
   image-rendering: crisp-edges;
 }

--- a/src/components/rhythmia/MultiplayerBattle.tsx
+++ b/src/components/rhythmia/MultiplayerBattle.tsx
@@ -926,7 +926,7 @@ export const MultiplayerBattle: React.FC<Props> = ({
   const renderPreview = (type: PieceType) => {
     const shape = getShape(type, 0);
     return (
-      <div className={styles.previewGrid} style={{ gridTemplateColumns: `repeat(${shape[0].length}, 1fr)` }}>
+      <div className={styles.previewGrid} style={{ gridTemplateColumns: `repeat(${shape[0].length}, auto)` }}>
         {shape.flat().map((val, i) => (
           <div
             key={i}
@@ -990,7 +990,7 @@ export const MultiplayerBattle: React.FC<Props> = ({
                 </div>
               )}
 
-              <div className={styles.board} style={{ gridTemplateColumns: `repeat(${W}, 1fr)` }}>
+              <div className={styles.board} style={{ gridTemplateColumns: `repeat(${W}, auto)` }}>
                 {displayBoard.flat().map((cell, i) => (
                   <div
                     key={i}
@@ -1020,7 +1020,7 @@ export const MultiplayerBattle: React.FC<Props> = ({
             </div>
 
             <div className={`${styles.boardWrap} ${styles.opponentBoardWrap}`}>
-              <div className={styles.board} style={{ gridTemplateColumns: `repeat(${W}, 1fr)` }}>
+              <div className={styles.board} style={{ gridTemplateColumns: `repeat(${W}, auto)` }}>
                 {opponentDisplay.flat().map((cell, i) => (
                   <div
                     key={i}


### PR DESCRIPTION
## Summary
Adjusted grid layout sizing in the multiplayer battle component to use `auto` instead of `1fr` for column sizing, and removed unnecessary padding from the preview grid.

## Changes
- Changed `gridTemplateColumns` from `repeat(${W}, 1fr)` to `repeat(${W}, auto)` for both player and opponent game boards
- Changed `gridTemplateColumns` from `repeat(${shape[0].length}, 1fr)` to `repeat(${shape[0].length}, auto)` for the piece preview grid
- Removed `padding: 2px` from `.previewGrid` CSS class

## Details
These changes improve the grid layout behavior by allowing columns to size based on their content rather than distributing space equally. Using `auto` sizing ensures that grid cells maintain consistent sizing based on the actual content dimensions, which is more appropriate for a pixel-perfect game board layout. The removal of the preview grid padding eliminates unnecessary spacing that could affect the visual alignment of piece previews.

https://claude.ai/code/session_011Sjqt5jYiZJXG1W7T9Vki6