### PR TITLE
Memoize useRhythmVFX hook return value to prevent unnecessary re-renders

### DIFF
--- a/src/components/rhythmia/tetris/hooks/useRhythmVFX.ts
+++ b/src/components/rhythmia/tetris/hooks/useRhythmVFX.ts
@@ -1,4 +1,4 @@
-import { useRef, useCallback, useEffect } from 'react';
+import { useRef, useCallback, useEffect, useMemo } from 'react';
 import type { VFXEvent } from '../types';
 import { BOARD_WIDTH, BOARD_HEIGHT, WORLDS } from '../constants';
 
@@ -694,12 +694,12 @@ export function useRhythmVFX() {
         };
     }, []);
 
-    return {
+    return useMemo(() => ({
         canvasRef,
         emit,
         updateBoardGeometry,
         start,
         stop,
         stateRef,
-    };
+    }), [canvasRef, emit, updateBoardGeometry, start, stop, stateRef]);
 }


### PR DESCRIPTION
## Summary
Wrapped the return object of the `useRhythmVFX` hook with `useMemo` to prevent unnecessary re-renders of consuming components when the hook's internal state hasn't changed.

## Changes
- Added `useMemo` import from React
- Wrapped the hook's return object with `useMemo` and included all returned values in the dependency array (`canvasRef`, `emit`, `updateBoardGeometry`, `start`, `stop`, `stateRef`)

## Implementation Details
This optimization ensures that the returned object reference remains stable across re-renders unless one of the dependencies changes. This is particularly important for hooks that return multiple functions and refs, as it prevents child components from re-rendering due to object reference changes rather than actual value changes.

https://claude.ai/code/session_01ChCaMzoBaVj5M9s7mmHNxP