### PR TITLE
Add SEO files and implement grid-based enemy movement system

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,13 @@
+# *
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /admin/
+Disallow: /images/
+Disallow: /net*
+
+# Host
+Host: https://azuretier.net
+
+# Sitemaps
+Sitemap: https://azuretier.net/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+<url><loc>https://azuretier.net/blog</loc><lastmod>2026-02-10T04:30:19.794Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/shader-demo</loc><lastmod>2026-02-10T04:30:19.795Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sns-widgets</loc><lastmod>2026-02-10T04:30:19.795Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sunphase</loc><lastmod>2026-02-10T04:30:19.795Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+</urlset>

--- a/src/components/rhythmia/tetris/constants.ts
+++ b/src/components/rhythmia/tetris/constants.ts
@@ -252,11 +252,19 @@ export const TERRAIN_PARTICLES_PER_LINE = 15;
 export const TERRAIN_PARTICLE_LIFETIME = 600;
 
 // ===== Tower Defense Settings =====
-export const ENEMY_SPAWN_DISTANCE = 18;  // Distance from center where enemies spawn
-export const ENEMY_BASE_SPEED = 0.5;     // Base movement speed toward tower per tick
-export const ENEMY_TOWER_RADIUS = 3;     // Distance at which enemy "reaches" tower
+export const ENEMY_SPAWN_DISTANCE = 18;  // Distance from center where enemies spawn (world units)
+export const ENEMY_BASE_SPEED = 0.5;     // Legacy — grid system uses 1 tile/turn
+export const ENEMY_TOWER_RADIUS = 3;     // Distance at which enemy "reaches" tower (world units)
 export const ENEMIES_PER_BEAT = 1;       // Enemies spawned per beat
 export const ENEMIES_KILLED_PER_LINE = 2; // Enemies killed per line clear
+
+// ===== Block Grid System =====
+// Enemies move on a discrete grid, 1 tile per turn, orthogonal only (no diagonals).
+// The tower sits at grid origin (0, 0). Grid extends from -GRID_HALF to +GRID_HALF.
+export const GRID_TILE_SIZE = 1;         // World units per grid tile
+export const GRID_HALF = 18;             // Grid extends ±18 tiles from center
+export const GRID_SPAWN_RING = 18;       // Manhattan distance from center for spawn perimeter
+export const GRID_TOWER_RADIUS = 1;      // Grid tiles — enemy reaches tower at Manhattan dist ≤ this
 
 // ===== Tower Defense HUD =====
 export const MAX_HEALTH = 100;

--- a/src/components/rhythmia/tetris/hooks/useGameState.ts
+++ b/src/components/rhythmia/tetris/hooks/useGameState.ts
@@ -9,6 +9,7 @@ import {
     ENEMIES_PER_BEAT, ENEMIES_KILLED_PER_LINE,
     MAX_HEALTH, ENEMY_REACH_DAMAGE, ENEMY_HP,
     BULLET_SPEED, BULLET_KILL_RADIUS, BULLET_DAMAGE,
+    GRID_TILE_SIZE, GRID_HALF, GRID_SPAWN_RING, GRID_TOWER_RADIUS,
 } from '../constants';
 import { createEmptyBoard, shuffleBag, getShape, isValidPosition, createSpawnPiece } from '../utils/boardUtils';
 
@@ -339,18 +340,49 @@ export function useGameState() {
 
     // ===== Tower Defense Enemy Actions =====
 
-    // Spawn enemies at the terrain edge
+    // Collect grid cells occupied by alive enemies (for collision avoidance)
+    const getOccupiedCells = useCallback((): Set<string> => {
+        const set = new Set<string>();
+        for (const e of enemiesRef.current) {
+            if (e.alive) set.add(`${e.gridX},${e.gridZ}`);
+        }
+        return set;
+    }, []);
+
+    // Spawn enemies on the grid perimeter (Manhattan distance = GRID_SPAWN_RING from center)
     const spawnEnemies = useCallback((count: number) => {
+        const occupied = getOccupiedCells();
         const newEnemies: Enemy[] = [];
+
         for (let i = 0; i < count; i++) {
-            const angle = Math.random() * Math.PI * 2;
-            const spawnDist = ENEMY_SPAWN_DISTANCE + Math.random() * 3;
+            // Build list of available perimeter cells at Manhattan distance = GRID_SPAWN_RING
+            const candidates: { gx: number; gz: number }[] = [];
+            for (let gx = -GRID_HALF; gx <= GRID_HALF; gx++) {
+                for (let gz = -GRID_HALF; gz <= GRID_HALF; gz++) {
+                    if (Math.abs(gx) + Math.abs(gz) === GRID_SPAWN_RING) {
+                        const key = `${gx},${gz}`;
+                        if (!occupied.has(key)) {
+                            candidates.push({ gx, gz });
+                        }
+                    }
+                }
+            }
+
+            if (candidates.length === 0) break; // No available spawn cells
+
+            const cell = candidates[Math.floor(Math.random() * candidates.length)];
+            const worldX = cell.gx * GRID_TILE_SIZE;
+            const worldZ = cell.gz * GRID_TILE_SIZE;
+            occupied.add(`${cell.gx},${cell.gz}`);
+
             newEnemies.push({
                 id: nextEnemyId++,
-                x: Math.cos(angle) * spawnDist,
+                x: worldX,
                 y: 0.5,
-                z: Math.sin(angle) * spawnDist,
-                speed: ENEMY_BASE_SPEED + Math.random() * 0.03,
+                z: worldZ,
+                gridX: cell.gx,
+                gridZ: cell.gz,
+                speed: 1, // 1 tile per turn (grid system)
                 health: ENEMY_HP,
                 maxHealth: ENEMY_HP,
                 alive: true,
@@ -358,37 +390,70 @@ export function useGameState() {
             });
         }
         setEnemies(prev => [...prev, ...newEnemies]);
-    }, []);
+    }, [getOccupiedCells]);
 
-    // Move enemies toward center (tower), returns number that reached the tower
-    // Enemies that reach the tower are removed immediately (disappear).
-    // Must compute reached OUTSIDE the state setter — React 18 batching
-    // defers the updater callback, so a `reached` counter inside it would
-    // still be 0 when this function returns.
+    // Move enemies 1 tile toward tower using orthogonal-only movement (no diagonals).
+    // Each enemy picks the best cardinal direction (Up/Down/Left/Right) that reduces
+    // Manhattan distance to (0,0), avoiding occupied cells. Returns number that reached tower.
     const updateEnemies = useCallback((): number => {
         const current = enemiesRef.current;
         let reached = 0;
         const updated: Enemy[] = [];
 
-        for (const e of current) {
-            if (!e.alive) continue;
+        // Build set of cells that will be occupied after movement.
+        // Process enemies closest to tower first so they get priority on cell claims.
+        const sorted = current
+            .filter(e => e.alive)
+            .sort((a, b) => (Math.abs(a.gridX) + Math.abs(a.gridZ)) - (Math.abs(b.gridX) + Math.abs(b.gridZ)));
 
-            const dx = -e.x;
-            const dz = -e.z;
-            const dist = Math.sqrt(dx * dx + dz * dz);
+        const claimed = new Set<string>();
 
-            if (dist < ENEMY_TOWER_RADIUS) {
+        // Orthogonal directions: Up, Down, Left, Right
+        const dirs: [number, number][] = [[0, -1], [0, 1], [-1, 0], [1, 0]];
+
+        for (const e of sorted) {
+            const manhattan = Math.abs(e.gridX) + Math.abs(e.gridZ);
+
+            // Check if enemy has reached the tower
+            if (manhattan <= GRID_TOWER_RADIUS) {
                 reached++;
-                // Enemy disappears — not added to updated array
-                continue;
+                continue; // removed from game
             }
 
-            const nx = dx / dist;
-            const nz = dz / dist;
+            // Evaluate orthogonal neighbors — pick the one closest to (0,0)
+            let bestDist = manhattan; // staying still is the fallback
+            let bestGx = e.gridX;
+            let bestGz = e.gridZ;
+
+            // Shuffle directions to break ties randomly
+            const shuffled = [...dirs].sort(() => Math.random() - 0.5);
+
+            for (const [dx, dz] of shuffled) {
+                const nx = e.gridX + dx;
+                const nz = e.gridZ + dz;
+                const nd = Math.abs(nx) + Math.abs(nz);
+
+                // Must reduce distance (move closer to tower)
+                if (nd >= manhattan) continue;
+
+                const key = `${nx},${nz}`;
+                if (claimed.has(key)) continue; // cell taken
+
+                if (nd < bestDist) {
+                    bestDist = nd;
+                    bestGx = nx;
+                    bestGz = nz;
+                }
+            }
+
+            claimed.add(`${bestGx},${bestGz}`);
+
             updated.push({
                 ...e,
-                x: e.x + nx * e.speed,
-                z: e.z + nz * e.speed,
+                gridX: bestGx,
+                gridZ: bestGz,
+                x: bestGx * GRID_TILE_SIZE,
+                z: bestGz * GRID_TILE_SIZE,
             });
         }
 
@@ -398,12 +463,13 @@ export function useGameState() {
     }, []);
 
     // Kill closest enemies (when lines are cleared) — removed instantly
+    // Uses Manhattan distance (tile distance) for sorting
     const killEnemies = useCallback((count: number) => {
         setEnemies(prev => {
             const alive = prev.filter(e => e.alive);
             alive.sort((a, b) => {
-                const distA = Math.sqrt(a.x * a.x + a.z * a.z);
-                const distB = Math.sqrt(b.x * b.x + b.z * b.z);
+                const distA = Math.abs(a.gridX) + Math.abs(a.gridZ);
+                const distB = Math.abs(b.gridX) + Math.abs(b.gridZ);
                 return distA - distB;
             });
 
@@ -415,30 +481,31 @@ export function useGameState() {
     }, []);
 
     // Fire a bullet from tower at the closest enemy (no mana cost)
+    // Uses Manhattan distance (tile distance) for targeting priority
     const fireBullet = useCallback((): boolean => {
         const alive = enemiesRef.current.filter(e => e.alive);
         if (alive.length === 0) return false;
 
-        // Find closest enemy
+        // Find closest enemy by Manhattan distance
         let closest = alive[0];
-        let closestDist = Math.sqrt(closest.x * closest.x + closest.z * closest.z);
+        let closestDist = Math.abs(closest.gridX) + Math.abs(closest.gridZ);
         for (let i = 1; i < alive.length; i++) {
-            const d = Math.sqrt(alive[i].x * alive[i].x + alive[i].z * alive[i].z);
+            const d = Math.abs(alive[i].gridX) + Math.abs(alive[i].gridZ);
             if (d < closestDist) {
                 closest = alive[i];
                 closestDist = d;
             }
         }
 
-        // Create bullet from tower top toward enemy
+        // Create bullet from tower top toward enemy's grid-based world position
         const bullet: Bullet = {
             id: nextBulletId++,
             x: 0,
             y: 12,
             z: 0,
-            targetX: closest.x,
+            targetX: closest.gridX * GRID_TILE_SIZE,
             targetY: 1.5,
-            targetZ: closest.z,
+            targetZ: closest.gridZ * GRID_TILE_SIZE,
             speed: BULLET_SPEED,
             alive: true,
         };

--- a/src/components/rhythmia/tetris/types.ts
+++ b/src/components/rhythmia/tetris/types.ts
@@ -124,11 +124,19 @@ export type CraftedCard = {
 };
 
 // ===== Tower Defense =====
+
+// Grid position for block-based movement (orthogonal only, 1 tile per turn)
+export type GridPos = { gx: number; gz: number };
+
 export type Enemy = {
     id: number;
+    // World-space position (derived from grid coords for rendering)
     x: number;
     y: number;
     z: number;
+    // Grid coordinates — enemies move 1 tile per turn, orthogonal only
+    gridX: number;
+    gridZ: number;
     speed: number;
     health: number;
     maxHealth: number;


### PR DESCRIPTION
## Summary
This PR adds SEO infrastructure (robots.txt and sitemap.xml) and refactors the tower defense enemy movement system from continuous physics-based movement to a discrete grid-based system with orthogonal-only movement.

## Key Changes

### SEO Infrastructure
- Added `public/robots.txt` with crawler directives (disallowing `/api/`, `/admin/`, `/images/`, `/net*`) and sitemap reference
- Added `public/sitemap.xml` with four main routes (blog, shader-demo, sns-widgets, sunphase) marked for daily crawling

### Tower Defense Grid System
- **New grid constants** in `constants.ts`:
  - `GRID_TILE_SIZE`: World units per grid tile (1 unit)
  - `GRID_HALF`: Grid extends ±18 tiles from center
  - `GRID_SPAWN_RING`: Enemies spawn at Manhattan distance 18 from tower
  - `GRID_TOWER_RADIUS`: Enemy reaches tower at Manhattan distance ≤ 1

- **Enemy type updates** in `types.ts`:
  - Added `gridX` and `gridZ` properties for discrete grid coordinates
  - World-space `x`, `y`, `z` are now derived from grid coords for rendering

- **Movement system refactor** in `useGameState.ts`:
  - Enemies now move 1 tile per turn on a discrete grid (orthogonal only: Up/Down/Left/Right)
  - `spawnEnemies()`: Spawns enemies on the perimeter at Manhattan distance = 18, with collision avoidance
  - `updateEnemies()`: Implements pathfinding using Manhattan distance; enemies pick the best cardinal direction that reduces distance to tower, avoiding occupied cells
  - Processes enemies closest to tower first to give priority on cell claims
  - `killEnemies()` and `fireBullet()`: Updated to use Manhattan distance for targeting priority

## Implementation Details
- Enemies are processed in order of proximity to tower during movement to ensure fair cell allocation
- Directions are shuffled to break ties randomly, preventing predictable movement patterns
- Collision avoidance prevents multiple enemies from occupying the same grid cell
- Grid coordinates are converted to world space (multiply by `GRID_TILE_SIZE`) for 3D rendering

https://claude.ai/code/session_01B1pGw7pTLFLwYhHVKFJig2