### PR TITLE
Render material items as isometric 3D ore blocks

### DIFF
--- a/src/components/rhythmia/tetris/VanillaGame.module.css
+++ b/src/components/rhythmia/tetris/VanillaGame.module.css
@@ -1210,7 +1210,7 @@
   opacity: 0.7;
 }
 
-/* Icon wrapper with subtle radial glow */
+/* Icon wrapper with subtle radial glow + 3D ore bob */
 .itemCardIconWrap {
   width: 28px;
   height: 28px;
@@ -1219,6 +1219,12 @@
   justify-content: center;
   border-radius: 6px;
   margin-bottom: 2px;
+  animation: oreBlockBob 3s ease-in-out infinite;
+}
+
+@keyframes oreBlockBob {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-1.5px); }
 }
 
 /* Large count number — dominant visual */


### PR DESCRIPTION
## Summary
Replaces flat SVG icons for material items (stone, iron, crystal, gold, obsidian, star) with detailed isometric 3D ore block renderings. Weapon card icons remain as flat SVG designs. Adds a subtle bobbing animation to all item card icons.

## Key Changes

- **Isometric 3D ore block rendering**: Implemented full 3D isometric projection system with:
  - Coordinate transformation functions for top, left, and right cube faces
  - Per-face pixel grid textures (5×5 resolution) with stone base and ore spot variations
  - Face-specific color palettes with proper isometric lighting (top=brightest, left=darkest)
  - Specular highlights and edge wireframes for depth definition
  - Optional glow effects for rare items (crystal, gold, obsidian, star)

- **Ore texture definitions**: Created unique 5×5 pixel patterns for each material type with stone variants and ore spots distributed across all three visible faces

- **Color system**: Defined material-specific color schemes with three tiers per face (stone base, stone variant, ore spots) matching Minecraft aesthetic

- **Icon separation**: Split `renderIcon()` into `renderOreBlock()` for materials and `renderWeaponIcon()` for weapons, with conditional routing in `ItemIcon` component

- **Animation enhancement**: Added `oreBlockBob` keyframe animation (3s infinite) to `.itemCardIconWrap` for subtle vertical bobbing effect on all item cards

- **Drop shadows**: Implemented color-matched drop shadows using ore-specific glow colors for cohesive 3D depth perception

## Implementation Details

- Uses SVG polygon rendering for pixel-perfect isometric faces with `crispEdges` shape rendering
- Isometric math: 30° angles with COS30 (0.866) and SIN30 (0.5) constants
- Face draw order (left → right → top) ensures correct depth layering
- Edge wireframe uses stroke-based silhouette and inner face boundaries
- Glow effects use semi-transparent circles with ore-specific colors
- Weapon icons unchanged; material items now exclusively use 3D block rendering

https://claude.ai/code/session_01XZzaLjC3wMtoV3iXBK165W