### PR TITLE
Refactor RankedMatch to accept WebSocket as prop

### DIFF
--- a/src/components/rhythmia/MultiplayerGame.tsx
+++ b/src/components/rhythmia/MultiplayerGame.tsx
@@ -677,6 +677,9 @@ export default function MultiplayerGame() {
         <RankedMatch
           playerName={playerName || 'Player'}
           onBack={() => setMode('lobby')}
+          ws={wsRef.current}
+          connectionStatus={connectionStatus}
+          playerId={playerIdRef.current}
         />
       )}
     </div>

--- a/src/components/rhythmia/RankedMatch.tsx
+++ b/src/components/rhythmia/RankedMatch.tsx
@@ -5,26 +5,21 @@ import styles from './RankedMatch.module.css';
 import MultiplayerBattle from './MultiplayerBattle';
 import type {
   ServerMessage,
-  RoomState,
-  Player,
 } from '@/types/multiplayer';
 import {
-  RANK_TIERS,
   getTierByPoints,
   getDefaultRankedState,
   calculateRankChange,
   tierProgress,
   pointsToNextTier,
-  MATCHMAKING_TIMEOUT_MS,
 } from '@/lib/ranked/constants';
 import type { RankedState, RankChange } from '@/lib/ranked/types';
 import { TetrisAIGame, getDifficultyForRank } from '@/lib/ranked/TetrisAI';
 import type { BoardCell } from '@/types/multiplayer';
 
 type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
-type MatchPhase = 'idle' | 'searching' | 'found' | 'countdown' | 'playing' | 'result';
+type MatchPhase = 'idle' | 'found' | 'countdown' | 'playing' | 'result';
 
-const MAX_RECONNECT_ATTEMPTS = 5;
 const RANKED_STORAGE_KEY = 'rhythmia_ranked_state';
 
 function loadRankedState(): RankedState {
@@ -56,16 +51,17 @@ function saveRankedState(state: RankedState): void {
 interface Props {
   playerName: string;
   onBack: () => void;
+  ws: WebSocket | null;
+  connectionStatus: ConnectionStatus;
+  playerId: string;
 }
 
-export default function RankedMatch({ playerName, onBack }: Props) {
-  // Connection
-  const wsRef = useRef<WebSocket | null>(null);
-  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('disconnected');
-  const playerIdRef = useRef<string>('');
-  const reconnectTokenRef = useRef<string>('');
-  const reconnectAttemptsRef = useRef(0);
-  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+export default function RankedMatch({ playerName, onBack, ws, connectionStatus, playerId }: Props) {
+  // Keep a ref to the ws prop for use in effects
+  const wsRef = useRef<WebSocket | null>(ws);
+  useEffect(() => {
+    wsRef.current = ws;
+  }, [ws]);
 
   // Ranked state
   const [rankedState, setRankedState] = useState<RankedState>(loadRankedState);
@@ -73,11 +69,8 @@ export default function RankedMatch({ playerName, onBack }: Props) {
 
   // Match state
   const [phase, setPhase] = useState<MatchPhase>('idle');
-  const [searchTimer, setSearchTimer] = useState(0);
-  const searchIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [opponentName, setOpponentName] = useState('');
   const [opponentId, setOpponentId] = useState('');
-  const [isAIMatch, setIsAIMatch] = useState(false);
   const [gameSeed, setGameSeed] = useState(0);
   const [roomCode, setRoomCode] = useState('');
   const [countdownNumber, setCountdownNumber] = useState<number | null>(null);
@@ -85,199 +78,38 @@ export default function RankedMatch({ playerName, onBack }: Props) {
 
   // AI game
   const aiGameRef = useRef<TetrisAIGame | null>(null);
-  const aiOpponentBoardRef = useRef<(BoardCell | null)[][]>([]);
 
-  // ===== WebSocket Connection =====
-  const connectWebSocketRef = useRef<() => void>(() => {});
-
-  const scheduleReconnect = useCallback(() => {
-    if (reconnectTimerRef.current) return;
-    if (reconnectAttemptsRef.current >= MAX_RECONNECT_ATTEMPTS) return;
-
-    const delay = Math.min(1000 * Math.pow(2, reconnectAttemptsRef.current), 15000);
-    reconnectAttemptsRef.current++;
-    setConnectionStatus('connecting');
-
-    reconnectTimerRef.current = setTimeout(() => {
-      reconnectTimerRef.current = null;
-      connectWebSocketRef.current();
-    }, delay);
-  }, []);
-
-  const connectWebSocket = useCallback(() => {
-    if (wsRef.current?.readyState === WebSocket.OPEN) return;
-    if (wsRef.current?.readyState === WebSocket.CONNECTING) return;
-
-    setConnectionStatus('connecting');
-    const wsUrl = process.env.NEXT_PUBLIC_MULTIPLAYER_URL || 'ws://localhost:3001';
-    const ws = new WebSocket(wsUrl);
-
-    ws.onopen = () => {
-      setConnectionStatus('connected');
-      reconnectAttemptsRef.current = 0;
-    };
-
-    ws.onmessage = (event) => {
-      try {
-        const message: ServerMessage = JSON.parse(event.data);
-        handleServerMessage(message);
-      } catch {}
-    };
-
-    ws.onclose = () => {
-      setConnectionStatus('disconnected');
-      wsRef.current = null;
-      if (reconnectTokenRef.current) {
-        scheduleReconnect();
-      }
-    };
-
-    ws.onerror = () => {
-      setConnectionStatus('error');
-    };
-
-    wsRef.current = ws;
-  }, [scheduleReconnect]);
-
-  connectWebSocketRef.current = connectWebSocket;
-
-  const send = useCallback((data: object) => {
-    if (wsRef.current?.readyState === WebSocket.OPEN) {
-      wsRef.current.send(JSON.stringify(data));
-    }
-  }, []);
-
-  // ===== Server Message Handler =====
-  const handleServerMessage = useCallback((msg: ServerMessage) => {
-    switch (msg.type) {
-      case 'connected':
-        playerIdRef.current = msg.playerId;
-        break;
-
-      case 'ranked_queued':
-        // Confirmed in queue
-        break;
-
-      case 'ranked_match_found':
-        reconnectTokenRef.current = msg.reconnectToken;
-        setRoomCode(msg.roomCode);
-        setOpponentName(msg.opponentName);
-        setOpponentId(msg.opponentId);
-        setIsAIMatch(msg.isAI);
-        setGameSeed(msg.gameSeed);
-        setPhase('found');
-
-        // Stop search timer
-        if (searchIntervalRef.current) {
-          clearInterval(searchIntervalRef.current);
-          searchIntervalRef.current = null;
-        }
-        break;
-
-      case 'countdown':
-        setCountdownNumber(msg.count);
-        setPhase('countdown');
-        break;
-
-      case 'game_started':
-        setGameSeed(msg.gameSeed);
-        setCountdownNumber(null);
-        setPhase('playing');
-        break;
-
-      case 'room_state':
-        // Handle room state updates
-        break;
-
-      case 'ping':
-        send({ type: 'pong' });
-        break;
-
-      case 'error':
-        // If error during search, reset
-        if (phase === 'searching') {
-          setPhase('idle');
-          if (searchIntervalRef.current) {
-            clearInterval(searchIntervalRef.current);
-            searchIntervalRef.current = null;
-          }
-        }
-        break;
-
-      default:
-        break;
-    }
-  }, [send, phase]);
-
-  // Connect on mount
-  useEffect(() => {
-    connectWebSocket();
-
-    return () => {
-      if (reconnectTimerRef.current) {
-        clearTimeout(reconnectTimerRef.current);
-      }
-      if (searchIntervalRef.current) {
-        clearInterval(searchIntervalRef.current);
-      }
-      if (wsRef.current) {
-        wsRef.current.close();
-        wsRef.current = null;
-      }
-      if (aiGameRef.current) {
-        aiGameRef.current.stop();
-      }
-    };
-  }, [connectWebSocket]);
-
-  // ===== Matchmaking =====
+  // ===== Start AI Match Directly =====
   const startSearch = useCallback(() => {
-    if (connectionStatus !== 'connected') return;
-
-    setPhase('searching');
-    setSearchTimer(0);
     setGameResult(null);
     setRankChange(null);
 
-    send({
-      type: 'queue_ranked',
-      playerName: playerName.trim(),
-      rankPoints: rankedState.points,
-    });
-
-    // Start search timer display
-    const start = Date.now();
-    searchIntervalRef.current = setInterval(() => {
-      setSearchTimer(Math.floor((Date.now() - start) / 1000));
-    }, 100);
-  }, [connectionStatus, send, playerName, rankedState.points]);
-
-  const cancelSearch = useCallback(() => {
-    send({ type: 'cancel_ranked' });
-    setPhase('idle');
-    setSearchTimer(0);
-    if (searchIntervalRef.current) {
-      clearInterval(searchIntervalRef.current);
-      searchIntervalRef.current = null;
-    }
-  }, [send]);
+    // Start AI match immediately (client-side, no server queue)
+    const seed = Math.floor(Math.random() * 2147483647);
+    setGameSeed(seed);
+    setOpponentName('AI Rival');
+    setOpponentId(`ai_${Date.now()}`);
+    setRoomCode(`ai_${Date.now()}`);
+    setPhase('found');
+  }, []);
 
   // ===== AI Match Setup =====
-  // For AI matches, we handle the game entirely client-side
-  // The AI runs its own game, relaying board updates through simulated messages
+  // The AI runs client-side, relaying board updates through fake WebSocket messages
   useEffect(() => {
-    if (phase !== 'playing' || !isAIMatch) return;
+    if (phase !== 'playing') return;
 
+    const currentWs = wsRef.current;
+    if (!currentWs) return;
+
+    const currentOpponentId = opponentId;
     const difficulty = getDifficultyForRank(rankedState.points);
 
     const aiGame = new TetrisAIGame(gameSeed, difficulty, {
       onBoardUpdate: (board, score, lines, combo, piece, hold) => {
-        // Simulate a relay message from the AI player
-        if (wsRef.current?.readyState === WebSocket.OPEN) {
-          // Inject as if it came from the server
+        if (currentWs.readyState === WebSocket.OPEN) {
           const fakeMessage: ServerMessage = {
             type: 'relayed',
-            fromPlayerId: opponentId,
+            fromPlayerId: currentOpponentId,
             payload: {
               event: 'board_update',
               board,
@@ -288,38 +120,36 @@ export default function RankedMatch({ playerName, onBack }: Props) {
               hold,
             },
           };
-          // Dispatch to the WebSocket message handler
           const event = new MessageEvent('message', {
             data: JSON.stringify(fakeMessage),
           });
-          wsRef.current.dispatchEvent(event);
+          currentWs.dispatchEvent(event);
         }
       },
       onGarbage: (lines) => {
-        if (wsRef.current?.readyState === WebSocket.OPEN) {
+        if (currentWs.readyState === WebSocket.OPEN) {
           const fakeMessage: ServerMessage = {
             type: 'relayed',
-            fromPlayerId: opponentId,
+            fromPlayerId: currentOpponentId,
             payload: { event: 'garbage', lines },
           };
           const event = new MessageEvent('message', {
             data: JSON.stringify(fakeMessage),
           });
-          wsRef.current.dispatchEvent(event);
+          currentWs.dispatchEvent(event);
         }
       },
       onGameOver: () => {
-        // AI lost, player wins
-        if (wsRef.current?.readyState === WebSocket.OPEN) {
+        if (currentWs.readyState === WebSocket.OPEN) {
           const fakeMessage: ServerMessage = {
             type: 'relayed',
-            fromPlayerId: opponentId,
+            fromPlayerId: currentOpponentId,
             payload: { event: 'game_over' },
           };
           const event = new MessageEvent('message', {
             data: JSON.stringify(fakeMessage),
           });
-          wsRef.current.dispatchEvent(event);
+          currentWs.dispatchEvent(event);
         }
       },
     });
@@ -327,53 +157,40 @@ export default function RankedMatch({ playerName, onBack }: Props) {
     aiGameRef.current = aiGame;
     aiGame.start();
 
-    // Listen for player's garbage sent to AI
-    const handlePlayerRelay = (event: MessageEvent) => {
+    // Intercept outgoing messages: route relay messages to AI locally,
+    // pass non-relay messages (pong, etc.) through to the server
+    const originalSend = currentWs.send.bind(currentWs);
+    currentWs.send = (data: string | ArrayBufferLike | Blob | ArrayBufferView) => {
       try {
-        const msg = JSON.parse(event.data);
-        if (msg.type === 'relay' && msg.payload?.event === 'garbage') {
-          aiGame.addGarbage(msg.payload.lines);
-        }
-      } catch {}
-    };
-
-    // We intercept outgoing relay messages to feed garbage to AI
-    const originalSend = wsRef.current?.send.bind(wsRef.current);
-    if (wsRef.current && originalSend) {
-      wsRef.current.send = (data: string | ArrayBufferLike | Blob | ArrayBufferView) => {
-        // Still send to server for normal relay
-        try {
-          originalSend(data);
-        } catch {}
-
-        // Also check if this is a garbage relay for the AI
-        try {
-          if (typeof data === 'string') {
-            const msg = JSON.parse(data);
-            if (msg.type === 'relay' && msg.payload?.event === 'garbage') {
+        if (typeof data === 'string') {
+          const msg = JSON.parse(data);
+          if (msg.type === 'relay') {
+            if (msg.payload?.event === 'garbage') {
               aiGame.addGarbage(msg.payload.lines);
             }
-            if (msg.type === 'relay' && msg.payload?.event === 'game_over') {
+            if (msg.payload?.event === 'game_over') {
               aiGame.stop();
             }
+            return; // Don't send relay messages to server for AI matches
           }
-        } catch {}
-      };
-    }
+        }
+        originalSend(data);
+      } catch {}
+    };
 
     return () => {
       aiGame.stop();
       aiGameRef.current = null;
       // Restore original send
-      if (wsRef.current && originalSend) {
-        wsRef.current.send = originalSend;
+      if (currentWs) {
+        currentWs.send = originalSend;
       }
     };
-  }, [phase, isAIMatch, gameSeed, opponentId, rankedState.points]);
+  }, [phase, gameSeed, opponentId, rankedState.points]);
 
   // ===== Game End =====
   const handleGameEnd = useCallback((winnerId: string) => {
-    const won = winnerId === playerIdRef.current;
+    const won = winnerId === playerId;
     setGameResult(won ? 'win' : 'loss');
 
     // Calculate rank change
@@ -397,18 +214,16 @@ export default function RankedMatch({ playerName, onBack }: Props) {
     }
 
     setPhase('result');
-  }, [rankedState]);
+  }, [rankedState, playerId]);
 
   const handleBackToLobby = useCallback(() => {
-    send({ type: 'leave_room' });
-    reconnectTokenRef.current = '';
     setPhase('idle');
     setGameResult(null);
     if (aiGameRef.current) {
       aiGameRef.current.stop();
       aiGameRef.current = null;
     }
-  }, [send]);
+  }, []);
 
   // ===== Derived State =====
   const tier = getTierByPoints(rankedState.points);
@@ -417,43 +232,38 @@ export default function RankedMatch({ playerName, onBack }: Props) {
 
   // For AI matches, auto-start countdown after "found" phase
   useEffect(() => {
-    if (phase === 'found' && isAIMatch) {
-      // Simulate a countdown
-      let count = 3;
-      setCountdownNumber(count);
-      setPhase('countdown');
+    if (phase !== 'found') return;
 
-      const interval = setInterval(() => {
-        count--;
-        if (count > 0) {
-          setCountdownNumber(count);
-        } else {
-          clearInterval(interval);
-          setCountdownNumber(null);
-          setPhase('playing');
-        }
-      }, 1000);
+    let count = 3;
+    setCountdownNumber(count);
+    setPhase('countdown');
 
-      return () => clearInterval(interval);
-    }
-  }, [phase, isAIMatch]);
+    const interval = setInterval(() => {
+      count--;
+      if (count > 0) {
+        setCountdownNumber(count);
+      } else {
+        clearInterval(interval);
+        setCountdownNumber(null);
+        setPhase('playing');
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [phase]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (aiGameRef.current) {
+        aiGameRef.current.stop();
+      }
+    };
+  }, []);
 
   // ===== Render =====
   return (
     <div className={styles.container}>
-      {/* Status Bar */}
-      <div className={styles.statusBar}>
-        <div className={styles.connectionStatus}>
-          <div className={`${styles.statusDot} ${styles[connectionStatus]}`} />
-          <span>
-            {connectionStatus === 'connected' && 'Online'}
-            {connectionStatus === 'connecting' && 'Connecting...'}
-            {connectionStatus === 'error' && 'Error'}
-            {connectionStatus === 'disconnected' && 'Offline'}
-          </span>
-        </div>
-      </div>
-
       {/* Idle - Rank Display + Start */}
       {phase === 'idle' && (
         <div className={styles.rankScreen}>
@@ -522,40 +332,12 @@ export default function RankedMatch({ playerName, onBack }: Props) {
           <button
             className={styles.searchBtn}
             onClick={startSearch}
-            disabled={connectionStatus !== 'connected'}
           >
             FIND MATCH
           </button>
 
           <button className={styles.backBtn} onClick={onBack}>
             Back
-          </button>
-        </div>
-      )}
-
-      {/* Searching */}
-      {phase === 'searching' && (
-        <div className={styles.searchScreen}>
-          <div className={styles.searchTitle}>SEARCHING FOR OPPONENT</div>
-
-          <div className={styles.searchAnim}>
-            <div className={styles.searchPulse} />
-            <div className={styles.searchTimer}>{searchTimer}s</div>
-          </div>
-
-          <div className={styles.searchInfo}>
-            <div className={styles.searchRank} style={{ color: tier.color }}>{tier.name}</div>
-            <div className={styles.searchPoints}>{rankedState.points} RP</div>
-          </div>
-
-          {searchTimer >= 5 && (
-            <div className={styles.searchHint}>
-              AI opponent joining soon...
-            </div>
-          )}
-
-          <button className={styles.cancelBtn} onClick={cancelSearch}>
-            Cancel
           </button>
         </div>
       )}
@@ -571,7 +353,7 @@ export default function RankedMatch({ playerName, onBack }: Props) {
             <div className={styles.matchupVs}>VS</div>
             <div className={styles.matchupPlayer}>
               <div className={styles.matchupName}>{opponentName}</div>
-              {isAIMatch && <div className={styles.aiBadge}>AI</div>}
+              <div className={styles.aiBadge}>AI</div>
             </div>
           </div>
           <div className={styles.countdownNumber}>{countdownNumber}</div>
@@ -579,11 +361,11 @@ export default function RankedMatch({ playerName, onBack }: Props) {
       )}
 
       {/* Playing */}
-      {phase === 'playing' && wsRef.current && (
+      {phase === 'playing' && ws && (
         <MultiplayerBattle
-          ws={wsRef.current}
+          ws={ws}
           roomCode={roomCode}
-          playerId={playerIdRef.current}
+          playerId={playerId}
           playerName={playerName}
           opponents={[{
             id: opponentId,


### PR DESCRIPTION
## Summary
Refactored the `RankedMatch` component to accept WebSocket connection and related state as props from the parent `MultiplayerGame` component, rather than managing its own connection lifecycle. This simplifies the component and centralizes connection management.

## Key Changes
- **Moved connection management to parent**: `MultiplayerGame` now passes `ws`, `connectionStatus`, and `playerId` as props to `RankedMatch`
- **Removed server-side matchmaking**: Eliminated the queue-based ranked matchmaking flow (`queue_ranked`, `cancel_ranked`, search timer, etc.)
- **Simplified to AI-only matches**: The component now only supports client-side AI matches that start immediately without server coordination
- **Removed connection lifecycle code**: Deleted WebSocket connection setup, reconnection logic, and related state management from `RankedMatch`
- **Removed status bar**: Eliminated the connection status display UI since connection is now managed externally
- **Removed searching phase**: Deleted the entire "searching for opponent" UI and related timer logic
- **Simplified message handling**: Removed most server message handlers (`ranked_queued`, `ranked_match_found`, etc.) since matches are now AI-only
- **Updated AI game integration**: Modified AI board update callbacks to use the passed WebSocket reference and opponent ID from props

## Implementation Details
- The component now uses a `useRef` to keep the WebSocket prop in sync with effects
- AI matches auto-start countdown immediately after the "found" phase
- Relay messages for AI garbage/game-over are intercepted at the WebSocket `send` level to prevent sending to server
- Cleanup on unmount properly stops any running AI game
- The component is now stateless regarding connection concerns, making it easier to test and reuse

https://claude.ai/code/session_01LURnwvyMCMH3jxsucseWiU