### PR TITLE
Consolidate online count display in lobby status bar

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -147,7 +147,7 @@ export default function RhythmiaPage() {
                     <div className={styles.statusBar}>
                         <div className={styles.statusItem}>
                             <span className={styles.statusDot}></span>
-                            <span>{t('lobby.online')}</span>
+                            <span>{t('lobby.onlineCount', { count: onlineCount })}</span>
                         </div>
                         <div className={styles.statusItem}>
                             <span>v{rhythmiaConfig.version}</span>
@@ -238,10 +238,6 @@ export default function RhythmiaPage() {
                                     <div className={styles.statValue}>LIVE</div>
                                     <div className={styles.statLabel}>{t('multiplayer.stats.status')}</div>
                                 </div>
-                            </div>
-                            <div className={styles.onlineCount}>
-                                <span className={styles.onlineDot}></span>
-                                <span>{t('lobby.onlineCount', { count: onlineCount })}</span>
                             </div>
                             <button className={styles.playButton}>{t('lobby.battle')}</button>
                         </motion.div>


### PR DESCRIPTION
## Summary
Moved the online count display from the multiplayer stats card to the main lobby status bar, eliminating the duplicate online count component.

## Changes
- Updated the status bar to display dynamic online count using `t('lobby.onlineCount', { count: onlineCount })` instead of static `t('lobby.online')`
- Removed the redundant `onlineCount` div component from the multiplayer stats card section
- Consolidated online status information into a single, more prominent location in the UI

## Details
This change improves the UI by:
- Reducing visual clutter by removing the duplicate online count display
- Making the online count more visible in the main status bar
- Maintaining the same functionality with a cleaner component structure

https://claude.ai/code/session_01D7yghJpWPynL19t1DzrTTw