### PR TITLE
Refactor Advancements component to support embedded mode

### DIFF
--- a/src/components/rhythmia/Advancements.module.css
+++ b/src/components/rhythmia/Advancements.module.css
@@ -103,12 +103,12 @@
 }
 
 .tab {
-  flex-shrink: 0;
+  flex: 1 1 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 2px;
-  padding: 8px 14px;
+  padding: 8px 6px;
   font-size: 0.65rem;
   letter-spacing: 0.06em;
   color: rgba(255, 255, 255, 0.35);
@@ -117,6 +117,7 @@
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.2s;
+  min-width: 0;
 }
 
 .tab:hover {
@@ -265,6 +266,6 @@
   }
 
   .tab {
-    padding: 6px 10px;
+    padding: 6px 4px;
   }
 }

--- a/src/components/rhythmia/tetris/components/Board.tsx
+++ b/src/components/rhythmia/tetris/components/Board.tsx
@@ -3,7 +3,7 @@ import { BOARD_WIDTH, BOARD_HEIGHT, COLORS, ColorTheme, getThemedColor } from '.
 import { getShape, isValidPosition, getGhostY } from '../utils/boardUtils';
 import { ADVANCEMENTS } from '@/lib/advancements/definitions';
 import { loadAdvancementState } from '@/lib/advancements/storage';
-import { AdvancementsMenu } from '@/components/rhythmia/AdvancementsMenu';
+import Advancements from '@/components/rhythmia/Advancements';
 import type { Piece, Board as BoardType } from '../types';
 import styles from '../VanillaGame.module.css';
 
@@ -218,7 +218,7 @@ export function Board({
                             )}
                         </>
                     ) : (
-                        <AdvancementsMenu onClose={() => setShowAdvancements(false)} />
+                        <Advancements embedded onClose={() => setShowAdvancements(false)} />
                     )}
                 </div>
             )}


### PR DESCRIPTION
## Summary
Refactored the Advancements component to support both fullscreen overlay and embedded panel modes, enabling reuse in the pause menu. This eliminates the need for a separate `AdvancementsMenu` component.

## Key Changes

- **Added `embedded` prop** to Advancements component to render as a simple panel without fullscreen overlay when `embedded={true}`
- **Extracted panel content** into a reusable `panelContent` variable to avoid duplication between fullscreen and embedded modes
- **Updated tab styling** for better space distribution:
  - Changed `flex-shrink: 0` to `flex: 1 1 0` to allow tabs to grow and shrink equally
  - Reduced horizontal padding from `8px 14px` to `8px 6px` (and `6px 10px` to `6px 4px` on mobile)
  - Added `min-width: 0` to prevent flex items from overflowing
- **Simplified animation** in embedded mode from `mode="wait"` with x-axis translation to `mode="popLayout"` with opacity-only transitions
- **Replaced AdvancementsMenu import** in Board.tsx with direct Advancements component using the new `embedded` prop

## Implementation Details

The component now conditionally renders based on the `embedded` prop:
- When `embedded={true}`: Returns a simple `<div className={styles.panel}>` wrapper with the panel content
- When `embedded={false}` (default): Returns the full motion-animated overlay with backdrop

This approach maintains backward compatibility while enabling the component to be embedded in other UI contexts like the pause menu.

https://claude.ai/code/session_01BexRZ6awuoFn2xJVzQ5gxt