### PR TITLE
Add Discord community link to header

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -59,7 +59,7 @@ export default function RhythmiaPage() {
                 } else if (message.type === 'ping') {
                     ws.send(JSON.stringify({ type: 'pong' }));
                 }
-            } catch {}
+            } catch { }
         };
 
         ws.onclose = () => {
@@ -184,7 +184,7 @@ export default function RhythmiaPage() {
                         </div>
                         <LocaleSwitcher />
                         <a
-                            href="https://discord.gg/TRFHTWCY4W"
+                            href="https://discord.gg/7mBCasYkJY"
                             target="_blank"
                             rel="noopener noreferrer"
                             className={styles.discordLink}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -11,6 +11,7 @@ import styles from '../../components/rhythmia/rhythmia.module.css';
 import VanillaGame from '../../components/rhythmia/tetris';
 import MultiplayerGame from '../../components/rhythmia/MultiplayerGame';
 import Advancements from '../../components/rhythmia/Advancements';
+import { FaDiscord } from 'react-icons/fa';
 import LocaleSwitcher from '../../components/LocaleSwitcher';
 
 type GameMode = 'lobby' | 'vanilla' | 'multiplayer';
@@ -182,6 +183,15 @@ export default function RhythmiaPage() {
                             <span>v{rhythmiaConfig.version}</span>
                         </div>
                         <LocaleSwitcher />
+                        <a
+                            href="https://discord.gg/TRFHTWCY4W"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={styles.discordLink}
+                            aria-label="Discord"
+                        >
+                            <FaDiscord size={16} />
+                        </a>
                     </div>
                 </motion.header>
 

--- a/src/components/rhythmia/rhythmia.module.css
+++ b/src/components/rhythmia/rhythmia.module.css
@@ -112,6 +112,19 @@
   }
 }
 
+/* Discord link */
+.discordLink {
+  display: flex;
+  align-items: center;
+  color: rgba(255, 255, 255, 0.7);
+  transition: color 0.25s, transform 0.25s;
+}
+
+.discordLink:hover {
+  color: #ffffff;
+  transform: scale(1.15);
+}
+
 /* Main content */
 .main {
   flex: 1;


### PR DESCRIPTION
## Summary
Added a Discord community link to the Rhythmia game header, allowing users to easily access the Discord server from the application.

## Changes
- **Import Discord icon**: Added `FaDiscord` from `react-icons/fa` for the Discord logo
- **Add Discord link button**: Placed a new Discord invite link in the header next to the LocaleSwitcher component
  - Links to: `https://discord.gg/TRFHTWCY4W`
  - Opens in a new tab with security attributes (`target="_blank"` and `rel="noopener noreferrer"`)
  - Includes proper accessibility label (`aria-label="Discord"`)
- **Style Discord link**: Added `.discordLink` CSS class with:
  - Flexbox alignment for proper icon centering
  - Semi-transparent white color (70% opacity) by default
  - Smooth transitions on hover (color and scale)
  - Hover effect: full white color and 1.15x scale transform for visual feedback

## Implementation Details
The Discord link is positioned in the header footer area alongside the version number and locale switcher, maintaining visual consistency with the existing UI. The icon scales up slightly on hover to provide clear interactive feedback to users.

https://claude.ai/code/session_01SbXHLz7qZRvhdBYA3yup2q