### PR TITLE
Add world progression system with visual indicators

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://azuretier.net/blog</loc><lastmod>2026-02-10T04:30:19.794Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/shader-demo</loc><lastmod>2026-02-10T04:30:19.795Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/sns-widgets</loc><lastmod>2026-02-10T04:30:19.795Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/sunphase</loc><lastmod>2026-02-10T04:30:19.795Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/blog</loc><lastmod>2026-02-10T05:07:44.289Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/shader-demo</loc><lastmod>2026-02-10T05:07:44.290Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sns-widgets</loc><lastmod>2026-02-10T05:07:44.290Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sunphase</loc><lastmod>2026-02-10T05:07:44.290Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/components/rhythmia/tetris/VanillaGame.module.css
+++ b/src/components/rhythmia/tetris/VanillaGame.module.css
@@ -507,6 +507,101 @@
   letter-spacing: 0.1em;
 }
 
+/* Title screen world display */
+.titleWorldDisplay {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.titleWorldName {
+  font-size: 1.6rem;
+  font-weight: 300;
+  color: rgba(255, 255, 255, 0.85);
+  letter-spacing: 0.15em;
+}
+
+.titleWorldLabel {
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.3);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+}
+
+/* Title screen world progression */
+.titleWorldProgress {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.titleProgressBar {
+  display: flex;
+  gap: 6px;
+}
+
+.titleProgressPip {
+  width: 28px;
+  height: 6px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  transition: background 0.3s, border-color 0.3s;
+}
+
+.titleProgressPipFilled {
+  background: rgba(255, 255, 255, 0.6);
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+.titleProgressText {
+  font-size: 0.7rem;
+  font-weight: 300;
+  color: rgba(255, 255, 255, 0.35);
+  letter-spacing: 0.12em;
+}
+
+/* In-game world progression display */
+.worldProgressDisplay {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  justify-content: center;
+}
+
+.worldProgressName {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.5);
+  letter-spacing: 0.05em;
+}
+
+.worldProgressPips {
+  display: flex;
+  gap: 3px;
+}
+
+.worldProgressPip {
+  width: 14px;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.12);
+  transition: background 0.3s;
+}
+
+.worldProgressPipFilled {
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.worldProgressLabel {
+  font-size: 0.6rem;
+  color: rgba(255, 255, 255, 0.3);
+  letter-spacing: 0.08em;
+}
+
 /* Theme Navbar */
 .themeNav {
   display: flex;

--- a/src/components/rhythmia/tetris/components/GameUI.tsx
+++ b/src/components/rhythmia/tetris/components/GameUI.tsx
@@ -1,18 +1,29 @@
 import React from 'react';
-import { WORLDS, ColorTheme } from '../constants';
+import { WORLDS, TERRAINS_PER_WORLD, ColorTheme } from '../constants';
 import type { GameMode } from '../types';
 import styles from '../VanillaGame.module.css';
 
 interface TitleScreenProps {
     onStart: (mode: GameMode) => void;
+    worldIdx?: number;
+    stageNumber?: number;
 }
 
 /**
- * Title screen component with game mode selection
+ * Title screen component with game mode selection and world display
  */
-export function TitleScreen({ onStart }: TitleScreenProps) {
+export function TitleScreen({ onStart, worldIdx = 0, stageNumber = 1 }: TitleScreenProps) {
+    const world = WORLDS[worldIdx];
+    const terrainsCleared = (stageNumber - 1) % TERRAINS_PER_WORLD;
+    const isMaxWorld = worldIdx >= WORLDS.length - 1;
+
     return (
         <div className={styles.titleScreen}>
+            {/* World display */}
+            <div className={styles.titleWorldDisplay}>
+                <div className={styles.titleWorldName}>{world.name}</div>
+                <div className={styles.titleWorldLabel}>WORLD {worldIdx + 1}</div>
+            </div>
             <p>リズムに乗ってブロックを積め！</p>
             <div className={styles.modeSelect}>
                 <button className={styles.modeBtn} onClick={() => onStart('vanilla')}>
@@ -26,6 +37,28 @@ export function TitleScreen({ onStart }: TitleScreenProps) {
                     <span className={styles.modeBtnDesc}>タワーを守れ！</span>
                 </button>
             </div>
+            {/* World progression info */}
+            {!isMaxWorld ? (
+                <div className={styles.titleWorldProgress}>
+                    <div className={styles.titleProgressBar}>
+                        {Array.from({ length: TERRAINS_PER_WORLD }).map((_, i) => (
+                            <div
+                                key={i}
+                                className={`${styles.titleProgressPip} ${i < terrainsCleared ? styles.titleProgressPipFilled : ''}`}
+                            />
+                        ))}
+                    </div>
+                    <div className={styles.titleProgressText}>
+                        Clear {TERRAINS_PER_WORLD - terrainsCleared} terrain{TERRAINS_PER_WORLD - terrainsCleared !== 1 ? 's' : ''} to Next World
+                    </div>
+                </div>
+            ) : (
+                <div className={styles.titleWorldProgress}>
+                    <div className={styles.titleProgressText}>
+                        FINAL WORLD — {TERRAINS_PER_WORLD - terrainsCleared} terrain{TERRAINS_PER_WORLD - terrainsCleared !== 1 ? 's' : ''} remaining
+                    </div>
+                </div>
+            )}
         </div>
     );
 }
@@ -40,6 +73,39 @@ interface WorldDisplayProps {
 export function WorldDisplay({ worldIdx }: WorldDisplayProps) {
     return (
         <div className={styles.worldDisplay}>{WORLDS[worldIdx].name}</div>
+    );
+}
+
+interface WorldProgressDisplayProps {
+    worldIdx: number;
+    stageNumber: number;
+}
+
+/**
+ * In-game world progression indicator showing terrains cleared toward next world
+ */
+export function WorldProgressDisplay({ worldIdx, stageNumber }: WorldProgressDisplayProps) {
+    const world = WORLDS[worldIdx];
+    const terrainsCleared = (stageNumber - 1) % TERRAINS_PER_WORLD;
+    const isMaxWorld = worldIdx >= WORLDS.length - 1;
+
+    return (
+        <div className={styles.worldProgressDisplay}>
+            <span className={styles.worldProgressName}>{world.name}</span>
+            <div className={styles.worldProgressPips}>
+                {Array.from({ length: TERRAINS_PER_WORLD }).map((_, i) => (
+                    <div
+                        key={i}
+                        className={`${styles.worldProgressPip} ${i < terrainsCleared ? styles.worldProgressPipFilled : ''}`}
+                    />
+                ))}
+            </div>
+            <span className={styles.worldProgressLabel}>
+                {isMaxWorld
+                    ? `${terrainsCleared}/${TERRAINS_PER_WORLD}`
+                    : `${terrainsCleared}/${TERRAINS_PER_WORLD} → Next World`}
+            </span>
+        </div>
     );
 }
 

--- a/src/components/rhythmia/tetris/components/index.ts
+++ b/src/components/rhythmia/tetris/components/index.ts
@@ -4,6 +4,7 @@ export { NextPiece, HoldPiece } from './PiecePreview';
 export {
     TitleScreen,
     WorldDisplay,
+    WorldProgressDisplay,
     ScoreDisplay,
     ComboDisplay,
     TerrainProgress,

--- a/src/components/rhythmia/tetris/constants.ts
+++ b/src/components/rhythmia/tetris/constants.ts
@@ -137,6 +137,8 @@ export const DEFAULT_ARR = 33;   // Auto Repeat Rate - delay between each auto-r
 export const DEFAULT_SDF = 50;   // Soft Drop Factor - soft drop speed in ms
 
 // ===== Terrain Settings =====
+// Number of terrains (stages) to clear before advancing to the next world
+export const TERRAINS_PER_WORLD = 4;
 // Voxel blocks destroyed per cleared line (multiplied by beat multiplier)
 export const TERRAIN_DAMAGE_PER_LINE = 4;
 

--- a/src/components/rhythmia/tetris/hooks/useGameState.ts
+++ b/src/components/rhythmia/tetris/hooks/useGameState.ts
@@ -2,9 +2,10 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import type { Piece, Board, KeyState, GamePhase, GameMode, InventoryItem, FloatingItem, CraftedCard, TerrainParticle, Enemy, Bullet } from '../types';
 import {
     BOARD_WIDTH, DEFAULT_DAS, DEFAULT_ARR, DEFAULT_SDF, ColorTheme,
-    ITEMS, TOTAL_DROP_WEIGHT, WEAPON_CARDS, WEAPON_CARD_MAP,
+    ITEMS, TOTAL_DROP_WEIGHT, WEAPON_CARDS, WEAPON_CARD_MAP, WORLDS,
     ITEMS_PER_TERRAIN_DAMAGE, MAX_FLOATING_ITEMS, FLOAT_DURATION,
     TERRAIN_PARTICLES_PER_LINE, TERRAIN_PARTICLE_LIFETIME,
+    TERRAINS_PER_WORLD,
     ENEMY_SPAWN_DISTANCE, ENEMY_BASE_SPEED, ENEMY_TOWER_RADIUS,
     ENEMIES_PER_BEAT, ENEMIES_KILLED_PER_LINE,
     MAX_HEALTH, ENEMY_REACH_DAMAGE, ENEMY_HP,
@@ -242,10 +243,19 @@ export function useGameState() {
         return remaining;
     }, []);
 
-    // Start a new terrain stage
+    // Start a new terrain stage — advances world when enough terrains are cleared
     const startNewStage = useCallback((newStageNumber: number) => {
         setStageNumber(newStageNumber);
         stageNumberRef.current = newStageNumber;
+
+        // Advance world based on completed stages (stage 1 = first terrain of world 0)
+        const newWorldIdx = Math.min(
+            Math.floor((newStageNumber - 1) / TERRAINS_PER_WORLD),
+            WORLDS.length - 1
+        );
+        setWorldIdx(newWorldIdx);
+        worldIdxRef.current = newWorldIdx;
+
         // New seed triggers VoxelWorldBackground regeneration
         setTerrainSeed(newStageNumber * 7919 + 42);
         setTerrainDestroyedCount(0);

--- a/src/components/rhythmia/tetris/tetris.tsx
+++ b/src/components/rhythmia/tetris/tetris.tsx
@@ -36,6 +36,7 @@ import {
   NextPiece,
   HoldPiece,
   TitleScreen,
+  WorldProgressDisplay,
   ScoreDisplay,
   ComboDisplay,
   TerrainProgress,
@@ -960,7 +961,7 @@ export default function Rhythmia() {
 
       {/* Title Screen */}
       {!isPlaying && !gameOver && (
-        <TitleScreen onStart={startGame} />
+        <TitleScreen onStart={startGame} worldIdx={worldIdx} stageNumber={stageNumber} />
       )}
 
       {/* Game */}
@@ -981,6 +982,9 @@ export default function Rhythmia() {
             stageNumber={stageNumber}
             gameMode={gameMode}
           />
+          {gameMode === 'vanilla' && (
+            <WorldProgressDisplay worldIdx={worldIdx} stageNumber={stageNumber} />
+          )}
 
           <div className={styles.gameArea} ref={gameAreaRef}>
             {/* Left sidebar: Hold + Inventory (separate containers) */}


### PR DESCRIPTION
## Summary
Implemented a world progression system for the Rhythmia tetris game that advances players through multiple worlds as they clear terrains. Added visual indicators on both the title screen and in-game UI to show progress toward the next world.

## Key Changes
- **World Progression Logic**: Added `TERRAINS_PER_WORLD` constant (4 terrains per world) and updated `startNewStage()` to automatically advance the world index based on completed stages
- **Title Screen Enhancement**: 
  - Display current world name and number
  - Show progress bar with filled/unfilled pips indicating terrains cleared
  - Display remaining terrains needed to advance to next world (or "FINAL WORLD" message for max world)
- **In-Game Progress Display**: New `WorldProgressDisplay` component shows current world name, progress pips, and terrain count during vanilla mode gameplay
- **Styling**: Added comprehensive CSS classes for world display elements with consistent visual hierarchy and animations
- **Component Updates**: 
  - `TitleScreen` now accepts `worldIdx` and `stageNumber` props
  - New `WorldProgressDisplay` component exported from GameUI
  - Updated `useGameState` hook to calculate and set world index based on stage progression

## Implementation Details
- World advancement is calculated as `Math.floor((stageNumber - 1) / TERRAINS_PER_WORLD)` with a cap at the maximum world index
- Progress indicators use visual pips (small bars) that fill as terrains are cleared
- The system gracefully handles the final world with appropriate messaging
- Sitemap timestamps updated to reflect build time

https://claude.ai/code/session_01X1fXZLLJYGWojL7hk863Y4