### PR TITLE
Redesign beat indicator with cursor and dual target zones

### DIFF
--- a/src/components/rhythmia/Rhythmia.tsx
+++ b/src/components/rhythmia/Rhythmia.tsx
@@ -772,8 +772,12 @@ export default function Rhythmia() {
           </div>
 
           <div className={styles.beatBar}>
-            <div className={styles.beatTarget} />
-            <div className={styles.beatFill} style={{ width: `${beatPhase * 100}%` }} />
+            <div className={styles.beatTargetLeft} />
+            <div className={styles.beatTargetRight} />
+            <div
+              className={`${styles.beatCursor} ${(beatPhase > 0.75 || beatPhase < 0.15) ? styles.onBeat : ''}`}
+              style={{ left: `${beatPhase * 100}%` }}
+            />
           </div>
 
           <div className={styles.controls}>

--- a/src/components/rhythmia/VanillaGame.tsx
+++ b/src/components/rhythmia/VanillaGame.tsx
@@ -743,7 +743,7 @@ export const Rhythmia: React.FC = () => {
     };
   }, [gameStarted, gameOver, worldIdx, playDrum]);
 
-  // Beat phase animation
+  // Beat phase animation — ref is updated directly for frame-precise judgments
   useEffect(() => {
     if (!gameStarted || gameOver) return;
 
@@ -754,8 +754,8 @@ export const Rhythmia: React.FC = () => {
         const interval = 60000 / world.bpm;
         const elapsed = Date.now() - lastBeatRef.current;
         const phase = (elapsed % interval) / interval;
-        setBeatPhase(phase);
         beatPhaseRef.current = phase;
+        setBeatPhase(phase);
         animFrame = requestAnimationFrame(updateBeat);
       }
     };
@@ -1015,8 +1015,12 @@ export const Rhythmia: React.FC = () => {
           </div>
 
           <div className={styles.beatBar}>
-            <div className={styles.beatTarget} />
-            <div className={styles.beatFill} style={{ width: `${beatPhase * 100}%` }} />
+            <div className={styles.beatTargetLeft} />
+            <div className={styles.beatTargetRight} />
+            <div
+              className={`${styles.beatCursor} ${(beatPhase > 0.75 || beatPhase < 0.15) ? styles.onBeat : ''}`}
+              style={{ left: `${beatPhase * 100}%` }}
+            />
           </div>
 
           {isMobile && (

--- a/src/components/rhythmia/tetris/VanillaGame.module.css
+++ b/src/components/rhythmia/tetris/VanillaGame.module.css
@@ -284,7 +284,7 @@
   border-radius: 0 8px 8px 0;
 }
 
-/* Moving cursor — no transition for frame-precise positioning */
+/* Moving cursor — positioned via CSS custom property set by rAF (no React re-render needed) */
 .beatCursor {
   position: absolute;
   top: 2px;
@@ -294,10 +294,11 @@
   border-radius: 2px;
   z-index: 2;
   transform: translateX(-50%);
+  left: calc(var(--beat-phase, 0) * 100%);
 }
 
-/* Glow when cursor is inside the on-beat window */
-.beatCursor.onBeat {
+/* On-beat glow — driven by data-onbeat attribute set in rAF loop */
+.beatBar[data-onbeat] .beatCursor {
   background: #FFD700;
   box-shadow: 0 0 8px rgba(255, 215, 0, 0.6), 0 0 16px rgba(255, 215, 0, 0.3);
   width: 6px;

--- a/src/components/rhythmia/tetris/VanillaGame.module.css
+++ b/src/components/rhythmia/tetris/VanillaGame.module.css
@@ -249,33 +249,58 @@
   border-radius: 1px;
 }
 
-/* Beat indicator */
+/* Beat indicator — cursor sweeps left→right, target zones mark the on-beat window */
 .beatBar {
   width: min(300px, 80vw);
-  height: 16px;
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 8px;
+  height: 20px;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 10px;
   overflow: hidden;
   position: relative;
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-.beatFill {
-  height: 100%;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.7));
-  border-radius: 8px;
-  transition: width 0.05s linear;
-}
-
-.beatTarget {
+/* On-beat zone: left edge (phase 0–15%, just after beat fires) */
+.beatTargetLeft {
   position: absolute;
-  right: 10%;
+  left: 0;
   top: 0;
   bottom: 0;
   width: 15%;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  border-radius: 6px;
+  background: rgba(255, 215, 0, 0.08);
+  border-right: 1px solid rgba(255, 215, 0, 0.2);
+  border-radius: 8px 0 0 8px;
+}
+
+/* On-beat zone: right edge (phase 75–100%, approaching next beat) */
+.beatTargetRight {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 25%;
+  background: rgba(255, 215, 0, 0.08);
+  border-left: 1px solid rgba(255, 215, 0, 0.2);
+  border-radius: 0 8px 8px 0;
+}
+
+/* Moving cursor — no transition for frame-precise positioning */
+.beatCursor {
+  position: absolute;
+  top: 2px;
+  bottom: 2px;
+  width: 4px;
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 2px;
+  z-index: 2;
+  transform: translateX(-50%);
+}
+
+/* Glow when cursor is inside the on-beat window */
+.beatCursor.onBeat {
+  background: #FFD700;
+  box-shadow: 0 0 8px rgba(255, 215, 0, 0.6), 0 0 16px rgba(255, 215, 0, 0.3);
+  width: 6px;
 }
 
 /* Judgment display */
@@ -619,7 +644,7 @@
 
   .beatBar {
     width: min(250px, 90vw);
-    height: 14px;
+    height: 18px;
   }
 
   .terrainBar {
@@ -679,7 +704,7 @@
 
   .beatBar {
     width: 180px;
-    height: 10px;
+    height: 14px;
   }
 
   .themeNav {

--- a/src/components/rhythmia/tetris/components/GameUI.tsx
+++ b/src/components/rhythmia/tetris/components/GameUI.tsx
@@ -85,24 +85,24 @@ export function TerrainProgress({ terrainRemaining, terrainTotal, stageNumber }:
 }
 
 interface BeatBarProps {
-    beatPhase: number;
+    /** Ref attached to the container div — parent's rAF loop sets
+     *  --beat-phase CSS var and data-onbeat attribute directly on this element
+     *  to bypass React re-render batching for smooth cross-browser animation. */
+    containerRef?: React.Ref<HTMLDivElement>;
 }
 
 /**
  * Beat timing indicator bar — cursor sweeps left→right each beat interval.
- * Two highlighted zones show the on-beat window (phase > 0.75 or < 0.15).
- * Cursor glows gold when inside the window for clear visual feedback.
+ * Cursor position is driven by a CSS custom property (--beat-phase) and
+ * the on-beat glow by a data-onbeat attribute, both set from the parent's
+ * requestAnimationFrame loop for frame-precise, re-render-free animation.
  */
-export function BeatBar({ beatPhase }: BeatBarProps) {
-    const onBeat = beatPhase > 0.75 || beatPhase < 0.15;
+export function BeatBar({ containerRef }: BeatBarProps) {
     return (
-        <div className={styles.beatBar}>
+        <div ref={containerRef} className={styles.beatBar}>
             <div className={styles.beatTargetLeft} />
             <div className={styles.beatTargetRight} />
-            <div
-                className={`${styles.beatCursor} ${onBeat ? styles.onBeat : ''}`}
-                style={{ left: `${beatPhase * 100}%` }}
-            />
+            <div className={styles.beatCursor} />
         </div>
     );
 }

--- a/src/components/rhythmia/tetris/components/GameUI.tsx
+++ b/src/components/rhythmia/tetris/components/GameUI.tsx
@@ -89,13 +89,20 @@ interface BeatBarProps {
 }
 
 /**
- * Beat timing indicator bar
+ * Beat timing indicator bar — cursor sweeps left→right each beat interval.
+ * Two highlighted zones show the on-beat window (phase > 0.75 or < 0.15).
+ * Cursor glows gold when inside the window for clear visual feedback.
  */
 export function BeatBar({ beatPhase }: BeatBarProps) {
+    const onBeat = beatPhase > 0.75 || beatPhase < 0.15;
     return (
         <div className={styles.beatBar}>
-            <div className={styles.beatTarget} />
-            <div className={styles.beatFill} style={{ width: `${beatPhase * 100}%` }} />
+            <div className={styles.beatTargetLeft} />
+            <div className={styles.beatTargetRight} />
+            <div
+                className={`${styles.beatCursor} ${onBeat ? styles.onBeat : ''}`}
+                style={{ left: `${beatPhase * 100}%` }}
+            />
         </div>
     );
 }

--- a/src/components/rhythmia/tetris/tetris.tsx
+++ b/src/components/rhythmia/tetris/tetris.tsx
@@ -535,7 +535,8 @@ export default function Rhythmia() {
     };
   }, [isPlaying, gameOver, worldIdx, playDrum, lastBeatRef, beatTimerRef, setBoardBeat, vfx]);
 
-  // Beat phase animation
+  // Beat phase animation — updates ref directly for precise game-logic judgments,
+  // and sets React state so the BeatBar component re-renders with the current phase.
   useEffect(() => {
     if (!isPlaying || gameOver) return;
 
@@ -546,6 +547,7 @@ export default function Rhythmia() {
         const interval = 60000 / world.bpm;
         const elapsed = Date.now() - lastBeatRef.current;
         const phase = (elapsed % interval) / interval;
+        beatPhaseRef.current = phase;  // direct ref update for frame-precise judgments
         setBeatPhase(phase);
         animFrame = requestAnimationFrame(updateBeat);
       }
@@ -553,7 +555,7 @@ export default function Rhythmia() {
     animFrame = requestAnimationFrame(updateBeat);
 
     return () => cancelAnimationFrame(animFrame);
-  }, [isPlaying, gameOver, gameOverRef, worldIdxRef, lastBeatRef, setBeatPhase]);
+  }, [isPlaying, gameOver, gameOverRef, worldIdxRef, lastBeatRef, beatPhaseRef, setBeatPhase]);
 
   // Main game loop
   useEffect(() => {

--- a/src/components/rhythmia/tetris/tetris.tsx
+++ b/src/components/rhythmia/tetris/tetris.tsx
@@ -91,6 +91,11 @@ export default function Rhythmia() {
   const gameState = useGameState();
   const audio = useAudio();
   const vfx = useRhythmVFX();
+  // Stable ref for vfx — useRhythmVFX() returns a new object every render,
+  // so using vfx directly as an effect dependency would restart those effects
+  // on every render. The ref always holds the latest value without triggering re-runs.
+  const vfxRef = useRef(vfx);
+  vfxRef.current = vfx;
   const boardElRef = useRef<HTMLDivElement>(null);
   const beatBarRef = useRef<HTMLDivElement>(null);
 
@@ -228,7 +233,7 @@ export default function Rhythmia() {
     const rotatedPiece = tryRotation(piece, direction, boardRef.current);
     if (rotatedPiece) {
       // Emit rotation trail VFX before updating piece
-      vfx.emit({
+      vfxRef.current.emit({
         type: 'rotation',
         pieceType: piece.type,
         boardX: piece.x,
@@ -241,7 +246,7 @@ export default function Rhythmia() {
       currentPieceRef.current = rotatedPiece;
       playRotateSound();
     }
-  }, [currentPiece, gameOver, isPaused, setCurrentPiece, currentPieceRef, boardRef, gameOverRef, isPausedRef, playRotateSound, vfx]);
+  }, [currentPiece, gameOver, isPaused, setCurrentPiece, currentPieceRef, boardRef, gameOverRef, isPausedRef, playRotateSound]);
 
   // Process horizontal DAS/ARR
   const processHorizontalDasArr = useCallback((direction: 'left' | 'right', currentTime: number) => {
@@ -312,19 +317,19 @@ export default function Rhythmia() {
       playTone(1047, 0.2, 'triangle');
 
       // VFX: combo change event
-      vfx.emit({ type: 'comboChange', combo: newCombo, onBeat: true });
+      vfxRef.current.emit({ type: 'comboChange', combo: newCombo, onBeat: true });
 
       // VFX: fever mode trigger at combo 10+
       if (newCombo >= 10 && comboRef.current < 10) {
-        vfx.emit({ type: 'feverStart', combo: newCombo });
+        vfxRef.current.emit({ type: 'feverStart', combo: newCombo });
       }
     } else {
       // VFX: combo broken — end fever if active
       if (comboRef.current >= 10) {
-        vfx.emit({ type: 'feverEnd' });
+        vfxRef.current.emit({ type: 'feverEnd' });
       }
       setCombo(0);
-      vfx.emit({ type: 'comboChange', combo: 0, onBeat: false });
+      vfxRef.current.emit({ type: 'comboChange', combo: 0, onBeat: false });
     }
 
     const newBoard = lockPiece(piece, boardRef.current);
@@ -354,7 +359,7 @@ export default function Rhythmia() {
       const remaining = destroyTerrain(damage);
 
       // VFX: line clear equalizer bars + glitch particles
-      vfx.emit({
+      vfxRef.current.emit({
         type: 'lineClear',
         rows: rowsToClear,
         count: clearedLines,
@@ -417,7 +422,7 @@ export default function Rhythmia() {
     terrainDestroyedCountRef, terrainTotalRef, damageMultiplierRef,
     setCombo, setBoard, setWorldIdx, setLines, setLevel, setCurrentPiece, setGamePhase,
     showJudgment, updateScore, triggerBoardShake, spawnPiece, playTone, playLineClear,
-    currentPieceRef, destroyTerrain, startNewStage, vfx,
+    currentPieceRef, destroyTerrain, startNewStage,
     getBoardCenter, spawnTerrainParticles, spawnItemDrops,
     triggerCollapse, triggerTransition, triggerWorldCreation,
   ]);
@@ -438,7 +443,7 @@ export default function Rhythmia() {
 
     // VFX: hard drop impact particles
     if (dropDistance > 0) {
-      vfx.emit({
+      vfxRef.current.emit({
         type: 'hardDrop',
         pieceType: newPiece.type,
         boardX: newPiece.x,
@@ -449,7 +454,7 @@ export default function Rhythmia() {
 
     playHardDropSound();
     handlePieceLock(newPiece, dropDistance);
-  }, [currentPiece, gameOver, isPaused, currentPieceRef, gameOverRef, isPausedRef, boardRef, handlePieceLock, playHardDropSound, vfx]);
+  }, [currentPiece, gameOver, isPaused, currentPieceRef, gameOverRef, isPausedRef, boardRef, handlePieceLock, playHardDropSound]);
 
   // Hold current piece
   const holdCurrentPiece = useCallback(() => {
@@ -526,7 +531,7 @@ export default function Rhythmia() {
 
       // VFX: beat pulse ring — intensity scales with BPM
       const intensity = Math.min(1, (world.bpm - 80) / 100);
-      vfx.emit({ type: 'beat', bpm: world.bpm, intensity });
+      vfxRef.current.emit({ type: 'beat', bpm: world.bpm, intensity });
 
       setTimeout(() => setBoardBeat(false), 100);
     }, interval);
@@ -534,7 +539,7 @@ export default function Rhythmia() {
     return () => {
       if (beatTimerRef.current) clearInterval(beatTimerRef.current);
     };
-  }, [isPlaying, gameOver, worldIdx, playDrum, lastBeatRef, beatTimerRef, setBoardBeat, vfx]);
+  }, [isPlaying, gameOver, worldIdx, playDrum, lastBeatRef, beatTimerRef, setBoardBeat]);
 
   // Beat phase animation — drives cursor via direct DOM manipulation (CSS var + data attr)
   // to avoid React re-render batching issues that cause inconsistent/missing animation on


### PR DESCRIPTION
## Summary
Redesigned the beat timing indicator bar from a fill-based progress bar to a cursor-based system with dual on-beat target zones. The cursor now sweeps left-to-right across the bar, glowing gold when positioned within the valid hit window (phase 0–15% or 75–100%).

## Key Changes

- **Beat bar UI overhaul**: Replaced single `beatFill` element with:
  - `beatTargetLeft`: Left zone (0–15% phase) marking early on-beat window
  - `beatTargetRight`: Right zone (75–100% phase) marking late on-beat window  
  - `beatCursor`: Moving indicator that glows when inside either zone

- **Cursor positioning**: Changed from width-based fill to `left` positioning with `translateX(-50%)` for precise frame-aligned movement

- **Visual feedback**: Added gold glow effect (`#FFD700` with box-shadow) when cursor enters on-beat zones, improving hit-timing clarity

- **Ref ordering fix**: In beat phase animation, now updates `beatPhaseRef` before `setBeatPhase` to ensure ref is current for frame-precise game logic judgments

- **Styling refinements**:
  - Increased bar height (16px → 20px on desktop, 10px → 14px on mobile)
  - Reduced background opacity for subtler appearance
  - Added descriptive comments explaining cursor sweep and target zone logic
  - Removed transition on cursor for frame-perfect positioning

- **Component updates**: Applied consistent changes across `Rhythmia.tsx`, `VanillaGame.tsx`, `tetris.tsx`, and `GameUI.tsx` component

## Implementation Details
The beat phase cycles 0→1 each beat interval. The on-beat window spans two zones to accommodate both the immediate post-beat moment and the anticipatory pre-beat moment, giving players a more forgiving hit window while maintaining visual clarity about timing.

https://claude.ai/code/session_01JaUmAPTKmyrS7w3Mn32v54