### PR TITLE
Add Mix Mode: hybrid terrain destruction + tower defense gameplay

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,116 +1,307 @@
 {
-    "meta": {
-        "title": "RHYTHMIA | Rhythm x Tetris Fusion Puzzle Game - Azuretier",
-        "description": "Experience the ultimate fusion of music and puzzles! Play RHYTHMIA, the free browser-based rhythm Tetris game. Match the beat, clear blocks, and climb the leaderboard.",
-        "ogTitle": "RHYTHMIA - The Next-Gen Rhythm Puzzle Experience",
-        "ogDescription": "Can you keep the beat? Drop into RHYTHMIA, a high-energy blend of rhythm action and classic falling-block puzzles. Play free on Azuretier.",
-        "ogType": "website",
-        "keywords": "RHYTHMIA, Tetris, Rhythm Game, Music Puzzle, Free Online Game, Browser Game, Falling Block Puzzle, Arcade, Azuretier"
+  "meta": {
+    "title": "RHYTHMIA | Rhythm x Tetris Fusion Puzzle Game - Azuretier",
+    "description": "Experience the ultimate fusion of music and puzzles! Play RHYTHMIA, the free browser-based rhythm Tetris game. Match the beat, clear blocks, and climb the leaderboard.",
+    "ogTitle": "RHYTHMIA - The Next-Gen Rhythm Puzzle Experience",
+    "ogDescription": "Can you keep the beat? Drop into RHYTHMIA, a high-energy blend of rhythm action and classic falling-block puzzles. Play free on Azuretier.",
+    "ogType": "website",
+    "keywords": "RHYTHMIA, Tetris, Rhythm Game, Music Puzzle, Free Online Game, Browser Game, Falling Block Puzzle, Arcade, Azuretier"
+  },
+  "lobby": {
+    "loading": "LOADING",
+    "selectServer": "SELECT SERVER",
+    "chooseMode": "Choose your mode",
+    "play": "PLAY",
+    "battle": "BATTLE",
+    "back": "← Back",
+    "online": "Online",
+    "onlineCount": "{count} online"
+  },
+  "vanilla": {
+    "badge": "OFFICIAL",
+    "title": "VANILLA",
+    "gameTitle": "RHYTHMIA — VANILLA",
+    "subtitle": "Original Experience",
+    "description": "Classic RHYTHMIA gameplay. Stack blocks to the rhythm and conquer worlds.",
+    "features": {
+      "worlds": "5 Worlds",
+      "rhythm": "Rhythm",
+      "solo": "Solo"
     },
-    "lobby": {
-        "loading": "LOADING",
-        "selectServer": "SELECT SERVER",
-        "chooseMode": "Choose your mode",
-        "play": "PLAY",
-        "battle": "BATTLE",
-        "back": "← Back",
-        "online": "Online",
-        "onlineCount": "{count} online"
-    },
-    "vanilla": {
-        "badge": "OFFICIAL",
-        "title": "VANILLA",
-        "gameTitle": "RHYTHMIA — VANILLA",
-        "subtitle": "Original Experience",
-        "description": "Classic RHYTHMIA gameplay. Stack blocks to the rhythm and conquer worlds.",
-        "features": {
-            "worlds": "5 Worlds",
-            "rhythm": "Rhythm",
-            "solo": "Solo"
-        },
-        "stats": {
-            "bpmStart": "BPM Start",
-            "bpmMax": "BPM Max",
-            "levels": "Levels"
-        }
-    },
-    "multiplayer": {
-        "badge": "1v1",
-        "title": "BATTLE ARENA",
-        "gameTitle": "BATTLE ARENA — 1v1",
-        "subtitle": "Multiplayer 1v1",
-        "description": "Real-time 1v1 battles. Send garbage lines to your opponent. Last one standing wins.",
-        "features": {
-            "vs": "1v1",
-            "websocket": "WebSocket",
-            "ranked": "Ranked"
-        },
-        "stats": {
-            "mode": "Mode",
-            "battle": "Battle",
-            "status": "Status"
-        }
-    },
-    "advancements": {
-        "title": "ADVANCEMENTS",
-        "button": "{count}/{total} Advancements",
-        "unlocked": "ADVANCEMENT UNLOCKED",
-        "locked": "LOCKED",
-        "lockMessage": "{current}/{required} advancements to unlock",
-        "lines_10": { "name": "Line Beginner", "desc": "Clear 10 total lines" },
-        "lines_50": { "name": "Line Apprentice", "desc": "Clear 50 total lines" },
-        "lines_200": { "name": "Line Expert", "desc": "Clear 200 total lines" },
-        "lines_500": { "name": "Line Master", "desc": "Clear 500 total lines" },
-        "lines_1000": { "name": "Line Legend", "desc": "Clear 1,000 total lines" },
-        "best_lines_10": { "name": "Warm Up", "desc": "Clear 10 lines in one game" },
-        "best_lines_25": { "name": "Getting Started", "desc": "Clear 25 lines in one game" },
-        "best_lines_50": { "name": "Line Machine", "desc": "Clear 50 lines in one game" },
-        "best_lines_100": { "name": "Unstoppable", "desc": "Clear 100 lines in one game" },
-        "tspin_1": { "name": "First Twist", "desc": "Perform your first T-Spin" },
-        "tspin_10": { "name": "Spin Doctor", "desc": "Perform 10 T-Spins" },
-        "tspin_50": { "name": "T-Spin Expert", "desc": "Perform 50 T-Spins" },
-        "tspin_200": { "name": "T-Spin Legend", "desc": "Perform 200 T-Spins" },
-        "score_10k": { "name": "Score Rookie", "desc": "Accumulate 10,000 total score" },
-        "score_100k": { "name": "Score Hunter", "desc": "Accumulate 100,000 total score" },
-        "score_1m": { "name": "Score Master", "desc": "Accumulate 1,000,000 total score" },
-        "score_10m": { "name": "Score Legend", "desc": "Accumulate 10,000,000 total score" },
-        "best_score_5k": { "name": "Nice Game", "desc": "Score 5,000 in one game" },
-        "best_score_25k": { "name": "Great Game", "desc": "Score 25,000 in one game" },
-        "best_score_100k": { "name": "Amazing Game", "desc": "Score 100,000 in one game" },
-        "best_score_500k": { "name": "Legendary Game", "desc": "Score 500,000 in one game" },
-        "combo_3": { "name": "Combo Starter", "desc": "Reach a 3 combo" },
-        "combo_10": { "name": "Combo King", "desc": "Reach a 10 combo" },
-        "combo_20": { "name": "Combo God", "desc": "Reach a 20 combo" },
-        "games_1": { "name": "First Steps", "desc": "Play your first game" },
-        "games_10": { "name": "Getting Serious", "desc": "Play 10 games" },
-        "games_50": { "name": "Dedicated Player", "desc": "Play 50 games" },
-        "games_100": { "name": "Veteran", "desc": "Play 100 games" },
-        "worlds_5": { "name": "World Traveler", "desc": "Clear 5 worlds" },
-        "tetris_1": { "name": "Tetris!", "desc": "Clear 4 lines at once" },
-        "tetris_10": { "name": "Tetris Addict", "desc": "Clear 4 lines at once 10 times" },
-        "tetris_50": { "name": "Tetris Master", "desc": "Clear 4 lines at once 50 times" },
-        "perfect_beats_10": { "name": "Rhythm Rookie", "desc": "Hit 10 perfect beats in one game" },
-        "perfect_beats_50": { "name": "Rhythm Master", "desc": "Hit 50 perfect beats in one game" },
-        "hard_drops_100": { "name": "Speed Dropper", "desc": "Perform 100 hard drops" },
-        "hard_drops_1000": { "name": "Terminal Velocity", "desc": "Perform 1,000 hard drops" },
-        "pieces_100": { "name": "Block Builder", "desc": "Place 100 pieces" },
-        "pieces_1000": { "name": "Block Architect", "desc": "Place 1,000 pieces" },
-        "pieces_10000": { "name": "Block Legend", "desc": "Place 10,000 pieces" },
-        "mp_win_1": { "name": "First Victory", "desc": "Win your first multiplayer match" },
-        "mp_win_10": { "name": "Arena Fighter", "desc": "Win 10 multiplayer matches" },
-        "mp_win_50": { "name": "Arena Champion", "desc": "Win 50 multiplayer matches" },
-        "mp_streak_3": { "name": "Hot Streak", "desc": "Win 3 matches in a row" },
-        "mp_streak_5": { "name": "Domination", "desc": "Win 5 matches in a row" },
-        "mp_streak_10": { "name": "Unbreakable", "desc": "Win 10 matches in a row" },
-        "mp_games_10": { "name": "Arena Regular", "desc": "Play 10 multiplayer matches" },
-        "mp_games_50": { "name": "Arena Veteran", "desc": "Play 50 multiplayer matches" }
-    },
-    "footer": {
-        "copyright": "RHYTHMIA © 2025"
-    },
-    "localeSwitcher": {
-        "label": "Language",
-        "en": "English",
-        "ja": "日本語"
+    "stats": {
+      "bpmStart": "BPM Start",
+      "bpmMax": "BPM Max",
+      "levels": "Levels"
     }
+  },
+  "multiplayer": {
+    "badge": "1v1",
+    "title": "BATTLE ARENA",
+    "gameTitle": "BATTLE ARENA — 1v1",
+    "subtitle": "Multiplayer 1v1",
+    "description": "Real-time 1v1 battles. Send garbage lines to your opponent. Last one standing wins.",
+    "features": {
+      "vs": "1v1",
+      "websocket": "WebSocket",
+      "ranked": "Ranked"
+    },
+    "stats": {
+      "mode": "Mode",
+      "battle": "Battle",
+      "status": "Status"
+    }
+  },
+  "advancements": {
+    "title": "ADVANCEMENTS",
+    "button": "{count}/{total} Advancements",
+    "unlocked": "ADVANCEMENT UNLOCKED",
+    "locked": "LOCKED",
+    "lockMessage": "{current}/{required} advancements to unlock",
+    "lines_10": {
+      "name": "Line Beginner",
+      "desc": "Clear 10 total lines"
+    },
+    "lines_50": {
+      "name": "Line Apprentice",
+      "desc": "Clear 50 total lines"
+    },
+    "lines_200": {
+      "name": "Line Expert",
+      "desc": "Clear 200 total lines"
+    },
+    "lines_500": {
+      "name": "Line Master",
+      "desc": "Clear 500 total lines"
+    },
+    "lines_1000": {
+      "name": "Line Legend",
+      "desc": "Clear 1,000 total lines"
+    },
+    "best_lines_10": {
+      "name": "Warm Up",
+      "desc": "Clear 10 lines in one game"
+    },
+    "best_lines_25": {
+      "name": "Getting Started",
+      "desc": "Clear 25 lines in one game"
+    },
+    "best_lines_50": {
+      "name": "Line Machine",
+      "desc": "Clear 50 lines in one game"
+    },
+    "best_lines_100": {
+      "name": "Unstoppable",
+      "desc": "Clear 100 lines in one game"
+    },
+    "tspin_1": {
+      "name": "First Twist",
+      "desc": "Perform your first T-Spin"
+    },
+    "tspin_10": {
+      "name": "Spin Doctor",
+      "desc": "Perform 10 T-Spins"
+    },
+    "tspin_50": {
+      "name": "T-Spin Expert",
+      "desc": "Perform 50 T-Spins"
+    },
+    "tspin_200": {
+      "name": "T-Spin Legend",
+      "desc": "Perform 200 T-Spins"
+    },
+    "score_10k": {
+      "name": "Score Rookie",
+      "desc": "Accumulate 10,000 total score"
+    },
+    "score_100k": {
+      "name": "Score Hunter",
+      "desc": "Accumulate 100,000 total score"
+    },
+    "score_1m": {
+      "name": "Score Master",
+      "desc": "Accumulate 1,000,000 total score"
+    },
+    "score_10m": {
+      "name": "Score Legend",
+      "desc": "Accumulate 10,000,000 total score"
+    },
+    "best_score_5k": {
+      "name": "Nice Game",
+      "desc": "Score 5,000 in one game"
+    },
+    "best_score_25k": {
+      "name": "Great Game",
+      "desc": "Score 25,000 in one game"
+    },
+    "best_score_100k": {
+      "name": "Amazing Game",
+      "desc": "Score 100,000 in one game"
+    },
+    "best_score_500k": {
+      "name": "Legendary Game",
+      "desc": "Score 500,000 in one game"
+    },
+    "combo_3": {
+      "name": "Combo Starter",
+      "desc": "Reach a 3 combo"
+    },
+    "combo_10": {
+      "name": "Combo King",
+      "desc": "Reach a 10 combo"
+    },
+    "combo_20": {
+      "name": "Combo God",
+      "desc": "Reach a 20 combo"
+    },
+    "games_1": {
+      "name": "First Steps",
+      "desc": "Play your first game"
+    },
+    "games_10": {
+      "name": "Getting Serious",
+      "desc": "Play 10 games"
+    },
+    "games_50": {
+      "name": "Dedicated Player",
+      "desc": "Play 50 games"
+    },
+    "games_100": {
+      "name": "Veteran",
+      "desc": "Play 100 games"
+    },
+    "worlds_5": {
+      "name": "World Traveler",
+      "desc": "Clear 5 worlds"
+    },
+    "tetris_1": {
+      "name": "Tetris!",
+      "desc": "Clear 4 lines at once"
+    },
+    "tetris_10": {
+      "name": "Tetris Addict",
+      "desc": "Clear 4 lines at once 10 times"
+    },
+    "tetris_50": {
+      "name": "Tetris Master",
+      "desc": "Clear 4 lines at once 50 times"
+    },
+    "perfect_beats_10": {
+      "name": "Rhythm Rookie",
+      "desc": "Hit 10 perfect beats in one game"
+    },
+    "perfect_beats_50": {
+      "name": "Rhythm Master",
+      "desc": "Hit 50 perfect beats in one game"
+    },
+    "hard_drops_100": {
+      "name": "Speed Dropper",
+      "desc": "Perform 100 hard drops"
+    },
+    "hard_drops_1000": {
+      "name": "Terminal Velocity",
+      "desc": "Perform 1,000 hard drops"
+    },
+    "pieces_100": {
+      "name": "Block Builder",
+      "desc": "Place 100 pieces"
+    },
+    "pieces_1000": {
+      "name": "Block Architect",
+      "desc": "Place 1,000 pieces"
+    },
+    "pieces_10000": {
+      "name": "Block Legend",
+      "desc": "Place 10,000 pieces"
+    },
+    "mp_win_1": {
+      "name": "First Victory",
+      "desc": "Win your first multiplayer match"
+    },
+    "mp_win_10": {
+      "name": "Arena Fighter",
+      "desc": "Win 10 multiplayer matches"
+    },
+    "mp_win_50": {
+      "name": "Arena Champion",
+      "desc": "Win 50 multiplayer matches"
+    },
+    "mp_streak_3": {
+      "name": "Hot Streak",
+      "desc": "Win 3 matches in a row"
+    },
+    "mp_streak_5": {
+      "name": "Domination",
+      "desc": "Win 5 matches in a row"
+    },
+    "mp_streak_10": {
+      "name": "Unbreakable",
+      "desc": "Win 10 matches in a row"
+    },
+    "mp_games_10": {
+      "name": "Arena Regular",
+      "desc": "Play 10 multiplayer matches"
+    },
+    "mp_games_50": {
+      "name": "Arena Veteran",
+      "desc": "Play 50 multiplayer matches"
+    }
+  },
+  "arena": {
+    "title": "ARENA",
+    "subtitle": "9-PLAYER RHYTHM BATTLE",
+    "maxPlayers": "{count} Players Max",
+    "quickMatch": "QUICK MATCH",
+    "createArena": "Create Arena",
+    "joinByCode": "Join by Code",
+    "enterName": "Enter Your Name",
+    "namePlaceholder": "Player Name",
+    "enterCode": "Arena Code",
+    "join": "Join",
+    "next": "Next",
+    "back": "Back",
+    "online": "Online",
+    "connecting": "Connecting...",
+    "connectionError": "Connection Error",
+    "offline": "Offline",
+    "searching": "Searching for Players",
+    "queueInfo": "Waiting for enough players to form an arena...",
+    "playersInQueue": "{count} in queue",
+    "cancel": "Cancel",
+    "arenaCode": "Arena Code",
+    "copy": "Copy",
+    "reconnecting": "Reconnecting...",
+    "ready": "READY",
+    "notReady": "Not Ready",
+    "waiting": "Waiting...",
+    "cancelReady": "Cancel Ready",
+    "readyUp": "Ready!",
+    "startArena": "Start Arena",
+    "waitingForPlayers": "Waiting for players...",
+    "leave": "Leave",
+    "getReady": "GET READY",
+    "chaos": "CHAOS",
+    "sync": "Sync",
+    "eliminated": "eliminated",
+    "resultLastStanding": "LAST ONE STANDING",
+    "resultTempoCollapse": "TEMPO COLLAPSED",
+    "resultChaosOverload": "CHAOS OVERLOAD",
+    "victory": "VICTORY",
+    "wins": "WINS",
+    "noWinner": "NO WINNER",
+    "duration": "DURATION",
+    "peakBpm": "PEAK BPM",
+    "gimmicks": "GIMMICKS",
+    "peakChaos": "PEAK CHAOS",
+    "tempoCollapses": "COLLAPSES",
+    "lowestBpm": "LOW BPM",
+    "backToLobby": "Back to Lobby"
+  },
+  "footer": {
+    "copyright": "RHYTHMIA © 2025"
+  },
+  "localeSwitcher": {
+    "label": "Language",
+    "en": "English",
+    "ja": "日本語"
+  }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1,116 +1,307 @@
 {
-    "meta": {
-        "title": "RHYTHMIA | リズム×テトリスの新感覚パズルゲーム - Azuretier",
-        "description": "音楽とパズルが完全融合！RHYTHMIA（リズミア）は、リズムに合わせてブロックを消す新感覚の無料ブラウザゲームです。テトリスの戦略性と音ゲーの爽快感を今すぐ体験しよう。",
-        "ogTitle": "RHYTHMIA - 究極のリズムパズル体験をブラウザで",
-        "ogDescription": "【音ゲー×テトリス】音楽の鼓動でブロックを操れ。Azuretierが贈る全く新しい落ち物パズルゲーム、RHYTHMIAをプレイ。",
-        "ogType": "website",
-        "keywords": "RHYTHMIA,リズミア,テトリス,音ゲー,リズムゲーム,落ち物パズル,無料ゲーム,ブラウザゲーム,Azuretier"
+  "meta": {
+    "title": "RHYTHMIA | リズム×テトリスの新感覚パズルゲーム - Azuretier",
+    "description": "音楽とパズルが完全融合！RHYTHMIA（リズミア）は、リズムに合わせてブロックを消す新感覚の無料ブラウザゲームです。テトリスの戦略性と音ゲーの爽快感を今すぐ体験しよう。",
+    "ogTitle": "RHYTHMIA - 究極のリズムパズル体験をブラウザで",
+    "ogDescription": "【音ゲー×テトリス】音楽の鼓動でブロックを操れ。Azuretierが贈る全く新しい落ち物パズルゲーム、RHYTHMIAをプレイ。",
+    "ogType": "website",
+    "keywords": "RHYTHMIA,リズミア,テトリス,音ゲー,リズムゲーム,落ち物パズル,無料ゲーム,ブラウザゲーム,Azuretier"
+  },
+  "lobby": {
+    "loading": "読み込み中",
+    "selectServer": "サーバーを選択",
+    "chooseMode": "モードを選択してください",
+    "play": "プレイ",
+    "battle": "バトル",
+    "back": "← 戻る",
+    "online": "オンライン",
+    "onlineCount": "{count} オンライン"
+  },
+  "vanilla": {
+    "badge": "公式",
+    "title": "VANILLA",
+    "gameTitle": "RHYTHMIA — VANILLA",
+    "subtitle": "オリジナル体験",
+    "description": "クラシックなRHYTHMIAゲームプレイ。リズムに合わせてブロックを積み上げ、世界を制覇しよう。",
+    "features": {
+      "worlds": "5つの世界",
+      "rhythm": "リズム",
+      "solo": "ソロ"
     },
-    "lobby": {
-        "loading": "読み込み中",
-        "selectServer": "サーバーを選択",
-        "chooseMode": "モードを選択してください",
-        "play": "プレイ",
-        "battle": "バトル",
-        "back": "← 戻る",
-        "online": "オンライン",
-        "onlineCount": "{count} オンライン"
-    },
-    "vanilla": {
-        "badge": "公式",
-        "title": "VANILLA",
-        "gameTitle": "RHYTHMIA — VANILLA",
-        "subtitle": "オリジナル体験",
-        "description": "クラシックなRHYTHMIAゲームプレイ。リズムに合わせてブロックを積み上げ、世界を制覇しよう。",
-        "features": {
-            "worlds": "5つの世界",
-            "rhythm": "リズム",
-            "solo": "ソロ"
-        },
-        "stats": {
-            "bpmStart": "開始BPM",
-            "bpmMax": "最大BPM",
-            "levels": "レベル"
-        }
-    },
-    "multiplayer": {
-        "badge": "1v1",
-        "title": "BATTLE ARENA",
-        "gameTitle": "BATTLE ARENA — 1v1",
-        "subtitle": "マルチプレイヤー 1v1",
-        "description": "リアルタイム1v1バトル。相手にお邪魔ラインを送り込もう。最後まで立っていた者が勝利。",
-        "features": {
-            "vs": "1v1",
-            "websocket": "WebSocket",
-            "ranked": "ランク戦"
-        },
-        "stats": {
-            "mode": "モード",
-            "battle": "バトル",
-            "status": "状態"
-        }
-    },
-    "advancements": {
-        "title": "進捗",
-        "button": "{count}/{total} 進捗",
-        "unlocked": "進捗達成",
-        "locked": "ロック中",
-        "lockMessage": "解放まで {current}/{required} 進捗",
-        "lines_10": { "name": "ライン初心者", "desc": "合計10ライン消去" },
-        "lines_50": { "name": "ライン見習い", "desc": "合計50ライン消去" },
-        "lines_200": { "name": "ラインエキスパート", "desc": "合計200ライン消去" },
-        "lines_500": { "name": "ラインマスター", "desc": "合計500ライン消去" },
-        "lines_1000": { "name": "ラインレジェンド", "desc": "合計1,000ライン消去" },
-        "best_lines_10": { "name": "ウォームアップ", "desc": "1ゲームで10ライン消去" },
-        "best_lines_25": { "name": "スタート", "desc": "1ゲームで25ライン消去" },
-        "best_lines_50": { "name": "ラインマシン", "desc": "1ゲームで50ライン消去" },
-        "best_lines_100": { "name": "止まらない", "desc": "1ゲームで100ライン消去" },
-        "tspin_1": { "name": "初回転", "desc": "初めてのTスピンを決める" },
-        "tspin_10": { "name": "スピンドクター", "desc": "Tスピンを10回決める" },
-        "tspin_50": { "name": "Tスピンエキスパート", "desc": "Tスピンを50回決める" },
-        "tspin_200": { "name": "Tスピンレジェンド", "desc": "Tスピンを200回決める" },
-        "score_10k": { "name": "スコアルーキー", "desc": "累計スコア10,000達成" },
-        "score_100k": { "name": "スコアハンター", "desc": "累計スコア100,000達成" },
-        "score_1m": { "name": "スコアマスター", "desc": "累計スコア1,000,000達成" },
-        "score_10m": { "name": "スコアレジェンド", "desc": "累計スコア10,000,000達成" },
-        "best_score_5k": { "name": "ナイスゲーム", "desc": "1ゲームでスコア5,000達成" },
-        "best_score_25k": { "name": "グレートゲーム", "desc": "1ゲームでスコア25,000達成" },
-        "best_score_100k": { "name": "アメイジングゲーム", "desc": "1ゲームでスコア100,000達成" },
-        "best_score_500k": { "name": "レジェンダリーゲーム", "desc": "1ゲームでスコア500,000達成" },
-        "combo_3": { "name": "コンボスターター", "desc": "3コンボ達成" },
-        "combo_10": { "name": "コンボキング", "desc": "10コンボ達成" },
-        "combo_20": { "name": "コンボゴッド", "desc": "20コンボ達成" },
-        "games_1": { "name": "最初の一歩", "desc": "初めてのゲームをプレイ" },
-        "games_10": { "name": "本気モード", "desc": "10ゲームプレイ" },
-        "games_50": { "name": "献身的プレイヤー", "desc": "50ゲームプレイ" },
-        "games_100": { "name": "ベテラン", "desc": "100ゲームプレイ" },
-        "worlds_5": { "name": "世界旅行者", "desc": "5つの世界をクリア" },
-        "tetris_1": { "name": "テトリス！", "desc": "4ライン同時消去" },
-        "tetris_10": { "name": "テトリス中毒", "desc": "4ライン同時消去を10回" },
-        "tetris_50": { "name": "テトリスマスター", "desc": "4ライン同時消去を50回" },
-        "perfect_beats_10": { "name": "リズムルーキー", "desc": "1ゲームでパーフェクトビート10回" },
-        "perfect_beats_50": { "name": "リズムマスター", "desc": "1ゲームでパーフェクトビート50回" },
-        "hard_drops_100": { "name": "スピードドロッパー", "desc": "ハードドロップ100回" },
-        "hard_drops_1000": { "name": "ターミナルベロシティ", "desc": "ハードドロップ1,000回" },
-        "pieces_100": { "name": "ブロックビルダー", "desc": "100ピース設置" },
-        "pieces_1000": { "name": "ブロックアーキテクト", "desc": "1,000ピース設置" },
-        "pieces_10000": { "name": "ブロックレジェンド", "desc": "10,000ピース設置" },
-        "mp_win_1": { "name": "初勝利", "desc": "マルチプレイヤー初勝利" },
-        "mp_win_10": { "name": "アリーナファイター", "desc": "マルチプレイヤー10勝" },
-        "mp_win_50": { "name": "アリーナチャンピオン", "desc": "マルチプレイヤー50勝" },
-        "mp_streak_3": { "name": "ホットストリーク", "desc": "3連勝達成" },
-        "mp_streak_5": { "name": "ドミネーション", "desc": "5連勝達成" },
-        "mp_streak_10": { "name": "アンブレイカブル", "desc": "10連勝達成" },
-        "mp_games_10": { "name": "アリーナ常連", "desc": "マルチプレイヤー10戦" },
-        "mp_games_50": { "name": "アリーナベテラン", "desc": "マルチプレイヤー50戦" }
-    },
-    "footer": {
-        "copyright": "RHYTHMIA © 2025"
-    },
-    "localeSwitcher": {
-        "label": "言語",
-        "en": "English",
-        "ja": "日本語"
+    "stats": {
+      "bpmStart": "開始BPM",
+      "bpmMax": "最大BPM",
+      "levels": "レベル"
     }
+  },
+  "multiplayer": {
+    "badge": "1v1",
+    "title": "BATTLE ARENA",
+    "gameTitle": "BATTLE ARENA — 1v1",
+    "subtitle": "マルチプレイヤー 1v1",
+    "description": "リアルタイム1v1バトル。相手にお邪魔ラインを送り込もう。最後まで立っていた者が勝利。",
+    "features": {
+      "vs": "1v1",
+      "websocket": "WebSocket",
+      "ranked": "ランク戦"
+    },
+    "stats": {
+      "mode": "モード",
+      "battle": "バトル",
+      "status": "状態"
+    }
+  },
+  "advancements": {
+    "title": "進捗",
+    "button": "{count}/{total} 進捗",
+    "unlocked": "進捗達成",
+    "locked": "ロック中",
+    "lockMessage": "解放まで {current}/{required} 進捗",
+    "lines_10": {
+      "name": "ライン初心者",
+      "desc": "合計10ライン消去"
+    },
+    "lines_50": {
+      "name": "ライン見習い",
+      "desc": "合計50ライン消去"
+    },
+    "lines_200": {
+      "name": "ラインエキスパート",
+      "desc": "合計200ライン消去"
+    },
+    "lines_500": {
+      "name": "ラインマスター",
+      "desc": "合計500ライン消去"
+    },
+    "lines_1000": {
+      "name": "ラインレジェンド",
+      "desc": "合計1,000ライン消去"
+    },
+    "best_lines_10": {
+      "name": "ウォームアップ",
+      "desc": "1ゲームで10ライン消去"
+    },
+    "best_lines_25": {
+      "name": "スタート",
+      "desc": "1ゲームで25ライン消去"
+    },
+    "best_lines_50": {
+      "name": "ラインマシン",
+      "desc": "1ゲームで50ライン消去"
+    },
+    "best_lines_100": {
+      "name": "止まらない",
+      "desc": "1ゲームで100ライン消去"
+    },
+    "tspin_1": {
+      "name": "初回転",
+      "desc": "初めてのTスピンを決める"
+    },
+    "tspin_10": {
+      "name": "スピンドクター",
+      "desc": "Tスピンを10回決める"
+    },
+    "tspin_50": {
+      "name": "Tスピンエキスパート",
+      "desc": "Tスピンを50回決める"
+    },
+    "tspin_200": {
+      "name": "Tスピンレジェンド",
+      "desc": "Tスピンを200回決める"
+    },
+    "score_10k": {
+      "name": "スコアルーキー",
+      "desc": "累計スコア10,000達成"
+    },
+    "score_100k": {
+      "name": "スコアハンター",
+      "desc": "累計スコア100,000達成"
+    },
+    "score_1m": {
+      "name": "スコアマスター",
+      "desc": "累計スコア1,000,000達成"
+    },
+    "score_10m": {
+      "name": "スコアレジェンド",
+      "desc": "累計スコア10,000,000達成"
+    },
+    "best_score_5k": {
+      "name": "ナイスゲーム",
+      "desc": "1ゲームでスコア5,000達成"
+    },
+    "best_score_25k": {
+      "name": "グレートゲーム",
+      "desc": "1ゲームでスコア25,000達成"
+    },
+    "best_score_100k": {
+      "name": "アメイジングゲーム",
+      "desc": "1ゲームでスコア100,000達成"
+    },
+    "best_score_500k": {
+      "name": "レジェンダリーゲーム",
+      "desc": "1ゲームでスコア500,000達成"
+    },
+    "combo_3": {
+      "name": "コンボスターター",
+      "desc": "3コンボ達成"
+    },
+    "combo_10": {
+      "name": "コンボキング",
+      "desc": "10コンボ達成"
+    },
+    "combo_20": {
+      "name": "コンボゴッド",
+      "desc": "20コンボ達成"
+    },
+    "games_1": {
+      "name": "最初の一歩",
+      "desc": "初めてのゲームをプレイ"
+    },
+    "games_10": {
+      "name": "本気モード",
+      "desc": "10ゲームプレイ"
+    },
+    "games_50": {
+      "name": "献身的プレイヤー",
+      "desc": "50ゲームプレイ"
+    },
+    "games_100": {
+      "name": "ベテラン",
+      "desc": "100ゲームプレイ"
+    },
+    "worlds_5": {
+      "name": "世界旅行者",
+      "desc": "5つの世界をクリア"
+    },
+    "tetris_1": {
+      "name": "テトリス！",
+      "desc": "4ライン同時消去"
+    },
+    "tetris_10": {
+      "name": "テトリス中毒",
+      "desc": "4ライン同時消去を10回"
+    },
+    "tetris_50": {
+      "name": "テトリスマスター",
+      "desc": "4ライン同時消去を50回"
+    },
+    "perfect_beats_10": {
+      "name": "リズムルーキー",
+      "desc": "1ゲームでパーフェクトビート10回"
+    },
+    "perfect_beats_50": {
+      "name": "リズムマスター",
+      "desc": "1ゲームでパーフェクトビート50回"
+    },
+    "hard_drops_100": {
+      "name": "スピードドロッパー",
+      "desc": "ハードドロップ100回"
+    },
+    "hard_drops_1000": {
+      "name": "ターミナルベロシティ",
+      "desc": "ハードドロップ1,000回"
+    },
+    "pieces_100": {
+      "name": "ブロックビルダー",
+      "desc": "100ピース設置"
+    },
+    "pieces_1000": {
+      "name": "ブロックアーキテクト",
+      "desc": "1,000ピース設置"
+    },
+    "pieces_10000": {
+      "name": "ブロックレジェンド",
+      "desc": "10,000ピース設置"
+    },
+    "mp_win_1": {
+      "name": "初勝利",
+      "desc": "マルチプレイヤー初勝利"
+    },
+    "mp_win_10": {
+      "name": "アリーナファイター",
+      "desc": "マルチプレイヤー10勝"
+    },
+    "mp_win_50": {
+      "name": "アリーナチャンピオン",
+      "desc": "マルチプレイヤー50勝"
+    },
+    "mp_streak_3": {
+      "name": "ホットストリーク",
+      "desc": "3連勝達成"
+    },
+    "mp_streak_5": {
+      "name": "ドミネーション",
+      "desc": "5連勝達成"
+    },
+    "mp_streak_10": {
+      "name": "アンブレイカブル",
+      "desc": "10連勝達成"
+    },
+    "mp_games_10": {
+      "name": "アリーナ常連",
+      "desc": "マルチプレイヤー10戦"
+    },
+    "mp_games_50": {
+      "name": "アリーナベテラン",
+      "desc": "マルチプレイヤー50戦"
+    }
+  },
+  "arena": {
+    "title": "ARENA",
+    "subtitle": "9人リズムバトル",
+    "maxPlayers": "最大{count}人",
+    "quickMatch": "クイックマッチ",
+    "createArena": "アリーナ作成",
+    "joinByCode": "コードで参加",
+    "enterName": "名前を入力",
+    "namePlaceholder": "プレイヤー名",
+    "enterCode": "アリーナコード",
+    "join": "参加",
+    "next": "次へ",
+    "back": "戻る",
+    "online": "オンライン",
+    "connecting": "接続中...",
+    "connectionError": "接続エラー",
+    "offline": "オフライン",
+    "searching": "プレイヤー検索中",
+    "queueInfo": "アリーナを形成するプレイヤーを待っています...",
+    "playersInQueue": "待機中 {count}人",
+    "cancel": "キャンセル",
+    "arenaCode": "アリーナコード",
+    "copy": "コピー",
+    "reconnecting": "再接続中...",
+    "ready": "準備完了",
+    "notReady": "未準備",
+    "waiting": "待機中...",
+    "cancelReady": "準備解除",
+    "readyUp": "準備完了！",
+    "startArena": "アリーナ開始",
+    "waitingForPlayers": "プレイヤーを待っています...",
+    "leave": "退出",
+    "getReady": "準備せよ",
+    "chaos": "カオス",
+    "sync": "同期",
+    "eliminated": "脱落",
+    "resultLastStanding": "最後の一人",
+    "resultTempoCollapse": "テンポ崩壊",
+    "resultChaosOverload": "カオス暴走",
+    "victory": "勝利",
+    "wins": "勝利",
+    "noWinner": "勝者なし",
+    "duration": "時間",
+    "peakBpm": "最高BPM",
+    "gimmicks": "ギミック",
+    "peakChaos": "最大カオス",
+    "tempoCollapses": "崩壊回数",
+    "lowestBpm": "最低BPM",
+    "backToLobby": "ロビーに戻る"
+  },
+  "footer": {
+    "copyright": "RHYTHMIA © 2025"
+  },
+  "localeSwitcher": {
+    "label": "言語",
+    "en": "English",
+    "ja": "日本語"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,6 +130,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -767,6 +768,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.7.tgz",
       "integrity": "sha512-o3ZfnOx0AWBD5n/36p2zPoB0rDDxQP8H/A60zDLvvfRLtW8b3LfCyV97GKpJaAVV1JMMl/BC89EDzMyzxFZxTw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -833,6 +835,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.7.tgz",
       "integrity": "sha512-MO+jfap8IBZQ+K8L2QCiHObyMgpYHrxo4Hc7iJgfb9hjGRW/z1y6LWVdT9wBBK+VJ7cRP2DjAiWQP+thu53hHA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.7",
         "@firebase/component": "0.7.0",
@@ -848,7 +851,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth-compat": {
       "version": "0.6.2",
@@ -1299,6 +1303,7 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2086,7 +2091,6 @@
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -4735,7 +4739,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -4747,7 +4750,6 @@
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -4838,6 +4840,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4867,6 +4870,7 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4878,6 +4882,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -5016,6 +5021,7 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -5525,7 +5531,6 @@
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -5536,24 +5541,21 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
@@ -5561,7 +5563,6 @@
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -5573,8 +5574,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
@@ -5582,7 +5582,6 @@
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -5596,7 +5595,6 @@
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -5607,7 +5605,6 @@
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -5617,8 +5614,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
@@ -5626,7 +5622,6 @@
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -5644,7 +5639,6 @@
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -5659,7 +5653,6 @@
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -5673,7 +5666,6 @@
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -5689,7 +5681,6 @@
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -5707,16 +5698,14 @@
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -5750,6 +5739,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5763,7 +5753,6 @@
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -5809,6 +5798,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5826,7 +5816,6 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -5845,7 +5834,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5862,8 +5850,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -6316,6 +6303,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6341,8 +6329,7 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/bufferutil": {
       "version": "4.1.0",
@@ -6350,6 +6337,7 @@
       "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -6508,7 +6496,6 @@
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -7114,7 +7101,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -7255,7 +7243,6 @@
       "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.3.0"
@@ -7386,8 +7373,7 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -7477,6 +7463,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7662,6 +7649,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7943,7 +7931,6 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -8035,8 +8022,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
       "version": "4.5.3",
@@ -8536,8 +8522,7 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/globals": {
       "version": "14.0.0",
@@ -8684,8 +8669,7 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/gtoken": {
       "version": "7.1.0",
@@ -9470,7 +9454,6 @@
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -9486,7 +9469,6 @@
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -9503,6 +9485,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -9569,8 +9552,7 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -9762,7 +9744,6 @@
       "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -9980,8 +9961,7 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -10162,14 +10142,14 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/next": {
       "version": "16.1.5",
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.5.tgz",
       "integrity": "sha512-f+wE+NSbiQgh3DSAlTaw2FwY5yGdVViAtp8TotNQj4kk4Q8Bh1sC/aL9aH+Rg1YAVn18OYXsRDT7U/079jgP7w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.1.5",
         "@swc/helpers": "0.5.15",
@@ -10292,17 +10272,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
-      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/next-intl/node_modules/negotiator": {
@@ -10772,6 +10741,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11009,7 +10979,6 @@
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -11040,6 +11009,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11083,6 +11053,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11367,7 +11338,6 @@
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11590,7 +11560,6 @@
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -11894,7 +11863,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11914,7 +11882,6 @@
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -12312,7 +12279,6 @@
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -12385,7 +12351,6 @@
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -12405,7 +12370,6 @@
       "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
@@ -12459,7 +12423,6 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -12472,8 +12435,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
       "version": "4.3.3",
@@ -12481,7 +12443,6 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -12501,8 +12462,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -12586,6 +12546,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12806,6 +12767,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13027,6 +12989,7 @@
       "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -13111,7 +13074,6 @@
       "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -13138,7 +13100,6 @@
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -13188,7 +13149,6 @@
       "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -13217,7 +13177,6 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -13231,7 +13190,6 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -13246,7 +13204,6 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -13256,8 +13213,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/webpack/node_modules/schema-utils": {
       "version": "4.3.3",
@@ -13265,7 +13221,6 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -13563,6 +13518,7 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://azuretier.net/blog</loc><lastmod>2026-02-10T04:30:19.794Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/shader-demo</loc><lastmod>2026-02-10T04:30:19.795Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/sns-widgets</loc><lastmod>2026-02-10T04:30:19.795Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/sunphase</loc><lastmod>2026-02-10T04:30:19.795Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/blog</loc><lastmod>2026-02-11T03:36:33.784Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/shader-demo</loc><lastmod>2026-02-11T03:36:33.784Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sns-widgets</loc><lastmod>2026-02-11T03:36:33.784Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sunphase</loc><lastmod>2026-02-11T03:36:33.784Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/[locale]/arena/page.tsx
+++ b/src/app/[locale]/arena/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import ArenaGame from '@/components/arena/ArenaGame';
+
+export default function ArenaPage() {
+  return <ArenaGame />;
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -13,6 +13,7 @@ import MultiplayerGame from '../../components/rhythmia/MultiplayerGame';
 import Advancements from '../../components/rhythmia/Advancements';
 import { FaDiscord } from 'react-icons/fa';
 import LocaleSwitcher from '../../components/LocaleSwitcher';
+import { useRouter } from '@/i18n/navigation';
 
 type GameMode = 'lobby' | 'vanilla' | 'multiplayer';
 
@@ -25,6 +26,7 @@ export default function RhythmiaPage() {
     const wsRef = useRef<WebSocket | null>(null);
 
     const t = useTranslations();
+    const router = useRouter();
 
     const isArenaLocked = unlockedCount < BATTLE_ARENA_REQUIRED_ADVANCEMENTS;
 
@@ -218,29 +220,6 @@ export default function RhythmiaPage() {
                         >
                             <span className={styles.cardBadge}>{t('vanilla.badge')}</span>
                             <h2 className={styles.cardTitle}>{t('vanilla.title')}</h2>
-                            <p className={styles.cardSubtitle}>{t('vanilla.subtitle')}</p>
-                            <p className={styles.cardDescription}>
-                                {t('vanilla.description')}
-                            </p>
-                            <div className={styles.cardFeatures}>
-                                <span className={styles.featureTag}>{t('vanilla.features.worlds')}</span>
-                                <span className={styles.featureTag}>{t('vanilla.features.rhythm')}</span>
-                                <span className={styles.featureTag}>{t('vanilla.features.solo')}</span>
-                            </div>
-                            <div className={styles.cardStats}>
-                                <div className={styles.stat}>
-                                    <div className={styles.statValue}>100</div>
-                                    <div className={styles.statLabel}>{t('vanilla.stats.bpmStart')}</div>
-                                </div>
-                                <div className={styles.stat}>
-                                    <div className={styles.statValue}>160</div>
-                                    <div className={styles.statLabel}>{t('vanilla.stats.bpmMax')}</div>
-                                </div>
-                                <div className={styles.stat}>
-                                    <div className={styles.statValue}>∞</div>
-                                    <div className={styles.statLabel}>{t('vanilla.stats.levels')}</div>
-                                </div>
-                            </div>
                             <button className={styles.playButton}>{t('lobby.play')}</button>
                         </motion.div>
 
@@ -295,6 +274,43 @@ export default function RhythmiaPage() {
                             <button className={`${styles.playButton} ${isArenaLocked ? styles.lockedButton : ''}`} disabled={isArenaLocked}>
                                 {isArenaLocked ? t('advancements.locked') : t('lobby.battle')}
                             </button>
+                        </motion.div>
+
+                        {/* 9-Player Arena */}
+                        <motion.div
+                            className={`${styles.serverCard} ${styles.multiplayer}`}
+                            onClick={() => router.push('/arena')}
+                            initial={{ opacity: 0, y: 40 }}
+                            animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? 40 : 0 }}
+                            transition={{ duration: 0.6, delay: 0.6 }}
+                            whileHover={{ y: -8, transition: { duration: 0.25 } }}
+                        >
+                            <span className={`${styles.cardBadge} ${styles.new}`}>9P</span>
+                            <h2 className={styles.cardTitle}>{t('arena.title')}</h2>
+                            <p className={styles.cardSubtitle}>{t('arena.subtitle')}</p>
+                            <p className={styles.cardDescription}>
+                                9 players, 1 rhythm. Shared chaos, synced tempo, random gimmicks. Stay on beat or the tempo collapses.
+                            </p>
+                            <div className={styles.cardFeatures}>
+                                <span className={styles.featureTag}>9 Players</span>
+                                <span className={styles.featureTag}>Chaos</span>
+                                <span className={styles.featureTag}>Rhythm Sync</span>
+                            </div>
+                            <div className={styles.cardStats}>
+                                <div className={styles.stat}>
+                                    <div className={styles.statValue}>9</div>
+                                    <div className={styles.statLabel}>Players</div>
+                                </div>
+                                <div className={styles.stat}>
+                                    <div className={styles.statValue}>120+</div>
+                                    <div className={styles.statLabel}>BPM</div>
+                                </div>
+                                <div className={styles.stat}>
+                                    <div className={styles.statValue}>LIVE</div>
+                                    <div className={styles.statLabel}>Status</div>
+                                </div>
+                            </div>
+                            <button className={styles.playButton}>{t('arena.quickMatch')}</button>
                         </motion.div>
                     </div>
                 </main>

--- a/src/components/arena/ArenaGame.module.css
+++ b/src/components/arena/ArenaGame.module.css
@@ -1,0 +1,803 @@
+:root {
+  --arena-accent: #00ffcc;
+  --arena-accent-dim: rgba(0, 255, 204, 0.15);
+  --arena-danger: #ff3366;
+  --arena-warning: #ffaa00;
+}
+
+.container {
+  min-height: 100vh;
+  font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
+  background: #000000;
+  color: white;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Status Bar */
+.statusBar {
+  padding: 8px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.connectionStatus {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.4);
+  letter-spacing: 0.05em;
+}
+
+.statusDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.3);
+  transition: background 0.3s;
+}
+
+.connected { background: var(--arena-accent); box-shadow: 0 0 6px var(--arena-accent-dim); }
+.connecting { background: var(--arena-warning); animation: blink 1s infinite; }
+.error, .disconnected { background: rgba(255, 255, 255, 0.2); }
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.tempoDisplay {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.5);
+  letter-spacing: 0.1em;
+}
+
+.bpmValue {
+  font-size: 1rem;
+  font-weight: 300;
+  color: var(--arena-accent);
+  font-variant-numeric: tabular-nums;
+  min-width: 48px;
+  text-align: right;
+}
+
+/* Error Banner */
+.errorBanner {
+  margin: 0 16px;
+  padding: 8px 14px;
+  background: rgba(255, 51, 102, 0.08);
+  border: 1px solid rgba(255, 51, 102, 0.2);
+  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.75rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  animation: fadeIn 0.3s ease-out;
+}
+
+.errorClose {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  padding: 4px 8px;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Lobby */
+.lobby {
+  height: calc(100vh - 50px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 28px;
+  padding: 20px;
+}
+
+.title {
+  font-size: clamp(1.8rem, 7vw, 3rem);
+  font-weight: 200;
+  letter-spacing: 0.3em;
+  color: var(--arena-accent);
+  text-shadow: 0 0 30px rgba(0, 255, 204, 0.2);
+}
+
+.subtitle {
+  color: rgba(255, 255, 255, 0.3);
+  font-size: 0.75rem;
+  letter-spacing: 0.25em;
+  font-weight: 400;
+}
+
+.playerCount {
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.25);
+  letter-spacing: 0.1em;
+}
+
+.lobbyActions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  max-width: 320px;
+}
+
+.primaryBtn {
+  padding: 14px 32px;
+  font-family: inherit;
+  font-size: 0.8rem;
+  font-weight: 500;
+  background: var(--arena-accent);
+  border: none;
+  border-radius: 8px;
+  color: #000000;
+  cursor: pointer;
+  letter-spacing: 0.2em;
+  transition: all 0.25s;
+  text-align: center;
+}
+
+.primaryBtn:hover:not(:disabled) {
+  background: rgba(0, 255, 204, 0.85);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 20px rgba(0, 255, 204, 0.2);
+}
+
+.primaryBtn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.secondaryBtn {
+  padding: 12px 24px;
+  font-family: inherit;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.6);
+  cursor: pointer;
+  transition: all 0.25s;
+  letter-spacing: 0.1em;
+  text-align: center;
+}
+
+.secondaryBtn:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.2);
+  color: #ffffff;
+}
+
+/* Name Entry */
+.nameEntry {
+  height: calc(100vh - 50px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+}
+
+.sectionTitle {
+  font-size: 1.3rem;
+  font-weight: 300;
+  color: #ffffff;
+  letter-spacing: 0.2em;
+  margin-bottom: 8px;
+}
+
+.nameInput {
+  padding: 12px 24px;
+  font-family: inherit;
+  font-size: 1rem;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  color: white;
+  width: 260px;
+  transition: border-color 0.3s;
+  letter-spacing: 0.05em;
+}
+
+.nameInput:focus {
+  outline: none;
+  border-color: var(--arena-accent);
+}
+
+/* Queue Screen */
+.queueScreen {
+  height: calc(100vh - 50px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+}
+
+.queuePulse {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: 2px solid var(--arena-accent);
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.3); opacity: 0.3; }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+.queueInfo {
+  text-align: center;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+}
+
+.queueCount {
+  font-size: 1.2rem;
+  font-weight: 300;
+  color: var(--arena-accent);
+  margin-top: 8px;
+}
+
+/* Waiting Room */
+.waitingRoom {
+  height: calc(100vh - 50px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  padding: 20px;
+}
+
+.arenaCode {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 18px;
+  background: rgba(0, 255, 204, 0.03);
+  border: 1px solid rgba(0, 255, 204, 0.12);
+  border-radius: 8px;
+}
+
+.arenaCodeLabel {
+  font-size: 0.6rem;
+  color: rgba(255, 255, 255, 0.3);
+  letter-spacing: 0.15em;
+}
+
+.arenaCodeValue {
+  font-size: 1.4rem;
+  font-weight: 400;
+  letter-spacing: 0.3em;
+  color: var(--arena-accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.copyBtn {
+  padding: 5px 10px;
+  font-size: 0.65rem;
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  color: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.copyBtn:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
+}
+
+/* 9-Player Grid */
+.playersGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  width: 100%;
+  max-width: 460px;
+}
+
+.playerSlot {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 12px 10px;
+  text-align: center;
+  transition: all 0.3s;
+  min-height: 56px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.playerSlot.ready {
+  border-color: var(--arena-accent);
+  background: rgba(0, 255, 204, 0.03);
+}
+
+.playerSlot.host {
+  border-color: rgba(0, 255, 204, 0.4);
+}
+
+.playerSlot.empty {
+  border-style: dashed;
+  opacity: 0.2;
+}
+
+.playerSlot.eliminated {
+  opacity: 0.3;
+  border-color: rgba(255, 51, 102, 0.3);
+}
+
+.playerSlotName {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+
+.hostBadge {
+  font-size: 0.5rem;
+  padding: 1px 5px;
+  background: var(--arena-accent-dim);
+  color: var(--arena-accent);
+  border-radius: 4px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.playerSlotStatus {
+  font-size: 0.6rem;
+  color: rgba(255, 255, 255, 0.3);
+  margin-top: 3px;
+}
+
+.waitingActions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* Countdown */
+.countdownScreen {
+  height: calc(100vh - 50px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.countdownNumber {
+  font-size: clamp(6rem, 25vw, 12rem);
+  font-weight: 200;
+  color: var(--arena-accent);
+  animation: countdownPop 0.5s ease-out;
+  text-shadow: 0 0 40px rgba(0, 255, 204, 0.3);
+}
+
+@keyframes countdownPop {
+  from { transform: scale(2); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+.countdownLabel {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.4);
+  letter-spacing: 0.3em;
+}
+
+/* ===== Playing Phase ===== */
+.arenaPlayfield {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 50px);
+  overflow: hidden;
+}
+
+/* HUD Bar */
+.hudBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px;
+  gap: 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  flex-shrink: 0;
+}
+
+.chaosBar {
+  flex: 1;
+  max-width: 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.chaosLabel {
+  font-size: 0.55rem;
+  color: rgba(255, 255, 255, 0.35);
+  letter-spacing: 0.15em;
+  display: flex;
+  justify-content: space-between;
+}
+
+.chaosTrack {
+  height: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.chaosFill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.3s, background 0.3s;
+}
+
+.chaosLow { background: var(--arena-accent); }
+.chaosMedium { background: var(--arena-warning); }
+.chaosHigh { background: var(--arena-danger); }
+
+.gimmickBanner {
+  padding: 4px 12px;
+  background: rgba(255, 170, 0, 0.1);
+  border: 1px solid rgba(255, 170, 0, 0.2);
+  border-radius: 4px;
+  font-size: 0.65rem;
+  color: var(--arena-warning);
+  letter-spacing: 0.1em;
+  animation: gimmickFlash 0.5s ease-out;
+}
+
+@keyframes gimmickFlash {
+  from { opacity: 0; transform: scale(1.1); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+.beatIndicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 255, 204, 0.3);
+  transition: all 0.1s;
+}
+
+.beatIndicator.onBeat {
+  background: var(--arena-accent);
+  box-shadow: 0 0 8px var(--arena-accent);
+  transform: scale(1.2);
+}
+
+.syncValue {
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.4);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Main Arena Content */
+.arenaContent {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+/* Player's own board area */
+.myBoardArea {
+  flex: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  position: relative;
+}
+
+.myBoard {
+  position: relative;
+  border: 1px solid rgba(0, 255, 204, 0.15);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.boardRow {
+  display: flex;
+}
+
+.boardCell {
+  width: var(--cell-size, 24px);
+  height: var(--cell-size, 24px);
+  border: 1px solid rgba(255, 255, 255, 0.03);
+  box-sizing: border-box;
+}
+
+.boardCell.filled {
+  border-color: rgba(0, 0, 0, 0.2);
+}
+
+/* Opponents sidebar */
+.opponentsSidebar {
+  flex: 3;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px;
+  padding: 8px;
+  overflow-y: auto;
+  align-content: start;
+}
+
+.opponentMini {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+}
+
+.opponentMini.eliminated {
+  opacity: 0.25;
+  border-color: rgba(255, 51, 102, 0.2);
+}
+
+.opponentName {
+  font-size: 0.55rem;
+  color: rgba(255, 255, 255, 0.5);
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.opponentMiniBoard {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 2px;
+}
+
+.miniRow {
+  display: flex;
+}
+
+.miniCell {
+  width: 4px;
+  height: 4px;
+}
+
+.miniCell.filled {
+  opacity: 0.8;
+}
+
+.opponentStats {
+  display: flex;
+  gap: 6px;
+  font-size: 0.5rem;
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.opponentSync {
+  width: 100%;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1px;
+  overflow: hidden;
+}
+
+.opponentSyncFill {
+  height: 100%;
+  background: var(--arena-accent);
+  transition: width 0.3s;
+}
+
+/* Tempo Collapse Overlay */
+.tempoCollapseOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(255, 0, 0, 0.05);
+  pointer-events: none;
+  animation: collapseFlash 1s ease-out forwards;
+  z-index: 50;
+}
+
+@keyframes collapseFlash {
+  0% { background: rgba(255, 0, 0, 0.15); }
+  100% { background: transparent; }
+}
+
+/* Elimination Banner */
+.eliminationBanner {
+  position: fixed;
+  top: 60px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 8px 20px;
+  background: rgba(255, 51, 102, 0.1);
+  border: 1px solid rgba(255, 51, 102, 0.2);
+  border-radius: 6px;
+  font-size: 0.75rem;
+  color: var(--arena-danger);
+  letter-spacing: 0.1em;
+  animation: fadeIn 0.3s ease-out;
+  z-index: 40;
+}
+
+/* Results Screen */
+.resultsScreen {
+  height: calc(100vh - 50px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  padding: 20px;
+}
+
+.resultReason {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.3);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.resultTitle {
+  font-size: clamp(2rem, 8vw, 3.5rem);
+  font-weight: 200;
+  color: var(--arena-accent);
+  letter-spacing: 0.2em;
+  text-shadow: 0 0 30px rgba(0, 255, 204, 0.2);
+}
+
+.resultTitle.defeat {
+  color: rgba(255, 255, 255, 0.5);
+  text-shadow: none;
+}
+
+.rankingsTable {
+  width: 100%;
+  max-width: 500px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.rankingRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 14px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 6px;
+  font-size: 0.75rem;
+}
+
+.rankingRow.isMe {
+  border-color: var(--arena-accent);
+  background: rgba(0, 255, 204, 0.03);
+}
+
+.rankingRow.first {
+  border-color: rgba(255, 215, 0, 0.3);
+  background: rgba(255, 215, 0, 0.03);
+}
+
+.rankingPlace {
+  font-size: 0.85rem;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.5);
+  min-width: 24px;
+  text-align: center;
+}
+
+.rankingName {
+  flex: 1;
+  color: #ffffff;
+  font-weight: 500;
+}
+
+.rankingStat {
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 0.65rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.statsGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  width: 100%;
+  max-width: 400px;
+}
+
+.statItem {
+  text-align: center;
+}
+
+.statValue {
+  font-size: 1.2rem;
+  font-weight: 300;
+  color: var(--arena-accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.statLabel {
+  font-size: 0.55rem;
+  color: rgba(255, 255, 255, 0.3);
+  letter-spacing: 0.1em;
+  margin-top: 2px;
+}
+
+.resultActions {
+  display: flex;
+  gap: 12px;
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .opponentsSidebar {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  .arenaContent {
+    flex-direction: column;
+  }
+
+  .myBoardArea {
+    flex: 1;
+  }
+
+  .opponentsSidebar {
+    flex: none;
+    max-height: 30vh;
+  }
+
+  .miniCell {
+    width: 3px;
+    height: 3px;
+  }
+
+  .playersGrid {
+    grid-template-columns: repeat(3, 1fr);
+    max-width: 320px;
+  }
+}
+
+@media (max-width: 480px) {
+  .title {
+    font-size: 1.5rem;
+  }
+
+  .statsGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/src/components/arena/ArenaGame.tsx
+++ b/src/components/arena/ArenaGame.tsx
@@ -1,0 +1,575 @@
+'use client';
+
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import { useArenaSocket } from '@/hooks/useArenaSocket';
+import { useTranslations } from 'next-intl';
+import type { ArenaGimmick, ArenaBoardPayload } from '@/types/arena';
+import { ARENA_MAX_PLAYERS, GIMMICK_DURATIONS } from '@/types/arena';
+import styles from './ArenaGame.module.css';
+
+const GIMMICK_LABELS: Record<string, string> = {
+  tempo_shift: 'TEMPO SHIFT',
+  gravity_surge: 'GRAVITY SURGE',
+  mirror_mode: 'MIRROR MODE',
+  garbage_rain: 'GARBAGE RAIN',
+  blackout: 'BLACKOUT',
+  speed_frenzy: 'SPEED FRENZY',
+  freeze_frame: 'FREEZE',
+  shuffle_preview: 'SHUFFLE',
+};
+
+// Mini board renderer for opponent preview
+function MiniBoardView({ board }: { board: (null | { color: string })[][] }) {
+  // Only show bottom 16 rows for mini preview
+  const visibleRows = board.slice(Math.max(0, board.length - 16));
+
+  return (
+    <div className={styles.opponentMiniBoard}>
+      {visibleRows.map((row, ri) => (
+        <div key={ri} className={styles.miniRow}>
+          {row.map((cell, ci) => (
+            <div
+              key={ci}
+              className={`${styles.miniCell} ${cell ? styles.filled : ''}`}
+              style={cell ? { background: cell.color } : undefined}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function ArenaGame() {
+  const t = useTranslations('arena');
+  const {
+    connectionStatus,
+    connectWebSocket,
+    playerId,
+    phase,
+    setPhase,
+    arenaState,
+    error,
+    setError,
+    countdownNumber,
+    gameSeed,
+    queuePosition,
+    queueSize,
+    bpm,
+    beatPhase,
+    chaosLevel,
+    activeGimmick,
+    syncMap,
+    lastPlayerAction,
+    lastElimination,
+    lastTempoCollapse,
+    sessionResult,
+    opponentBoards,
+    queueForArena,
+    cancelQueue,
+    createArena,
+    joinArena,
+    setReady,
+    startArena,
+    sendAction,
+    sendBoardRelay,
+    leaveArena,
+  } = useArenaSocket();
+
+  const [playerName, setPlayerName] = useState('');
+  const [joinCode, setJoinCode] = useState('');
+  const [showElimBanner, setShowElimBanner] = useState(false);
+  const [showCollapse, setShowCollapse] = useState(false);
+  const elimTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const collapseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Beat indicator
+  const onBeat = beatPhase > 0.75 || beatPhase < 0.15;
+
+  // My sync accuracy
+  const mySync = syncMap[playerId] ?? 1.0;
+
+  // Chaos bar class
+  const chaosClass = chaosLevel >= 75 ? styles.chaosHigh
+    : chaosLevel >= 40 ? styles.chaosMedium : styles.chaosLow;
+
+  // Show elimination banner briefly
+  useEffect(() => {
+    if (lastElimination) {
+      setShowElimBanner(true);
+      if (elimTimerRef.current) clearTimeout(elimTimerRef.current);
+      elimTimerRef.current = setTimeout(() => setShowElimBanner(false), 3000);
+    }
+    return () => { if (elimTimerRef.current) clearTimeout(elimTimerRef.current); };
+  }, [lastElimination]);
+
+  // Show tempo collapse flash
+  useEffect(() => {
+    if (lastTempoCollapse) {
+      setShowCollapse(true);
+      if (collapseTimerRef.current) clearTimeout(collapseTimerRef.current);
+      collapseTimerRef.current = setTimeout(() => setShowCollapse(false), 1000);
+    }
+    return () => { if (collapseTimerRef.current) clearTimeout(collapseTimerRef.current); };
+  }, [lastTempoCollapse]);
+
+  // ===== Derived state =====
+  const isHost = arenaState?.hostId === playerId;
+  const myPlayer = arenaState?.players.find(p => p.id === playerId);
+  const opponents = useMemo(
+    () => arenaState?.players.filter(p => p.id !== playerId) || [],
+    [arenaState, playerId],
+  );
+  const allReady = arenaState?.players.every(p => p.ready || p.id === arenaState.hostId)
+    && (arenaState?.players.length ?? 0) >= 3;
+
+  // ===== Handlers =====
+  const handleNameSubmit = useCallback(() => {
+    if (playerName.trim().length < 2) return;
+    const next = sessionStorage.getItem('arena_nextMode');
+    sessionStorage.removeItem('arena_nextMode');
+    if (next === 'queue') {
+      queueForArena(playerName.trim());
+    } else if (next === 'create') {
+      createArena(playerName.trim());
+    } else {
+      // Default: go to queue
+      queueForArena(playerName.trim());
+    }
+  }, [playerName, queueForArena, createArena]);
+
+  const handleJoinByCode = useCallback(() => {
+    const code = joinCode.trim().toUpperCase();
+    if (code.length < 4) {
+      setError('Enter a valid arena code');
+      return;
+    }
+    joinArena(code, playerName.trim());
+  }, [joinCode, joinArena, playerName, setError]);
+
+  // ===== Simulated board for demo (the actual game engine would plug in here) =====
+  // In a full implementation, this would use the tetris engine from components/rhythmia/tetris
+  // For now, we render the arena structure and opponent boards from relayed data
+
+  // Empty 10x20 board for display
+  const emptyBoard = useMemo(() => {
+    const board: (null | { color: string })[][] = [];
+    for (let r = 0; r < 20; r++) {
+      const row: (null | { color: string })[] = [];
+      for (let c = 0; c < 10; c++) {
+        row.push(null);
+      }
+      board.push(row);
+    }
+    return board;
+  }, []);
+
+  return (
+    <div className={styles.container}>
+      {/* Status Bar */}
+      <div className={styles.statusBar}>
+        <div className={styles.connectionStatus}>
+          <div className={`${styles.statusDot} ${styles[connectionStatus]}`} />
+          <span>
+            {connectionStatus === 'connected' && t('online')}
+            {connectionStatus === 'connecting' && t('connecting')}
+            {connectionStatus === 'error' && t('connectionError')}
+            {connectionStatus === 'disconnected' && t('offline')}
+          </span>
+        </div>
+        {phase === 'playing' && (
+          <div className={styles.tempoDisplay}>
+            <div
+              className={`${styles.beatIndicator} ${onBeat ? styles.onBeat : ''}`}
+            />
+            <div className={styles.bpmValue}>{Math.round(bpm)}</div>
+            <span>BPM</span>
+            <span className={styles.syncValue}>
+              {t('sync')}: {Math.round(mySync * 100)}%
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Error Banner */}
+      {error && (
+        <div className={styles.errorBanner}>
+          {error}
+          <button className={styles.errorClose} onClick={() => setError(null)}>×</button>
+        </div>
+      )}
+
+      {/* ===== LOBBY ===== */}
+      {phase === 'lobby' && (
+        <div className={styles.lobby}>
+          <h1 className={styles.title}>{t('title')}</h1>
+          <p className={styles.subtitle}>{t('subtitle')}</p>
+          <p className={styles.playerCount}>{t('maxPlayers', { count: ARENA_MAX_PLAYERS })}</p>
+
+          <div className={styles.lobbyActions}>
+            <button
+              className={styles.primaryBtn}
+              onClick={() => {
+                if (connectionStatus !== 'connected') connectWebSocket();
+                if (playerName.trim().length >= 2) {
+                  queueForArena(playerName.trim());
+                } else {
+                  sessionStorage.setItem('arena_nextMode', 'queue');
+                  setPhase('name-entry');
+                }
+              }}
+            >
+              {t('quickMatch')}
+            </button>
+
+            <button
+              className={styles.secondaryBtn}
+              onClick={() => {
+                if (connectionStatus !== 'connected') connectWebSocket();
+                if (playerName.trim().length >= 2) {
+                  createArena(playerName.trim());
+                } else {
+                  sessionStorage.setItem('arena_nextMode', 'create');
+                  setPhase('name-entry');
+                }
+              }}
+            >
+              {t('createArena')}
+            </button>
+
+            <button
+              className={styles.secondaryBtn}
+              onClick={() => {
+                if (connectionStatus !== 'connected') connectWebSocket();
+                setPhase('name-entry');
+                sessionStorage.setItem('arena_nextMode', 'join');
+              }}
+            >
+              {t('joinByCode')}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ===== NAME ENTRY ===== */}
+      {phase === 'name-entry' && (
+        <div className={styles.nameEntry}>
+          <div className={styles.sectionTitle}>{t('enterName')}</div>
+          <input
+            type="text"
+            className={styles.nameInput}
+            placeholder={t('namePlaceholder')}
+            value={playerName}
+            onChange={(e) => setPlayerName(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleNameSubmit()}
+            maxLength={12}
+            autoFocus
+          />
+
+          {sessionStorage.getItem('arena_nextMode') === 'join' && (
+            <>
+              <div className={styles.sectionTitle} style={{ fontSize: '0.9rem', marginTop: 12 }}>
+                {t('enterCode')}
+              </div>
+              <input
+                type="text"
+                className={styles.nameInput}
+                placeholder="AXXX"
+                value={joinCode}
+                onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
+                maxLength={5}
+                style={{ letterSpacing: '0.3em', textTransform: 'uppercase' }}
+              />
+              <button
+                className={styles.primaryBtn}
+                onClick={handleJoinByCode}
+                disabled={playerName.trim().length < 2 || joinCode.trim().length < 4}
+              >
+                {t('join')}
+              </button>
+            </>
+          )}
+
+          {sessionStorage.getItem('arena_nextMode') !== 'join' && (
+            <button
+              className={styles.primaryBtn}
+              onClick={handleNameSubmit}
+              disabled={playerName.trim().length < 2}
+            >
+              {t('next')}
+            </button>
+          )}
+
+          <button className={styles.secondaryBtn} onClick={() => setPhase('lobby')}>
+            {t('back')}
+          </button>
+        </div>
+      )}
+
+      {/* ===== QUEUE ===== */}
+      {phase === 'queue' && (
+        <div className={styles.queueScreen}>
+          <div className={styles.queuePulse} />
+          <div className={styles.sectionTitle}>{t('searching')}</div>
+          <div className={styles.queueInfo}>
+            {t('queueInfo')}
+          </div>
+          <div className={styles.queueCount}>
+            {t('playersInQueue', { count: queueSize })}
+          </div>
+          <button className={styles.secondaryBtn} onClick={cancelQueue}>
+            {t('cancel')}
+          </button>
+        </div>
+      )}
+
+      {/* ===== WAITING ROOM ===== */}
+      {phase === 'waiting-room' && arenaState && (
+        <div className={styles.waitingRoom}>
+          <div className={styles.sectionTitle}>{arenaState.name}</div>
+
+          <div className={styles.arenaCode}>
+            <span className={styles.arenaCodeLabel}>{t('arenaCode')}</span>
+            <span className={styles.arenaCodeValue}>{arenaState.code}</span>
+            <button
+              className={styles.copyBtn}
+              onClick={() => navigator.clipboard.writeText(arenaState.code)}
+            >
+              {t('copy')}
+            </button>
+          </div>
+
+          <div className={styles.playersGrid}>
+            {arenaState.players.map((player) => (
+              <div
+                key={player.id}
+                className={`${styles.playerSlot} ${player.ready ? styles.ready : ''} ${player.id === arenaState.hostId ? styles.host : ''}`}
+                style={!player.connected ? { opacity: 0.5 } : {}}
+              >
+                <div className={styles.playerSlotName}>
+                  {player.name}
+                  {player.id === arenaState.hostId && (
+                    <span className={styles.hostBadge}>HOST</span>
+                  )}
+                </div>
+                <div className={styles.playerSlotStatus}>
+                  {!player.connected ? t('reconnecting') : player.ready ? t('ready') : t('notReady')}
+                </div>
+              </div>
+            ))}
+            {Array.from({ length: ARENA_MAX_PLAYERS - arenaState.players.length }).map((_, i) => (
+              <div key={`empty-${i}`} className={`${styles.playerSlot} ${styles.empty}`}>
+                <div className={styles.playerSlotName}>{t('waiting')}</div>
+              </div>
+            ))}
+          </div>
+
+          <div className={styles.waitingActions}>
+            {!isHost && (
+              <button
+                className={myPlayer?.ready ? styles.secondaryBtn : styles.primaryBtn}
+                onClick={() => setReady(!myPlayer?.ready)}
+              >
+                {myPlayer?.ready ? t('cancelReady') : t('readyUp')}
+              </button>
+            )}
+
+            {isHost && (
+              <button
+                className={styles.primaryBtn}
+                onClick={startArena}
+                disabled={!allReady}
+              >
+                {allReady ? t('startArena') : t('waitingForPlayers')}
+              </button>
+            )}
+
+            <button className={styles.secondaryBtn} onClick={leaveArena}>
+              {t('leave')}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ===== COUNTDOWN ===== */}
+      {phase === 'countdown' && (
+        <div className={styles.countdownScreen}>
+          <div className={styles.countdownNumber}>{countdownNumber}</div>
+          <div className={styles.countdownLabel}>{t('getReady')}</div>
+        </div>
+      )}
+
+      {/* ===== PLAYING ===== */}
+      {phase === 'playing' && arenaState && (
+        <div className={styles.arenaPlayfield}>
+          {/* HUD */}
+          <div className={styles.hudBar}>
+            <div className={styles.chaosBar}>
+              <div className={styles.chaosLabel}>
+                <span>{t('chaos')}</span>
+                <span>{Math.round(chaosLevel)}%</span>
+              </div>
+              <div className={styles.chaosTrack}>
+                <div
+                  className={`${styles.chaosFill} ${chaosClass}`}
+                  style={{ width: `${Math.min(100, chaosLevel)}%` }}
+                />
+              </div>
+            </div>
+
+            {activeGimmick && (
+              <div className={styles.gimmickBanner}>
+                {GIMMICK_LABELS[activeGimmick.type] || activeGimmick.type}
+              </div>
+            )}
+
+            <div className={styles.tempoDisplay}>
+              <div className={`${styles.beatIndicator} ${onBeat ? styles.onBeat : ''}`} />
+              <div className={styles.bpmValue}>{Math.round(bpm)}</div>
+              <span>BPM</span>
+            </div>
+          </div>
+
+          {/* Main Content: My Board + Opponents */}
+          <div className={styles.arenaContent}>
+            {/* My board */}
+            <div className={styles.myBoardArea}>
+              <div className={styles.myBoard} style={{ '--cell-size': '24px' } as React.CSSProperties}>
+                {emptyBoard.map((row, ri) => (
+                  <div key={ri} className={styles.boardRow}>
+                    {row.map((cell, ci) => (
+                      <div
+                        key={ci}
+                        className={`${styles.boardCell} ${cell ? styles.filled : ''}`}
+                        style={cell ? { background: cell.color } : { background: 'rgba(255,255,255,0.02)' }}
+                      />
+                    ))}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Opponents mini boards */}
+            <div className={styles.opponentsSidebar}>
+              {opponents.map((opp) => {
+                const board = opponentBoards.get(opp.id);
+                const oppSync = syncMap[opp.id] ?? 1.0;
+
+                return (
+                  <div
+                    key={opp.id}
+                    className={`${styles.opponentMini} ${!opp.alive ? styles.eliminated : ''}`}
+                  >
+                    <div className={styles.opponentName}>{opp.name}</div>
+                    {board ? (
+                      <MiniBoardView board={board.board} />
+                    ) : (
+                      <div className={styles.opponentMiniBoard}>
+                        {Array.from({ length: 10 }).map((_, ri) => (
+                          <div key={ri} className={styles.miniRow}>
+                            {Array.from({ length: 10 }).map((__, ci) => (
+                              <div key={ci} className={styles.miniCell} />
+                            ))}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    <div className={styles.opponentStats}>
+                      <span>{board?.score ?? 0}</span>
+                      <span>{board?.lines ?? 0}L</span>
+                    </div>
+                    <div className={styles.opponentSync}>
+                      <div
+                        className={styles.opponentSyncFill}
+                        style={{ width: `${Math.round(oppSync * 100)}%` }}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Overlays */}
+          {showCollapse && <div className={styles.tempoCollapseOverlay} />}
+          {showElimBanner && lastElimination && (
+            <div className={styles.eliminationBanner}>
+              {lastElimination.playerName} {t('eliminated')} #{lastElimination.placement}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ===== RESULTS ===== */}
+      {phase === 'ended' && sessionResult && (
+        <div className={styles.resultsScreen}>
+          <div className={styles.resultReason}>
+            {sessionResult.reason === 'last_standing' && t('resultLastStanding')}
+            {sessionResult.reason === 'tempo_collapse' && t('resultTempoCollapse')}
+            {sessionResult.reason === 'chaos_overload' && t('resultChaosOverload')}
+          </div>
+
+          <h2 className={`${styles.resultTitle} ${sessionResult.winnerId !== playerId ? styles.defeat : ''}`}>
+            {sessionResult.winnerId === playerId
+              ? t('victory')
+              : sessionResult.winnerId
+                ? `${sessionResult.winnerName} ${t('wins')}`
+                : t('noWinner')}
+          </h2>
+
+          {/* Rankings */}
+          <div className={styles.rankingsTable}>
+            {sessionResult.rankings.map((r) => (
+              <div
+                key={r.playerId}
+                className={`${styles.rankingRow} ${r.playerId === playerId ? styles.isMe : ''} ${r.placement === 1 ? styles.first : ''}`}
+              >
+                <div className={styles.rankingPlace}>#{r.placement}</div>
+                <div className={styles.rankingName}>{r.playerName}</div>
+                <div className={styles.rankingStat}>{r.score} pts</div>
+                <div className={styles.rankingStat}>{r.kills} KO</div>
+                <div className={styles.rankingStat}>{Math.round(r.avgSync * 100)}%</div>
+              </div>
+            ))}
+          </div>
+
+          {/* Session Stats */}
+          <div className={styles.statsGrid}>
+            <div className={styles.statItem}>
+              <div className={styles.statValue}>
+                {Math.floor(sessionResult.stats.totalDurationMs / 1000)}s
+              </div>
+              <div className={styles.statLabel}>{t('duration')}</div>
+            </div>
+            <div className={styles.statItem}>
+              <div className={styles.statValue}>{Math.round(sessionResult.stats.peakBpm)}</div>
+              <div className={styles.statLabel}>{t('peakBpm')}</div>
+            </div>
+            <div className={styles.statItem}>
+              <div className={styles.statValue}>{sessionResult.stats.totalGimmicks}</div>
+              <div className={styles.statLabel}>{t('gimmicks')}</div>
+            </div>
+            <div className={styles.statItem}>
+              <div className={styles.statValue}>{Math.round(sessionResult.stats.peakChaos)}</div>
+              <div className={styles.statLabel}>{t('peakChaos')}</div>
+            </div>
+            <div className={styles.statItem}>
+              <div className={styles.statValue}>{sessionResult.stats.tempoCollapses}</div>
+              <div className={styles.statLabel}>{t('tempoCollapses')}</div>
+            </div>
+            <div className={styles.statItem}>
+              <div className={styles.statValue}>{Math.round(sessionResult.stats.lowestBpm)}</div>
+              <div className={styles.statLabel}>{t('lowestBpm')}</div>
+            </div>
+          </div>
+
+          <div className={styles.resultActions}>
+            <button className={styles.primaryBtn} onClick={() => { leaveArena(); }}>
+              {t('backToLobby')}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/rhythmia/tetris/VanillaGame.module.css
+++ b/src/components/rhythmia/tetris/VanillaGame.module.css
@@ -460,6 +460,15 @@
   box-shadow: 0 0 20px rgba(255, 80, 80, 0.15);
 }
 
+.modeBtnMix {
+  border-color: rgba(160, 80, 255, 0.3);
+}
+
+.modeBtnMix:hover {
+  border-color: rgba(160, 80, 255, 0.6);
+  box-shadow: 0 0 20px rgba(160, 80, 255, 0.2);
+}
+
 .modeBtnIcon {
   font-size: 2rem;
 }
@@ -1797,6 +1806,12 @@
   animation: phasePulse 0.8s infinite alternate;
 }
 
+.phaseDot[data-phase="PRE_STAGE"] {
+  background: #FFD700;
+  box-shadow: 0 0 8px rgba(255, 215, 0, 0.5);
+  animation: phasePulse 0.6s infinite alternate;
+}
+
 @keyframes phasePulse {
   from { opacity: 0.5; }
   to { opacity: 1; }
@@ -2067,5 +2082,159 @@
 
   .vBarLabel {
     font-size: 0.5rem;
+  }
+}
+
+/* ===== Pre-Stage Upgrade Screen (Mix Mode) ===== */
+.preStageOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 350;
+  background: rgba(0, 0, 0, 0.92);
+  backdrop-filter: blur(16px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: preStageIn 0.5s ease;
+}
+
+@keyframes preStageIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.preStagePanel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  max-width: 520px;
+  width: 90vw;
+}
+
+.preStageClear {
+  font-size: clamp(1.8rem, 6vw, 3rem);
+  font-weight: 200;
+  color: #FFD700;
+  letter-spacing: 0.3em;
+  text-shadow: 0 0 30px rgba(255, 215, 0, 0.3);
+  animation: preStageClearPulse 2s ease-in-out infinite alternate;
+}
+
+@keyframes preStageClearPulse {
+  0% { text-shadow: 0 0 20px rgba(255, 215, 0, 0.2); }
+  100% { text-shadow: 0 0 40px rgba(255, 215, 0, 0.5); }
+}
+
+.preStageCycle {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.5);
+  letter-spacing: 0.2em;
+  font-weight: 400;
+}
+
+.preStagePrompt {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.35);
+  letter-spacing: 0.1em;
+  font-weight: 300;
+}
+
+.preStageChoices {
+  display: flex;
+  gap: 20px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.preStageBtn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 28px 36px;
+  min-width: 200px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  cursor: pointer;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.preStageBtn:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.3);
+}
+
+.preStageBtnHp {
+  border-color: rgba(229, 57, 53, 0.3);
+}
+
+.preStageBtnHp:hover {
+  border-color: rgba(229, 57, 53, 0.6);
+  background: rgba(229, 57, 53, 0.08);
+  box-shadow: 0 8px 30px rgba(229, 57, 53, 0.15);
+}
+
+.preStageBtnMana {
+  border-color: rgba(66, 165, 245, 0.3);
+}
+
+.preStageBtnMana:hover {
+  border-color: rgba(66, 165, 245, 0.6);
+  background: rgba(66, 165, 245, 0.08);
+  box-shadow: 0 8px 30px rgba(66, 165, 245, 0.15);
+}
+
+.preStageBtnIcon {
+  font-size: 2.5rem;
+}
+
+.preStageBtnTitle {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: white;
+  letter-spacing: 0.15em;
+}
+
+.preStageBtnCurrent {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.5);
+  letter-spacing: 0.08em;
+  font-weight: 400;
+}
+
+.preStageBtnDesc {
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.3);
+  letter-spacing: 0.1em;
+  font-weight: 300;
+}
+
+.preStageWarning {
+  font-size: 0.7rem;
+  color: rgba(255, 100, 100, 0.5);
+  letter-spacing: 0.15em;
+  font-weight: 400;
+  margin-top: 8px;
+}
+
+/* Responsive pre-stage */
+@media screen and (max-width: 480px) {
+  .preStageBtn {
+    padding: 20px 24px;
+    min-width: 160px;
+  }
+
+  .preStageBtnIcon {
+    font-size: 2rem;
+  }
+
+  .preStageBtnTitle {
+    font-size: 0.8rem;
+  }
+
+  .preStageClear {
+    font-size: 1.5rem;
   }
 }

--- a/src/components/rhythmia/tetris/components/GameUI.tsx
+++ b/src/components/rhythmia/tetris/components/GameUI.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { WORLDS, ColorTheme } from '../constants';
+import { WORLDS, TERRAINS_PER_WORLD, ColorTheme } from '../constants';
 import type { GameMode } from '../types';
 import styles from '../VanillaGame.module.css';
 

--- a/src/components/rhythmia/tetris/components/GameUI.tsx
+++ b/src/components/rhythmia/tetris/components/GameUI.tsx
@@ -25,6 +25,11 @@ export function TitleScreen({ onStart }: TitleScreenProps) {
                     <span className={styles.modeBtnTitle}>TOWER DEFENSE</span>
                     <span className={styles.modeBtnDesc}>タワーを守れ！</span>
                 </button>
+                <button className={`${styles.modeBtn} ${styles.modeBtnMix}`} onClick={() => onStart('mix')}>
+                    <span className={styles.modeBtnIcon}>⚔️</span>
+                    <span className={styles.modeBtnTitle}>MIX MODE</span>
+                    <span className={styles.modeBtnDesc}>破壊と防衛の融合</span>
+                </button>
             </div>
         </div>
     );
@@ -87,6 +92,22 @@ interface TerrainProgressProps {
  * TD: enemy count indicator
  */
 export function TerrainProgress({ terrainRemaining, terrainTotal, stageNumber, gameMode }: TerrainProgressProps) {
+    if (gameMode === 'mix') {
+        // Mix mode: terrain gauge (like vanilla) + enemy count
+        const remainingPct = terrainTotal > 0 ? Math.max(0, (terrainRemaining / terrainTotal) * 100) : 100;
+        return (
+            <>
+                <div className={styles.terrainLabel}>STAGE {stageNumber} — MIX</div>
+                <div className={styles.terrainBar}>
+                    <div className={styles.terrainFill} style={{ width: `${remainingPct}%`, background: 'linear-gradient(90deg, rgba(160, 80, 255, 0.5), rgba(255, 160, 80, 0.7))' }} />
+                </div>
+                <div style={{ color: '#aaa', fontSize: '0.7em', textAlign: 'center', marginTop: '2px' }}>
+                    {terrainRemaining} / {terrainTotal} blocks
+                </div>
+            </>
+        );
+    }
+
     if (gameMode === 'td') {
         return (
             <>

--- a/src/components/rhythmia/tetris/components/HealthManaHUD.tsx
+++ b/src/components/rhythmia/tetris/components/HealthManaHUD.tsx
@@ -6,16 +6,25 @@ import { MAX_HEALTH } from '../constants';
 
 interface HealthHUDProps {
   health: number;
+  maxHealth?: number;
+  mana?: number;
+  maxMana?: number;
+  showMana?: boolean;
 }
 
 /**
- * Vertical HP bar placed to the right of the game board.
+ * Vertical HP bar (and optional Mana bar) placed to the right of the game board.
  * Red vignette flashes when the tower takes damage.
  */
-export function HealthManaHUD({ health }: HealthHUDProps) {
-  const healthPct = Math.max(0, Math.min(100, (health / MAX_HEALTH) * 100));
+export function HealthManaHUD({ health, maxHealth, mana, maxMana, showMana = false }: HealthHUDProps) {
+  const effectiveMaxHealth = maxHealth ?? MAX_HEALTH;
+  const healthPct = Math.max(0, Math.min(100, (health / effectiveMaxHealth) * 100));
 
   const isLow = healthPct < 30;
+
+  // Mana percentage
+  const effectiveMaxMana = maxMana ?? 100;
+  const manaPct = showMana ? Math.max(0, Math.min(100, ((mana ?? 0) / effectiveMaxMana) * 100)) : 0;
 
   // Damage vignette: flash when health decreases
   const [showVignette, setShowVignette] = useState(false);
@@ -55,6 +64,25 @@ export function HealthManaHUD({ health }: HealthHUDProps) {
           </div>
           <div className={styles.vBarValue}>{Math.ceil(health)}</div>
         </div>
+
+        {/* Mana Bar (Mix Mode) */}
+        {showMana && (
+          <div className={styles.vBar}>
+            <div className={styles.vBarLabel}>MP</div>
+            <div className={`${styles.vBarTrack} ${styles.vBarMpTrack}`}>
+              <div
+                className={`${styles.vBarFill} ${styles.vBarMpFill}`}
+                style={{ height: `${manaPct}%` }}
+              />
+              <div className={styles.vBarTicks}>
+                <div className={styles.vBarTick} style={{ bottom: '25%' }} />
+                <div className={styles.vBarTick} style={{ bottom: '50%' }} />
+                <div className={styles.vBarTick} style={{ bottom: '75%' }} />
+              </div>
+            </div>
+            <div className={styles.vBarValue}>{Math.ceil(mana ?? 0)}</div>
+          </div>
+        )}
       </div>
     </>
   );

--- a/src/components/rhythmia/tetris/components/PreStageScreen.tsx
+++ b/src/components/rhythmia/tetris/components/PreStageScreen.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import React from 'react';
+import styles from '../VanillaGame.module.css';
+import type { PreStageUpgrade } from '../types';
+
+interface PreStageScreenProps {
+  cycleCount: number;
+  currentMaxHP: number;
+  currentMaxMana: number;
+  hpBonus: number;
+  manaBonus: number;
+  onChoose: (choice: PreStageUpgrade) => void;
+}
+
+/**
+ * Pre-stage upgrade screen shown after clearing all 5 worlds in Mix Mode.
+ * Allows the player to choose between increasing max HP or max Mana
+ * before starting the next cycle with increased difficulty.
+ */
+export function PreStageScreen({
+  cycleCount,
+  currentMaxHP,
+  currentMaxMana,
+  hpBonus,
+  manaBonus,
+  onChoose,
+}: PreStageScreenProps) {
+  return (
+    <div className={styles.preStageOverlay}>
+      <div className={styles.preStagePanel}>
+        <div className={styles.preStageClear}>ALL WORLDS CLEARED</div>
+        <div className={styles.preStageCycle}>CYCLE {cycleCount + 1} COMPLETE</div>
+        <div className={styles.preStagePrompt}>Choose an upgrade before the next cycle</div>
+
+        <div className={styles.preStageChoices}>
+          <button
+            className={`${styles.preStageBtn} ${styles.preStageBtnHp}`}
+            onClick={() => onChoose('hp')}
+          >
+            <span className={styles.preStageBtnIcon}>❤️</span>
+            <span className={styles.preStageBtnTitle}>MAX HP +{hpBonus}</span>
+            <span className={styles.preStageBtnCurrent}>
+              {currentMaxHP} → {currentMaxHP + hpBonus}
+            </span>
+            <span className={styles.preStageBtnDesc}>最大HPを増加</span>
+          </button>
+
+          <button
+            className={`${styles.preStageBtn} ${styles.preStageBtnMana}`}
+            onClick={() => onChoose('mana')}
+          >
+            <span className={styles.preStageBtnIcon}>💎</span>
+            <span className={styles.preStageBtnTitle}>MAX MANA +{manaBonus}</span>
+            <span className={styles.preStageBtnCurrent}>
+              {currentMaxMana} → {currentMaxMana + manaBonus}
+            </span>
+            <span className={styles.preStageBtnDesc}>最大マナを増加</span>
+          </button>
+        </div>
+
+        <div className={styles.preStageWarning}>
+          Next cycle enemies are stronger
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/rhythmia/tetris/components/TutorialGuide.tsx
+++ b/src/components/rhythmia/tetris/components/TutorialGuide.tsx
@@ -1,0 +1,166 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import styles from '../VanillaGame.module.css';
+
+const TUTORIAL_SEEN_KEY = 'rhythmia_tutorial_seen';
+
+interface TutorialGuideProps {
+    onComplete: () => void;
+}
+
+interface TutorialStep {
+    title: string;
+    subtitle: string;
+    items: { key: string; label: string }[];
+}
+
+const STEPS: TutorialStep[] = [
+    {
+        title: 'MOVEMENT',
+        subtitle: '移動操作',
+        items: [
+            { key: '← →', label: 'Move' },
+            { key: '↓', label: 'Soft Drop' },
+            { key: 'SPACE', label: 'Hard Drop' },
+        ],
+    },
+    {
+        title: 'ROTATION',
+        subtitle: '回転操作',
+        items: [
+            { key: '↑ / X', label: 'Rotate CW' },
+            { key: 'Z / CTRL', label: 'Rotate CCW' },
+            { key: 'C / SHIFT', label: 'Hold Piece' },
+        ],
+    },
+    {
+        title: 'RHYTHM',
+        subtitle: 'リズムシステム',
+        items: [
+            { key: 'BEAT', label: 'Drop on beat for 2x score' },
+            { key: 'COMBO', label: 'Chain beats for multiplier' },
+            { key: 'DIG', label: 'Clear lines to destroy terrain' },
+        ],
+    },
+];
+
+/**
+ * Honkai: Star Rail-style tutorial guidance screen.
+ * Shows once on first play, with step-based navigation.
+ */
+export function TutorialGuide({ onComplete }: TutorialGuideProps) {
+    const [currentStep, setCurrentStep] = useState(0);
+    const [fadeIn, setFadeIn] = useState(false);
+    const [stepAnim, setStepAnim] = useState(false);
+
+    useEffect(() => {
+        requestAnimationFrame(() => setFadeIn(true));
+    }, []);
+
+    useEffect(() => {
+        setStepAnim(false);
+        const t = requestAnimationFrame(() => setStepAnim(true));
+        return () => cancelAnimationFrame(t);
+    }, [currentStep]);
+
+    const handleNext = useCallback(() => {
+        if (currentStep < STEPS.length - 1) {
+            setCurrentStep(prev => prev + 1);
+        } else {
+            localStorage.setItem(TUTORIAL_SEEN_KEY, '1');
+            onComplete();
+        }
+    }, [currentStep, onComplete]);
+
+    const handleSkip = useCallback(() => {
+        localStorage.setItem(TUTORIAL_SEEN_KEY, '1');
+        onComplete();
+    }, [onComplete]);
+
+    // Allow Space/Enter/click to advance
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === ' ' || e.key === 'Enter') {
+                e.preventDefault();
+                handleNext();
+            } else if (e.key === 'Escape') {
+                e.preventDefault();
+                handleSkip();
+            }
+        };
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    }, [handleNext, handleSkip]);
+
+    const step = STEPS[currentStep];
+    const isLast = currentStep === STEPS.length - 1;
+
+    return (
+        <div
+            className={`${styles.tutorialOverlay} ${fadeIn ? styles.tutorialVisible : ''}`}
+            onClick={handleNext}
+        >
+            {/* Geometric corner decorations */}
+            <div className={`${styles.tutCorner} ${styles.tutCornerTL}`} />
+            <div className={`${styles.tutCorner} ${styles.tutCornerTR}`} />
+            <div className={`${styles.tutCorner} ${styles.tutCornerBL}`} />
+            <div className={`${styles.tutCorner} ${styles.tutCornerBR}`} />
+
+            {/* Horizontal scan line */}
+            <div className={styles.tutScanLine} />
+
+            {/* Top label */}
+            <div className={styles.tutTopLabel}>NAVIGATION GUIDE</div>
+
+            {/* Main content */}
+            <div className={`${styles.tutContent} ${stepAnim ? styles.tutStepIn : ''}`}>
+                {/* Step indicator */}
+                <div className={styles.tutStepIndicator}>
+                    {STEPS.map((_, i) => (
+                        <div
+                            key={i}
+                            className={`${styles.tutStepDot} ${i === currentStep ? styles.tutStepDotActive : ''} ${i < currentStep ? styles.tutStepDotDone : ''}`}
+                        />
+                    ))}
+                </div>
+
+                {/* Step title */}
+                <div className={styles.tutStepTitle}>{step.title}</div>
+                <div className={styles.tutStepSubtitle}>{step.subtitle}</div>
+
+                {/* Separator */}
+                <div className={styles.tutSeparator} />
+
+                {/* Control items */}
+                <div className={styles.tutItems}>
+                    {step.items.map((item, i) => (
+                        <div key={i} className={styles.tutItem}>
+                            <span className={styles.tutItemKey}>{item.key}</span>
+                            <span className={styles.tutItemLabel}>{item.label}</span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            {/* Bottom bar */}
+            <div className={styles.tutBottomBar}>
+                <button className={styles.tutSkipBtn} onClick={(e) => { e.stopPropagation(); handleSkip(); }}>
+                    SKIP
+                </button>
+                <div className={styles.tutProgressText}>
+                    {currentStep + 1} / {STEPS.length}
+                </div>
+                <button className={styles.tutNextBtn} onClick={(e) => { e.stopPropagation(); handleNext(); }}>
+                    {isLast ? 'START' : 'NEXT'}
+                </button>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * Returns true if the tutorial has already been seen.
+ */
+export function hasTutorialBeenSeen(): boolean {
+    if (typeof window === 'undefined') return true;
+    return localStorage.getItem(TUTORIAL_SEEN_KEY) === '1';
+}

--- a/src/components/rhythmia/tetris/components/WorldTransition.tsx
+++ b/src/components/rhythmia/tetris/components/WorldTransition.tsx
@@ -25,14 +25,14 @@ export function WorldTransition({ phase, worldIdx, stageNumber, gameMode = 'vani
         if (phase === 'WORLD_CREATION') {
             setVisible(true);
             setText(`STAGE ${stageNumber}`);
-            const modeSuffix = gameMode === 'td' ? ' — TOWER DEFENSE' : '';
+            const modeSuffix = gameMode === 'td' ? ' — TOWER DEFENSE' : gameMode === 'mix' ? ' — MIX' : '';
             setSubText((WORLDS[worldIdx]?.name || '') + modeSuffix);
             const timer = setTimeout(() => setVisible(false), 1400);
             return () => clearTimeout(timer);
         } else if (phase === 'COLLAPSE') {
             setVisible(true);
             setText(gameMode === 'td' ? 'WAVE COMPLETE!' : 'TERRAIN CLEARED!');
-            setSubText(gameMode === 'td' ? 'ウェーブクリア！' : '地形破壊完了');
+            setSubText(gameMode === 'td' ? 'ウェーブクリア！' : gameMode === 'mix' ? 'ワールドクリア！' : '地形破壊完了');
             const timer = setTimeout(() => setVisible(false), 1200);
             return () => clearTimeout(timer);
         } else if (phase === 'TRANSITION') {
@@ -96,6 +96,7 @@ export function GamePhaseIndicator({ phase, stageNumber, damageMultiplier }: Gam
         CRAFTING: 'FORGE',
         COLLAPSE: 'COLLAPSE',
         TRANSITION: 'RELOAD',
+        PRE_STAGE: 'UPGRADE',
     };
 
     return (

--- a/src/components/rhythmia/tetris/components/index.ts
+++ b/src/components/rhythmia/tetris/components/index.ts
@@ -20,3 +20,4 @@ export { CraftingUI } from './CraftingUI';
 export { TerrainParticles } from './TerrainParticles';
 export { WorldTransition, GamePhaseIndicator } from './WorldTransition';
 export { HealthManaHUD } from './HealthManaHUD';
+export { PreStageScreen } from './PreStageScreen';

--- a/src/components/rhythmia/tetris/constants.ts
+++ b/src/components/rhythmia/tetris/constants.ts
@@ -146,30 +146,7 @@ export const MAX_LOCK_MOVES = 15;  // Max moves/rotations on ground before force
 export const TERRAINS_PER_WORLD = 4;
 // Voxel blocks destroyed per cleared line (multiplied by beat multiplier)
 export const TERRAIN_DAMAGE_PER_LINE = 4;
-            if (pieceIndex >= 0 && WORLDS[worldIdx]) {
-                return WORLDS[worldIdx].colors[pieceIndex] || COLORS[pieceType];
-            }
-            return COLORS[pieceType];
-    }
-};
-export const MIX_BULLET_MANA_COST = 15;          // Mana cost per bullet fired
-export const MIX_PRE_STAGE_HP_BONUS = 25;        // HP added per pre-stage upgrade
-export const MIX_PRE_STAGE_MANA_BONUS = 25;      // Mana added per pre-stage upgrade
-export const MIX_DIFFICULTY_SCALE_PER_CYCLE = 0.15; // 15% harder per cycle (enemy speed/spawn rate)
 
-// ===== Helper Constants =====
-export const ROTATION_NAMES = ['0', 'R', '2', 'L'];
-
-// ===== Piece Type Array =====
-export const PIECE_TYPES = ['I', 'O', 'T', 'S', 'Z', 'J', 'L'];
-
-// ===== Color Theme Helper =====
-// Get color for a piece type based on theme and world
-export const getThemedColor = (
-    pieceType: string,
-    theme: ColorTheme,
-    worldIdx: number
-): string => {
 // ===== Item Definitions =====
 import type { ItemType, WeaponCard } from './types';
 
@@ -315,3 +292,29 @@ export const MIX_INITIAL_MAX_HP = 100;            // Starting max HP
 export const MIX_INITIAL_MAX_MANA = 100;          // Starting max mana
 export const MIX_MANA_REGEN_PER_BEAT = 3;        // Mana regenerated each beat
 export const MIX_MANA_PER_LINE_CLEAR = 10;       // Mana gained per line clear
+export const MIX_BULLET_MANA_COST = 15;          // Mana cost per bullet fired
+export const MIX_PRE_STAGE_HP_BONUS = 25;        // HP added per pre-stage upgrade
+export const MIX_PRE_STAGE_MANA_BONUS = 25;      // Mana added per pre-stage upgrade
+export const MIX_DIFFICULTY_SCALE_PER_CYCLE = 0.15; // 15% harder per cycle (enemy speed/spawn rate)
+
+// ===== Helper Constants =====
+export const ROTATION_NAMES = ['0', 'R', '2', 'L'];
+
+// ===== Piece Type Array =====
+export const PIECE_TYPES = ['I', 'O', 'T', 'S', 'Z', 'J', 'L'];
+
+// ===== Color Theme Helper =====
+// Get color for a piece type based on theme and world
+export const getThemedColor = (
+    pieceType: string,
+    theme: ColorTheme,
+    worldIdx: number
+): string => {
+    if (theme === 'stage') {
+        const pieceIndex = PIECE_TYPES.indexOf(pieceType);
+        if (pieceIndex >= 0 && WORLDS[worldIdx]) {
+            return WORLDS[worldIdx].colors[pieceIndex] || COLORS[pieceType];
+        }
+    }
+    return COLORS[pieceType];
+};

--- a/src/components/rhythmia/tetris/constants.ts
+++ b/src/components/rhythmia/tetris/constants.ts
@@ -275,6 +275,21 @@ export const BULLET_KILL_RADIUS = 1.5;  // Distance at which bullet hits enemy
 export const BULLET_DAMAGE = 1;         // Damage per bullet hit
 export const BULLET_FIRE_INTERVAL = 1000; // Auto-fire interval in ms
 
+// ===== Mix Mode Settings =====
+// Mix Mode spawns enemies at a lower rate and combines terrain destruction + TD
+export const MIX_ENEMIES_PER_BEAT = 1;           // Enemies spawned per beat (same as TD)
+export const MIX_ENEMY_SPAWN_INTERVAL = 2;       // Spawn enemies every N beats (slower than TD)
+export const MIX_TERRAIN_DAMAGE_PER_LINE = 4;    // Same as vanilla terrain damage
+export const MIX_ENEMIES_KILLED_PER_LINE = 1;    // Fewer kills per line than pure TD
+export const MIX_INITIAL_MAX_HP = 100;            // Starting max HP
+export const MIX_INITIAL_MAX_MANA = 100;          // Starting max mana
+export const MIX_MANA_REGEN_PER_BEAT = 3;        // Mana regenerated each beat
+export const MIX_MANA_PER_LINE_CLEAR = 10;       // Mana gained per line clear
+export const MIX_BULLET_MANA_COST = 15;          // Mana cost per bullet fired
+export const MIX_PRE_STAGE_HP_BONUS = 25;        // HP added per pre-stage upgrade
+export const MIX_PRE_STAGE_MANA_BONUS = 25;      // Mana added per pre-stage upgrade
+export const MIX_DIFFICULTY_SCALE_PER_CYCLE = 0.15; // 15% harder per cycle (enemy speed/spawn rate)
+
 // ===== Helper Constants =====
 export const ROTATION_NAMES = ['0', 'R', '2', 'L'];
 

--- a/src/components/rhythmia/tetris/constants.ts
+++ b/src/components/rhythmia/tetris/constants.ts
@@ -136,10 +136,40 @@ export const DEFAULT_ARR = 33;   // Auto Repeat Rate - delay between each auto-r
 // Set to 0 for instant movement (common in competitive play)
 export const DEFAULT_SDF = 50;   // Soft Drop Factor - soft drop speed in ms
 
+
+// ===== Lock Delay Settings =====
+export const LOCK_DELAY = 500;     // Grace period (ms) after piece lands before locking
+export const MAX_LOCK_MOVES = 15;  // Max moves/rotations on ground before forced lock
+
 // ===== Terrain Settings =====
+// Number of terrains (stages) to clear before advancing to the next world
+export const TERRAINS_PER_WORLD = 4;
 // Voxel blocks destroyed per cleared line (multiplied by beat multiplier)
 export const TERRAIN_DAMAGE_PER_LINE = 4;
+            if (pieceIndex >= 0 && WORLDS[worldIdx]) {
+                return WORLDS[worldIdx].colors[pieceIndex] || COLORS[pieceType];
+            }
+            return COLORS[pieceType];
+    }
+};
+export const MIX_BULLET_MANA_COST = 15;          // Mana cost per bullet fired
+export const MIX_PRE_STAGE_HP_BONUS = 25;        // HP added per pre-stage upgrade
+export const MIX_PRE_STAGE_MANA_BONUS = 25;      // Mana added per pre-stage upgrade
+export const MIX_DIFFICULTY_SCALE_PER_CYCLE = 0.15; // 15% harder per cycle (enemy speed/spawn rate)
 
+// ===== Helper Constants =====
+export const ROTATION_NAMES = ['0', 'R', '2', 'L'];
+
+// ===== Piece Type Array =====
+export const PIECE_TYPES = ['I', 'O', 'T', 'S', 'Z', 'J', 'L'];
+
+// ===== Color Theme Helper =====
+// Get color for a piece type based on theme and world
+export const getThemedColor = (
+    pieceType: string,
+    theme: ColorTheme,
+    worldIdx: number
+): string => {
 // ===== Item Definitions =====
 import type { ItemType, WeaponCard } from './types';
 
@@ -285,36 +315,3 @@ export const MIX_INITIAL_MAX_HP = 100;            // Starting max HP
 export const MIX_INITIAL_MAX_MANA = 100;          // Starting max mana
 export const MIX_MANA_REGEN_PER_BEAT = 3;        // Mana regenerated each beat
 export const MIX_MANA_PER_LINE_CLEAR = 10;       // Mana gained per line clear
-export const MIX_BULLET_MANA_COST = 15;          // Mana cost per bullet fired
-export const MIX_PRE_STAGE_HP_BONUS = 25;        // HP added per pre-stage upgrade
-export const MIX_PRE_STAGE_MANA_BONUS = 25;      // Mana added per pre-stage upgrade
-export const MIX_DIFFICULTY_SCALE_PER_CYCLE = 0.15; // 15% harder per cycle (enemy speed/spawn rate)
-
-// ===== Helper Constants =====
-export const ROTATION_NAMES = ['0', 'R', '2', 'L'];
-
-// ===== Piece Type Array =====
-export const PIECE_TYPES = ['I', 'O', 'T', 'S', 'Z', 'J', 'L'];
-
-// ===== Color Theme Helper =====
-// Get color for a piece type based on theme and world
-export const getThemedColor = (
-    pieceType: string,
-    theme: ColorTheme,
-    worldIdx: number
-): string => {
-    switch (theme) {
-        case 'standard':
-            return STANDARD_COLORS[pieceType] || COLORS[pieceType];
-        case 'monochrome':
-            return MONOCHROME_COLORS[pieceType] || '#FFFFFF';
-        case 'stage':
-        default:
-            // Use world colors based on piece index
-            const pieceIndex = PIECE_TYPES.indexOf(pieceType);
-            if (pieceIndex >= 0 && WORLDS[worldIdx]) {
-                return WORLDS[worldIdx].colors[pieceIndex] || COLORS[pieceType];
-            }
-            return COLORS[pieceType];
-    }
-};

--- a/src/components/rhythmia/tetris/tetris.tsx
+++ b/src/components/rhythmia/tetris/tetris.tsx
@@ -1054,7 +1054,7 @@ export default function Rhythmia() {
       {/* Voxel World Background — mode-aware */}
       <VoxelWorldBackground
         seed={terrainSeed}
-        gameMode={gameMode === 'mix' ? 'vanilla' : gameMode}
+        gameMode={gameMode}
         terrainDestroyedCount={terrainDestroyedCount}
         enemies={(gameMode === 'td' || gameMode === 'mix') ? enemies : []}
         bullets={(gameMode === 'td' || gameMode === 'mix') ? bullets : []}

--- a/src/components/rhythmia/tetris/types.ts
+++ b/src/components/rhythmia/tetris/types.ts
@@ -77,7 +77,6 @@ export type PreStageUpgrade = 'hp' | 'mana';
 
 // ===== Item System =====
 export type ItemRarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary';
-export type ItemRarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary';
 
 export type ItemType = {
     id: string;

--- a/src/components/rhythmia/tetris/types.ts
+++ b/src/components/rhythmia/tetris/types.ts
@@ -77,6 +77,7 @@ export type PreStageUpgrade = 'hp' | 'mana';
 
 // ===== Item System =====
 export type ItemRarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary';
+export type ItemRarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary';
 
 export type ItemType = {
     id: string;

--- a/src/components/rhythmia/tetris/types.ts
+++ b/src/components/rhythmia/tetris/types.ts
@@ -1,5 +1,5 @@
 // ===== Game Mode =====
-export type GameMode = 'vanilla' | 'td';
+export type GameMode = 'vanilla' | 'td' | 'mix';
 
 // ===== Game Types =====
 
@@ -69,7 +69,11 @@ export type GamePhase =
     | 'PLAYING'
     | 'CRAFTING'
     | 'COLLAPSE'
-    | 'TRANSITION';
+    | 'TRANSITION'
+    | 'PRE_STAGE';
+
+// ===== Pre-Stage Upgrade (Mix Mode) =====
+export type PreStageUpgrade = 'hp' | 'mana';
 
 // ===== Item System =====
 export type ItemRarity = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary';

--- a/src/hooks/useArenaSocket.ts
+++ b/src/hooks/useArenaSocket.ts
@@ -1,0 +1,429 @@
+'use client';
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import type {
+  ArenaRoomState,
+  ArenaGimmick,
+  ArenaAction,
+  ArenaRanking,
+  ArenaSessionStats,
+  ArenaBoardPayload,
+} from '@/types/arena';
+
+type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
+
+export type ArenaPhase =
+  | 'lobby'
+  | 'name-entry'
+  | 'queue'
+  | 'waiting-room'
+  | 'countdown'
+  | 'playing'
+  | 'ended';
+
+interface ArenaSessionResult {
+  reason: 'last_standing' | 'tempo_collapse' | 'chaos_overload';
+  winnerId: string | null;
+  winnerName: string | null;
+  rankings: ArenaRanking[];
+  stats: ArenaSessionStats;
+}
+
+interface PlayerActionEvent {
+  playerId: string;
+  playerName: string;
+  action: ArenaAction;
+  onBeat: boolean;
+}
+
+interface TempoCollapseEvent {
+  avgSync: number;
+  bpmDeviation: number;
+}
+
+interface EliminationEvent {
+  playerId: string;
+  playerName: string;
+  placement: number;
+  eliminatedBy: string | null;
+}
+
+const MAX_RECONNECT_ATTEMPTS = 5;
+const PING_TIMEOUT = 60000;
+
+export function useArenaSocket() {
+  // Connection
+  const wsRef = useRef<WebSocket | null>(null);
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('disconnected');
+  const playerIdRef = useRef<string>('');
+  const reconnectTokenRef = useRef<string>('');
+  const reconnectAttemptsRef = useRef(0);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastPingRef = useRef<number>(Date.now());
+  const pingCheckTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Arena state
+  const [phase, setPhase] = useState<ArenaPhase>('lobby');
+  const [arenaState, setArenaState] = useState<ArenaRoomState | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [countdownNumber, setCountdownNumber] = useState<number | null>(null);
+  const [gameSeed, setGameSeed] = useState<number>(0);
+  const [queuePosition, setQueuePosition] = useState<number>(0);
+  const [queueSize, setQueueSize] = useState<number>(0);
+
+  // Tempo state
+  const [bpm, setBpm] = useState(120);
+  const [beatPhase, setBeatPhase] = useState(0);
+  const serverTimeOffsetRef = useRef(0);
+
+  // Chaos and gimmick state
+  const [chaosLevel, setChaosLevel] = useState(0);
+  const [activeGimmick, setActiveGimmick] = useState<ArenaGimmick | null>(null);
+  const [syncMap, setSyncMap] = useState<Record<string, number>>({});
+
+  // Events (for UI reactions)
+  const [lastPlayerAction, setLastPlayerAction] = useState<PlayerActionEvent | null>(null);
+  const [lastElimination, setLastElimination] = useState<EliminationEvent | null>(null);
+  const [lastTempoCollapse, setLastTempoCollapse] = useState<TempoCollapseEvent | null>(null);
+  const [sessionResult, setSessionResult] = useState<ArenaSessionResult | null>(null);
+
+  // Opponent boards (relayed)
+  const opponentBoardsRef = useRef<Map<string, ArenaBoardPayload>>(new Map());
+  const [opponentBoards, setOpponentBoards] = useState<Map<string, ArenaBoardPayload>>(new Map());
+
+  // ===== WebSocket Connection =====
+  const connectWebSocketRef = useRef<() => void>(() => {});
+
+  const scheduleReconnect = useCallback(() => {
+    if (reconnectTimerRef.current) return;
+    if (reconnectAttemptsRef.current >= MAX_RECONNECT_ATTEMPTS) {
+      setError('Connection lost. Please rejoin manually.');
+      return;
+    }
+
+    const delay = Math.min(1000 * Math.pow(2, reconnectAttemptsRef.current), 15000);
+    reconnectAttemptsRef.current++;
+    setConnectionStatus('connecting');
+
+    reconnectTimerRef.current = setTimeout(() => {
+      reconnectTimerRef.current = null;
+      connectWebSocketRef.current();
+    }, delay);
+  }, []);
+
+  const send = useCallback((data: object) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify(data));
+    }
+  }, []);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleServerMessage = useCallback((msg: any) => {
+    const type = msg.type as string;
+    switch (type) {
+      // Standard multiplayer messages we still need
+      case 'connected':
+        playerIdRef.current = msg.playerId;
+        serverTimeOffsetRef.current = Date.now() - msg.serverTime;
+        break;
+
+      case 'ping':
+        lastPingRef.current = Date.now();
+        send({ type: 'pong' });
+        break;
+
+      case 'error':
+        setError(msg.message);
+        break;
+
+      case 'server_shutdown':
+        setError('Server is restarting. Reconnecting...');
+        setConnectionStatus('disconnected');
+        break;
+
+      // Arena-specific messages
+      case 'arena_created':
+        reconnectTokenRef.current = msg.reconnectToken;
+        sessionStorage.setItem('arena_reconnectToken', msg.reconnectToken);
+        break;
+
+      case 'arena_joined': {
+        playerIdRef.current = msg.playerId;
+        reconnectTokenRef.current = msg.reconnectToken;
+        sessionStorage.setItem('arena_reconnectToken', msg.reconnectToken);
+        setArenaState(msg.arenaState);
+        setPhase('waiting-room');
+        setError(null);
+        break;
+      }
+
+      case 'arena_state':
+        setArenaState(msg.arenaState);
+        break;
+
+      case 'arena_player_joined':
+        setArenaState(prev => {
+          if (!prev) return prev;
+          const p = msg.player;
+          const exists = prev.players.some(x => x.id === p.id);
+          return {
+            ...prev,
+            players: exists ? prev.players : [...prev.players, p],
+          };
+        });
+        break;
+
+      case 'arena_player_left':
+        setArenaState(prev => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            players: prev.players.filter(p => p.id !== msg.playerId),
+          };
+        });
+        break;
+
+      case 'arena_countdown':
+        setCountdownNumber(msg.count);
+        setPhase('countdown');
+        break;
+
+      case 'arena_started': {
+        setGameSeed(msg.gameSeed);
+        setBpm(msg.bpm);
+        serverTimeOffsetRef.current = Date.now() - msg.serverTime;
+        setCountdownNumber(null);
+        setSessionResult(null);
+        setPhase('playing');
+        break;
+      }
+
+      case 'arena_tempo': {
+        setBpm(msg.bpm);
+        setBeatPhase(msg.beatPhase);
+        serverTimeOffsetRef.current = Date.now() - msg.serverTime;
+        break;
+      }
+
+      case 'arena_gimmick':
+        setActiveGimmick(msg.gimmick);
+        break;
+
+      case 'arena_chaos': {
+        setChaosLevel(msg.chaosLevel);
+        setSyncMap(msg.syncMap);
+        break;
+      }
+
+      case 'arena_player_action': {
+        setLastPlayerAction(msg as PlayerActionEvent);
+        break;
+      }
+
+      case 'arena_player_eliminated': {
+        const elim = msg as EliminationEvent;
+        setLastElimination(elim);
+
+        setArenaState(prev => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            players: prev.players.map(p =>
+              p.id === elim.playerId ? { ...p, alive: false, placement: elim.placement } : p
+            ),
+            aliveCount: prev.aliveCount - 1,
+          };
+        });
+        break;
+      }
+
+      case 'arena_relayed': {
+        opponentBoardsRef.current.set(msg.fromPlayerId, msg.payload);
+        setOpponentBoards(new Map(opponentBoardsRef.current));
+        break;
+      }
+
+      case 'arena_session_end': {
+        setSessionResult(msg as ArenaSessionResult);
+        setPhase('ended');
+        break;
+      }
+
+      case 'arena_queued': {
+        setQueuePosition(msg.position);
+        setQueueSize(msg.queueSize);
+        setPhase('queue');
+        break;
+      }
+
+      case 'arena_tempo_collapse': {
+        setLastTempoCollapse(msg as TempoCollapseEvent);
+        break;
+      }
+    }
+  }, [send]);
+
+  const connectWebSocket = useCallback(() => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) return;
+    if (wsRef.current?.readyState === WebSocket.CONNECTING) return;
+
+    setConnectionStatus('connecting');
+    const wsUrl = process.env.NEXT_PUBLIC_MULTIPLAYER_URL || 'ws://localhost:3001';
+    const ws = new WebSocket(wsUrl);
+
+    ws.onopen = () => {
+      setConnectionStatus('connected');
+      setError(null);
+      reconnectAttemptsRef.current = 0;
+      lastPingRef.current = Date.now();
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const message = JSON.parse(event.data);
+        handleServerMessage(message);
+      } catch (err) {
+        console.error('[ARENA WS] Parse error:', err);
+      }
+    };
+
+    ws.onclose = () => {
+      setConnectionStatus('disconnected');
+      wsRef.current = null;
+      if (reconnectTokenRef.current) {
+        scheduleReconnect();
+      }
+    };
+
+    ws.onerror = () => {
+      setConnectionStatus('error');
+    };
+
+    wsRef.current = ws;
+  }, [scheduleReconnect, handleServerMessage]);
+
+  connectWebSocketRef.current = connectWebSocket;
+
+  // Connect on mount
+  useEffect(() => {
+    connectWebSocket();
+
+    pingCheckTimerRef.current = setInterval(() => {
+      if (
+        wsRef.current?.readyState === WebSocket.OPEN &&
+        Date.now() - lastPingRef.current > PING_TIMEOUT
+      ) {
+        wsRef.current.close();
+      }
+    }, 10000);
+
+    return () => {
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+      if (pingCheckTimerRef.current) {
+        clearInterval(pingCheckTimerRef.current);
+        pingCheckTimerRef.current = null;
+      }
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+    };
+  }, [connectWebSocket]);
+
+  // ===== Actions =====
+
+  const queueForArena = useCallback((playerName: string) => {
+    send({ type: 'queue_arena', playerName });
+  }, [send]);
+
+  const cancelQueue = useCallback(() => {
+    send({ type: 'cancel_arena_queue' });
+    setPhase('lobby');
+  }, [send]);
+
+  const createArena = useCallback((playerName: string, roomName?: string) => {
+    send({ type: 'create_arena', playerName, roomName });
+    setPhase('waiting-room');
+  }, [send]);
+
+  const joinArena = useCallback((arenaCode: string, playerName: string) => {
+    send({ type: 'join_arena', arenaCode, playerName });
+  }, [send]);
+
+  const setReady = useCallback((ready: boolean) => {
+    send({ type: 'arena_ready', ready });
+  }, [send]);
+
+  const startArena = useCallback(() => {
+    send({ type: 'arena_start' });
+  }, [send]);
+
+  const sendAction = useCallback((action: ArenaAction) => {
+    send({ type: 'arena_action', action });
+  }, [send]);
+
+  const sendBoardRelay = useCallback((payload: ArenaBoardPayload) => {
+    send({ type: 'arena_relay', payload });
+  }, [send]);
+
+  const leaveArena = useCallback(() => {
+    send({ type: 'arena_leave' });
+    reconnectTokenRef.current = '';
+    sessionStorage.removeItem('arena_reconnectToken');
+    setArenaState(null);
+    setPhase('lobby');
+    setError(null);
+    opponentBoardsRef.current.clear();
+    setOpponentBoards(new Map());
+  }, [send]);
+
+  return {
+    // Connection
+    connectionStatus,
+    connectWebSocket,
+    playerId: playerIdRef.current,
+
+    // Arena state
+    phase,
+    setPhase,
+    arenaState,
+    error,
+    setError,
+    countdownNumber,
+    gameSeed,
+    queuePosition,
+    queueSize,
+
+    // Tempo
+    bpm,
+    beatPhase,
+
+    // Chaos & gimmicks
+    chaosLevel,
+    activeGimmick,
+    syncMap,
+
+    // Events
+    lastPlayerAction,
+    lastElimination,
+    lastTempoCollapse,
+    sessionResult,
+
+    // Opponent boards
+    opponentBoards,
+
+    // Actions
+    queueForArena,
+    cancelQueue,
+    createArena,
+    joinArena,
+    setReady,
+    startArena,
+    sendAction,
+    sendBoardRelay,
+    leaveArena,
+  };
+}

--- a/src/lib/arena/ArenaManager.ts
+++ b/src/lib/arena/ArenaManager.ts
@@ -1,0 +1,823 @@
+import type {
+  ArenaPlayer,
+  ArenaRoomState,
+  ArenaGimmick,
+  ArenaAction,
+  GimmickType,
+  ArenaRanking,
+  ArenaSessionStats,
+} from '@/types/arena';
+import {
+  ARENA_MAX_PLAYERS,
+  ARENA_MIN_PLAYERS,
+  ARENA_BASE_BPM,
+  ARENA_CHAOS_DECAY_RATE,
+  ARENA_CHAOS_GIMMICK_THRESHOLD,
+  ARENA_CHAOS_FRENZY_THRESHOLD,
+  ARENA_TEMPO_COLLAPSE_THRESHOLD,
+  ARENA_TICK_RATE,
+  GIMMICK_DURATIONS,
+  GIMMICK_WEIGHTS,
+} from '@/types/arena';
+
+// ===== Arena Room (Server-side) =====
+
+export interface ArenaRoom {
+  code: string;
+  name: string;
+  hostId: string;
+  players: ArenaPlayer[];
+  status: 'waiting' | 'countdown' | 'playing' | 'ended';
+  maxPlayers: number;
+  createdAt: number;
+  gameStartedAt: number | null;
+  gameSeed: number | null;
+
+  // Tempo engine
+  bpm: number;
+  baseBpm: number;
+  beatPhase: number;
+  lastBeatTime: number;
+  tempoCollapseCount: number;
+
+  // Chaos system
+  chaosLevel: number;
+  peakChaos: number;
+
+  // Gimmick system
+  activeGimmick: ArenaGimmick | null;
+  gimmickCooldown: number;
+  totalGimmicks: number;
+
+  // Player sync tracking
+  syncMap: Map<string, number>;
+
+  // Stats
+  peakBpm: number;
+  lowestBpm: number;
+
+  // Elimination tracking
+  eliminationOrder: string[];
+}
+
+// ===== Callbacks for server integration =====
+
+export interface ArenaCallbacks {
+  onBroadcast: (roomCode: string, message: object, excludePlayerId?: string) => void;
+  onSendToPlayer: (playerId: string, message: object) => void;
+  onSessionEnd: (roomCode: string) => void;
+}
+
+// ===== Arena Room Manager =====
+
+export class ArenaRoomManager {
+  private rooms = new Map<string, ArenaRoom>();
+  private playerToRoom = new Map<string, string>();
+  private tickIntervals = new Map<string, NodeJS.Timeout>();
+  private readonly ROOM_TIMEOUT = 10 * 60 * 1000;
+  private cleanupInterval: NodeJS.Timeout;
+  private callbacks: ArenaCallbacks;
+
+  constructor(callbacks: ArenaCallbacks) {
+    this.callbacks = callbacks;
+    this.cleanupInterval = setInterval(() => this.cleanupStaleRooms(), 60000);
+  }
+
+  // ===== Room Lifecycle =====
+
+  createRoom(
+    playerId: string,
+    playerName: string,
+    roomName?: string,
+  ): { roomCode: string; player: ArenaPlayer } {
+    const roomCode = this.generateRoomCode();
+    const sanitizedName = (playerName || 'Player').slice(0, 20);
+    const sanitizedRoomName = (roomName || `${sanitizedName}'s Arena`).slice(0, 30);
+
+    const player: ArenaPlayer = {
+      id: playerId,
+      name: sanitizedName,
+      ready: false,
+      connected: true,
+      alive: true,
+      score: 0,
+      lines: 0,
+      combo: 0,
+      syncAccuracy: 1.0,
+      chaosContribution: 0,
+      kills: 0,
+      placement: null,
+    };
+
+    const room: ArenaRoom = {
+      code: roomCode,
+      name: sanitizedRoomName,
+      hostId: playerId,
+      players: [player],
+      status: 'waiting',
+      maxPlayers: ARENA_MAX_PLAYERS,
+      createdAt: Date.now(),
+      gameStartedAt: null,
+      gameSeed: null,
+      bpm: ARENA_BASE_BPM,
+      baseBpm: ARENA_BASE_BPM,
+      beatPhase: 0,
+      lastBeatTime: 0,
+      tempoCollapseCount: 0,
+      chaosLevel: 0,
+      peakChaos: 0,
+      activeGimmick: null,
+      gimmickCooldown: 0,
+      totalGimmicks: 0,
+      syncMap: new Map(),
+      peakBpm: ARENA_BASE_BPM,
+      lowestBpm: ARENA_BASE_BPM,
+      eliminationOrder: [],
+    };
+
+    this.rooms.set(roomCode, room);
+    this.playerToRoom.set(playerId, roomCode);
+
+    return { roomCode, player };
+  }
+
+  joinRoom(
+    roomCode: string,
+    playerId: string,
+    playerName: string,
+  ): { success: boolean; error?: string; player?: ArenaPlayer } {
+    const normalized = roomCode.toUpperCase().trim();
+    const room = this.rooms.get(normalized);
+
+    if (!room) return { success: false, error: 'Arena not found' };
+    if (room.status !== 'waiting') return { success: false, error: 'Arena already in progress' };
+    if (room.players.length >= room.maxPlayers) return { success: false, error: 'Arena is full' };
+
+    const existing = room.players.find(p => p.id === playerId);
+    if (existing) {
+      existing.connected = true;
+      return { success: true, player: existing };
+    }
+
+    const player: ArenaPlayer = {
+      id: playerId,
+      name: (playerName || 'Player').slice(0, 20),
+      ready: false,
+      connected: true,
+      alive: true,
+      score: 0,
+      lines: 0,
+      combo: 0,
+      syncAccuracy: 1.0,
+      chaosContribution: 0,
+      kills: 0,
+      placement: null,
+    };
+
+    room.players.push(player);
+    this.playerToRoom.set(playerId, normalized);
+
+    return { success: true, player };
+  }
+
+  setPlayerReady(playerId: string, ready: boolean): { success: boolean; error?: string } {
+    const roomCode = this.playerToRoom.get(playerId);
+    if (!roomCode) return { success: false, error: 'Not in an arena' };
+
+    const room = this.rooms.get(roomCode);
+    if (!room) return { success: false, error: 'Arena not found' };
+    if (room.status !== 'waiting') return { success: false, error: 'Arena already started' };
+
+    const player = room.players.find(p => p.id === playerId);
+    if (!player) return { success: false, error: 'Player not found' };
+
+    player.ready = ready;
+    return { success: true };
+  }
+
+  startGame(playerId: string): { success: boolean; error?: string; gameSeed?: number } {
+    const roomCode = this.playerToRoom.get(playerId);
+    if (!roomCode) return { success: false, error: 'Not in an arena' };
+
+    const room = this.rooms.get(roomCode);
+    if (!room) return { success: false, error: 'Arena not found' };
+    if (room.hostId !== playerId) return { success: false, error: 'Only the host can start' };
+    if (room.players.length < ARENA_MIN_PLAYERS) {
+      return { success: false, error: `Need at least ${ARENA_MIN_PLAYERS} players` };
+    }
+
+    const notReady = room.players.filter(p => !p.ready && p.id !== room.hostId);
+    if (notReady.length > 0) return { success: false, error: 'All players must be ready' };
+
+    const gameSeed = Math.floor(Math.random() * 2147483647);
+    room.status = 'countdown';
+    room.gameSeed = gameSeed;
+
+    return { success: true, gameSeed };
+  }
+
+  beginPlaying(roomCode: string): void {
+    const room = this.rooms.get(roomCode);
+    if (!room || room.status !== 'countdown') return;
+
+    room.status = 'playing';
+    room.gameStartedAt = Date.now();
+    room.lastBeatTime = Date.now();
+
+    // Initialize sync map
+    for (const p of room.players) {
+      room.syncMap.set(p.id, 1.0);
+      p.alive = true;
+      p.score = 0;
+      p.lines = 0;
+      p.combo = 0;
+      p.syncAccuracy = 1.0;
+      p.chaosContribution = 0;
+      p.kills = 0;
+      p.placement = null;
+    }
+
+    // Start the game tick loop
+    this.startTickLoop(roomCode);
+  }
+
+  removePlayer(playerId: string): { roomCode?: string; room?: ArenaRoom } {
+    const roomCode = this.playerToRoom.get(playerId);
+    if (!roomCode) return {};
+
+    const room = this.rooms.get(roomCode);
+    if (!room) {
+      this.playerToRoom.delete(playerId);
+      return {};
+    }
+
+    // During gameplay, mark as eliminated rather than removing
+    if (room.status === 'playing') {
+      const player = room.players.find(p => p.id === playerId);
+      if (player && player.alive) {
+        this.eliminatePlayer(room, playerId, null);
+      }
+    }
+
+    room.players = room.players.filter(p => p.id !== playerId);
+    this.playerToRoom.delete(playerId);
+    room.syncMap.delete(playerId);
+
+    if (room.players.length === 0) {
+      this.stopTickLoop(roomCode);
+      this.rooms.delete(roomCode);
+      return { roomCode };
+    }
+
+    // Transfer host
+    if (room.hostId === playerId) {
+      const next = room.players.find(p => p.connected) || room.players[0];
+      room.hostId = next.id;
+    }
+
+    return { roomCode, room };
+  }
+
+  markDisconnected(playerId: string): { roomCode?: string } {
+    const roomCode = this.playerToRoom.get(playerId);
+    if (!roomCode) return {};
+
+    const room = this.rooms.get(roomCode);
+    if (!room) return {};
+
+    const player = room.players.find(p => p.id === playerId);
+    if (player) {
+      player.connected = false;
+      if (room.status === 'playing' && player.alive) {
+        this.eliminatePlayer(room, playerId, null);
+      }
+    }
+
+    return { roomCode };
+  }
+
+  // ===== Game Actions =====
+
+  handleAction(playerId: string, action: ArenaAction): void {
+    const roomCode = this.playerToRoom.get(playerId);
+    if (!roomCode) return;
+
+    const room = this.rooms.get(roomCode);
+    if (!room || room.status !== 'playing') return;
+
+    const player = room.players.find(p => p.id === playerId);
+    if (!player || !player.alive) return;
+
+    // Calculate beat sync accuracy for this action
+    const beatInterval = 60000 / room.bpm;
+    const now = Date.now();
+    const elapsed = (now - room.lastBeatTime) % beatInterval;
+    const phase = elapsed / beatInterval;
+    const onBeat = phase > 0.75 || phase < 0.15;
+
+    // Update player sync (rolling average)
+    const syncScore = onBeat ? 1.0 : Math.max(0, 1.0 - Math.abs(phase - 0.5) * 2);
+    player.syncAccuracy = player.syncAccuracy * 0.8 + syncScore * 0.2;
+    room.syncMap.set(playerId, player.syncAccuracy);
+
+    // Chaos contribution from actions
+    let chaosIncrease = 0;
+    switch (action.action) {
+      case 'piece_placed':
+        chaosIncrease = 0.5;
+        break;
+      case 'line_clear':
+        chaosIncrease = 2 + (action.value || 1);
+        break;
+      case 'hard_drop':
+        chaosIncrease = 1;
+        break;
+      case 'combo':
+        chaosIncrease = (action.value || 1) * 1.5;
+        break;
+      case 't_spin':
+        chaosIncrease = 4;
+        break;
+      case 'tetris_clear':
+        chaosIncrease = 8;
+        // Tetris clears send garbage to all other alive players
+        this.broadcastGarbageToAll(room, playerId, 2);
+        break;
+      case 'game_over':
+        this.eliminatePlayer(room, playerId, null);
+        return;
+    }
+
+    // Off-beat actions add more chaos
+    if (!onBeat) {
+      chaosIncrease *= 1.5;
+    }
+
+    player.chaosContribution += chaosIncrease;
+    room.chaosLevel = Math.min(100, room.chaosLevel + chaosIncrease);
+    if (room.chaosLevel > room.peakChaos) {
+      room.peakChaos = room.chaosLevel;
+    }
+
+    // Line clears send garbage proportional to lines cleared
+    if (action.action === 'line_clear' && action.value && action.value >= 2) {
+      const garbageLines = Math.max(0, (action.value || 0) - 1);
+      if (garbageLines > 0) {
+        this.broadcastGarbageToAll(room, playerId, garbageLines);
+      }
+    }
+
+    // Broadcast the action to all other players
+    this.callbacks.onBroadcast(roomCode, {
+      type: 'arena_player_action',
+      playerId,
+      playerName: player.name,
+      action,
+      onBeat,
+    }, playerId);
+  }
+
+  handleRelay(playerId: string, payload: object): void {
+    const roomCode = this.playerToRoom.get(playerId);
+    if (!roomCode) return;
+
+    const room = this.rooms.get(roomCode);
+    if (!room || room.status !== 'playing') return;
+
+    // Broadcast board state to all other players
+    this.callbacks.onBroadcast(roomCode, {
+      type: 'arena_relayed',
+      fromPlayerId: playerId,
+      payload,
+    }, playerId);
+  }
+
+  // ===== Tick Loop (Server-authoritative tempo + gimmicks) =====
+
+  private startTickLoop(roomCode: string): void {
+    const tickInterval = 1000 / ARENA_TICK_RATE;
+
+    const interval = setInterval(() => {
+      const room = this.rooms.get(roomCode);
+      if (!room || room.status !== 'playing') {
+        this.stopTickLoop(roomCode);
+        return;
+      }
+
+      this.tick(room);
+    }, tickInterval);
+
+    this.tickIntervals.set(roomCode, interval);
+  }
+
+  private stopTickLoop(roomCode: string): void {
+    const interval = this.tickIntervals.get(roomCode);
+    if (interval) {
+      clearInterval(interval);
+      this.tickIntervals.delete(roomCode);
+    }
+  }
+
+  private tick(room: ArenaRoom): void {
+    const now = Date.now();
+    const elapsed = room.gameStartedAt ? now - room.gameStartedAt : 0;
+
+    // 1. Update beat phase
+    const beatInterval = 60000 / room.bpm;
+    const beatElapsed = (now - room.lastBeatTime) % beatInterval;
+    room.beatPhase = beatElapsed / beatInterval;
+
+    // Track beat transitions
+    if (beatElapsed < beatInterval / ARENA_TICK_RATE) {
+      room.lastBeatTime = now - beatElapsed;
+    }
+
+    // 2. Chaos decay
+    room.chaosLevel = Math.max(0, room.chaosLevel - ARENA_CHAOS_DECAY_RATE / ARENA_TICK_RATE);
+
+    // 3. Calculate average sync
+    const alivePlayers = room.players.filter(p => p.alive && p.connected);
+    const avgSync = alivePlayers.length > 0
+      ? alivePlayers.reduce((sum, p) => sum + p.syncAccuracy, 0) / alivePlayers.length
+      : 0;
+
+    // 4. Tempo adjustment based on sync + chaos
+    this.updateTempo(room, avgSync);
+
+    // 5. Check for tempo collapse
+    if (avgSync < ARENA_TEMPO_COLLAPSE_THRESHOLD && alivePlayers.length > 1) {
+      room.tempoCollapseCount++;
+
+      this.callbacks.onBroadcast(room.code, {
+        type: 'arena_tempo_collapse',
+        avgSync,
+        bpmDeviation: Math.abs(room.bpm - room.baseBpm),
+      });
+
+      // After 3 collapses, end the session
+      if (room.tempoCollapseCount >= 3) {
+        this.endSession(room, 'tempo_collapse');
+        return;
+      }
+    }
+
+    // 6. Gimmick management
+    this.updateGimmicks(room, now);
+
+    // 7. Check win condition
+    if (alivePlayers.length <= 1 && room.players.filter(p => p.alive).length <= 1) {
+      this.endSession(room, 'last_standing');
+      return;
+    }
+
+    // 8. Chaos overload check
+    if (room.chaosLevel >= 100) {
+      this.endSession(room, 'chaos_overload');
+      return;
+    }
+
+    // 9. Broadcast tempo update every 5 ticks (~500ms)
+    if (Math.floor(elapsed / (1000 / ARENA_TICK_RATE)) % 5 === 0) {
+      this.callbacks.onBroadcast(room.code, {
+        type: 'arena_tempo',
+        bpm: room.bpm,
+        beatPhase: room.beatPhase,
+        serverTime: now,
+      });
+    }
+
+    // 10. Broadcast chaos update every 10 ticks (~1s)
+    if (Math.floor(elapsed / (1000 / ARENA_TICK_RATE)) % 10 === 0) {
+      const syncMapObj: Record<string, number> = {};
+      room.syncMap.forEach((v, k) => { syncMapObj[k] = Math.round(v * 100) / 100; });
+
+      this.callbacks.onBroadcast(room.code, {
+        type: 'arena_chaos',
+        chaosLevel: Math.round(room.chaosLevel * 10) / 10,
+        syncMap: syncMapObj,
+      });
+    }
+  }
+
+  private updateTempo(room: ArenaRoom, avgSync: number): void {
+    // Base tempo increases gradually over time
+    const elapsed = room.gameStartedAt ? Date.now() - room.gameStartedAt : 0;
+    const timeScaling = 1 + (elapsed / 120000) * 0.3; // +30% over 2 minutes
+
+    // Sync affects tempo stability
+    // High sync = stable near baseBpm * timeScaling
+    // Low sync = erratic BPM swings
+    const syncFactor = avgSync;
+    const chaosModifier = (room.chaosLevel / 100) * 0.4; // Up to 40% BPM swing from chaos
+
+    const targetBpm = room.baseBpm * timeScaling;
+    const instability = (1 - syncFactor) * 30 + chaosModifier * 20;
+
+    // Add some controlled randomness for instability
+    const jitter = (Math.random() - 0.5) * instability;
+
+    // Smooth towards target with jitter
+    room.bpm = room.bpm * 0.95 + (targetBpm + jitter) * 0.05;
+    room.bpm = Math.max(60, Math.min(240, room.bpm));
+
+    // Track extremes
+    if (room.bpm > room.peakBpm) room.peakBpm = room.bpm;
+    if (room.bpm < room.lowestBpm) room.lowestBpm = room.bpm;
+  }
+
+  private updateGimmicks(room: ArenaRoom, now: number): void {
+    // Check if active gimmick has expired
+    if (room.activeGimmick) {
+      const elapsed = now - room.activeGimmick.startedAt;
+      if (elapsed >= room.activeGimmick.durationMs) {
+        room.activeGimmick = null;
+      }
+    }
+
+    // Cooldown
+    if (room.gimmickCooldown > 0) {
+      room.gimmickCooldown -= 1000 / ARENA_TICK_RATE;
+      return;
+    }
+
+    // Spawn gimmick based on chaos level
+    if (!room.activeGimmick && room.chaosLevel >= ARENA_CHAOS_GIMMICK_THRESHOLD) {
+      const shouldSpawn = Math.random() < (room.chaosLevel / 100) * 0.02; // Higher chaos = more likely
+      if (shouldSpawn) {
+        const gimmick = this.pickRandomGimmick(room);
+        room.activeGimmick = gimmick;
+        room.totalGimmicks++;
+        room.gimmickCooldown = 5000; // 5 second minimum between gimmicks
+
+        this.callbacks.onBroadcast(room.code, {
+          type: 'arena_gimmick',
+          gimmick,
+        });
+
+        // Apply gimmick effects
+        this.applyGimmickEffect(room, gimmick);
+      }
+    }
+  }
+
+  private pickRandomGimmick(room: ArenaRoom): ArenaGimmick {
+    // Weight selection
+    const types = Object.keys(GIMMICK_WEIGHTS) as GimmickType[];
+    const weights = types.map(t => GIMMICK_WEIGHTS[t]);
+    const totalWeight = weights.reduce((a, b) => a + b, 0);
+    let rand = Math.random() * totalWeight;
+
+    let selectedType: GimmickType = 'tempo_shift';
+    for (let i = 0; i < types.length; i++) {
+      rand -= weights[i];
+      if (rand <= 0) {
+        selectedType = types[i];
+        break;
+      }
+    }
+
+    // Intensity scales with chaos
+    const intensity = room.chaosLevel >= ARENA_CHAOS_FRENZY_THRESHOLD ? 3
+      : room.chaosLevel >= ARENA_CHAOS_GIMMICK_THRESHOLD + 20 ? 2 : 1;
+
+    return {
+      type: selectedType,
+      durationMs: GIMMICK_DURATIONS[selectedType] * (1 + (intensity - 1) * 0.3),
+      intensity,
+      startedAt: Date.now(),
+    };
+  }
+
+  private applyGimmickEffect(room: ArenaRoom, gimmick: ArenaGimmick): void {
+    switch (gimmick.type) {
+      case 'tempo_shift': {
+        const shift = gimmick.intensity * 20 * (Math.random() > 0.5 ? 1 : -1);
+        room.bpm = Math.max(60, Math.min(240, room.bpm + shift));
+        break;
+      }
+      case 'garbage_rain': {
+        // Send garbage to everyone
+        const lines = gimmick.intensity;
+        for (const p of room.players) {
+          if (p.alive && p.connected) {
+            this.callbacks.onSendToPlayer(p.id, {
+              type: 'arena_relayed',
+              fromPlayerId: 'GIMMICK',
+              payload: {
+                event: 'garbage',
+                lines,
+              },
+            });
+          }
+        }
+        break;
+      }
+      // Other gimmick effects are handled client-side based on the broadcast
+    }
+  }
+
+  // ===== Player Elimination =====
+
+  private eliminatePlayer(room: ArenaRoom, playerId: string, eliminatedBy: string | null): void {
+    const player = room.players.find(p => p.id === playerId);
+    if (!player || !player.alive) return;
+
+    player.alive = false;
+    const aliveCount = room.players.filter(p => p.alive).length;
+    player.placement = aliveCount + 1;
+    room.eliminationOrder.push(playerId);
+
+    // Credit the eliminator
+    if (eliminatedBy) {
+      const killer = room.players.find(p => p.id === eliminatedBy);
+      if (killer) killer.kills++;
+    }
+
+    this.callbacks.onBroadcast(room.code, {
+      type: 'arena_player_eliminated',
+      playerId,
+      playerName: player.name,
+      placement: player.placement,
+      eliminatedBy,
+    });
+  }
+
+  private broadcastGarbageToAll(room: ArenaRoom, fromPlayerId: string, lines: number): void {
+    for (const p of room.players) {
+      if (p.id !== fromPlayerId && p.alive && p.connected) {
+        this.callbacks.onSendToPlayer(p.id, {
+          type: 'arena_relayed',
+          fromPlayerId,
+          payload: {
+            event: 'garbage',
+            lines,
+          },
+        });
+      }
+    }
+  }
+
+  // ===== Session End =====
+
+  private endSession(
+    room: ArenaRoom,
+    reason: 'last_standing' | 'tempo_collapse' | 'chaos_overload',
+  ): void {
+    room.status = 'ended';
+    this.stopTickLoop(room.code);
+
+    // Determine winner
+    const alivePlayers = room.players.filter(p => p.alive);
+    let winnerId: string | null = null;
+    let winnerName: string | null = null;
+
+    if (alivePlayers.length === 1) {
+      winnerId = alivePlayers[0].id;
+      winnerName = alivePlayers[0].name;
+      alivePlayers[0].placement = 1;
+    } else if (alivePlayers.length > 1) {
+      // Multiple survivors: winner = highest score
+      alivePlayers.sort((a, b) => b.score - a.score);
+      for (let i = 0; i < alivePlayers.length; i++) {
+        alivePlayers[i].placement = i + 1;
+      }
+      winnerId = alivePlayers[0].id;
+      winnerName = alivePlayers[0].name;
+    }
+
+    // Build rankings
+    const rankings: ArenaRanking[] = room.players
+      .filter(p => p.placement !== null)
+      .sort((a, b) => (a.placement || 999) - (b.placement || 999))
+      .map(p => ({
+        playerId: p.id,
+        playerName: p.name,
+        placement: p.placement!,
+        score: p.score,
+        lines: p.lines,
+        kills: p.kills,
+        avgSync: Math.round(p.syncAccuracy * 100) / 100,
+      }));
+
+    const stats: ArenaSessionStats = {
+      totalDurationMs: room.gameStartedAt ? Date.now() - room.gameStartedAt : 0,
+      peakChaos: Math.round(room.peakChaos * 10) / 10,
+      totalGimmicks: room.totalGimmicks,
+      tempoCollapses: room.tempoCollapseCount,
+      peakBpm: Math.round(room.peakBpm),
+      lowestBpm: Math.round(room.lowestBpm),
+    };
+
+    this.callbacks.onBroadcast(room.code, {
+      type: 'arena_session_end',
+      reason,
+      winnerId,
+      winnerName,
+      rankings,
+      stats,
+    });
+
+    this.callbacks.onSessionEnd(room.code);
+  }
+
+  // ===== Queries =====
+
+  getRoomState(roomCode: string): ArenaRoomState | null {
+    const room = this.rooms.get(roomCode.toUpperCase().trim());
+    if (!room) return null;
+
+    return {
+      code: room.code,
+      name: room.name,
+      hostId: room.hostId,
+      players: room.players.map(p => ({ ...p })),
+      status: room.status,
+      maxPlayers: room.maxPlayers,
+      bpm: Math.round(room.bpm * 10) / 10,
+      beatPhase: room.beatPhase,
+      chaosLevel: Math.round(room.chaosLevel * 10) / 10,
+      activeGimmick: room.activeGimmick,
+      aliveCount: room.players.filter(p => p.alive).length,
+      elapsedMs: room.gameStartedAt ? Date.now() - room.gameStartedAt : 0,
+    };
+  }
+
+  getRoomByPlayerId(playerId: string): ArenaRoom | null {
+    const code = this.playerToRoom.get(playerId);
+    if (!code) return null;
+    return this.rooms.get(code) || null;
+  }
+
+  getPlayerIdsInRoom(roomCode: string): string[] {
+    const room = this.rooms.get(roomCode.toUpperCase().trim());
+    if (!room) return [];
+    return room.players.filter(p => p.connected).map(p => p.id);
+  }
+
+  getPublicArenas(): { code: string; name: string; playerCount: number; maxPlayers: number }[] {
+    const result: { code: string; name: string; playerCount: number; maxPlayers: number }[] = [];
+    this.rooms.forEach(room => {
+      if (room.status === 'waiting' && room.players.length < room.maxPlayers) {
+        result.push({
+          code: room.code,
+          name: room.name,
+          playerCount: room.players.length,
+          maxPlayers: room.maxPlayers,
+        });
+      }
+    });
+    return result;
+  }
+
+  getRoomCount(): number {
+    return this.rooms.size;
+  }
+
+  // ===== Utilities =====
+
+  private generateRoomCode(): string {
+    const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+    let code: string;
+    let attempts = 0;
+    do {
+      code = 'A'; // Prefix A for arena rooms
+      const len = attempts > 100 ? 5 : 4;
+      for (let i = 1; i < len; i++) {
+        code += chars.charAt(Math.floor(Math.random() * chars.length));
+      }
+      attempts++;
+    } while (this.rooms.has(code));
+    return code;
+  }
+
+  private cleanupStaleRooms(): void {
+    const now = Date.now();
+    const toDelete: string[] = [];
+
+    this.rooms.forEach((room, code) => {
+      const connected = room.players.filter(p => p.connected);
+      if (connected.length === 0 && now - room.createdAt > this.ROOM_TIMEOUT) {
+        toDelete.push(code);
+      }
+      if (room.status === 'ended' && now - (room.gameStartedAt || room.createdAt) > this.ROOM_TIMEOUT) {
+        toDelete.push(code);
+      }
+    });
+
+    toDelete.forEach(code => {
+      this.stopTickLoop(code);
+      const room = this.rooms.get(code);
+      if (room) {
+        room.players.forEach(p => this.playerToRoom.delete(p.id));
+      }
+      this.rooms.delete(code);
+      console.log(`[ARENA CLEANUP] Removed stale arena ${code}`);
+    });
+  }
+
+  destroy(): void {
+    clearInterval(this.cleanupInterval);
+    this.tickIntervals.forEach(interval => clearInterval(interval));
+    this.tickIntervals.clear();
+  }
+}

--- a/src/types/arena.ts
+++ b/src/types/arena.ts
@@ -1,0 +1,345 @@
+// ===== Arena Types — 9-Player Multiplayer Arena =====
+// All nine players participate simultaneously with shared tempo,
+// synchronized music, communal gimmicks, and a chaos system.
+
+import type { BoardCell } from './multiplayer';
+
+// ===== Arena Constants =====
+
+export const ARENA_MAX_PLAYERS = 9;
+export const ARENA_MIN_PLAYERS = 3;
+export const ARENA_QUEUE_TIMEOUT = 30000; // 30s before filling with AI
+export const ARENA_TICK_RATE = 10; // Server ticks per second
+export const ARENA_BASE_BPM = 120;
+export const ARENA_CHAOS_DECAY_RATE = 0.5; // Per second
+export const ARENA_CHAOS_GIMMICK_THRESHOLD = 40;
+export const ARENA_CHAOS_FRENZY_THRESHOLD = 75;
+export const ARENA_TEMPO_COLLAPSE_THRESHOLD = 0.3; // If avg sync < 30%, tempo collapses
+
+// ===== Arena Player =====
+
+export interface ArenaPlayer {
+  id: string;
+  name: string;
+  ready: boolean;
+  connected: boolean;
+  alive: boolean;
+  score: number;
+  lines: number;
+  combo: number;
+  /** 0.0 - 1.0: how well this player is synced to the beat */
+  syncAccuracy: number;
+  /** Contribution to the chaos meter this tick */
+  chaosContribution: number;
+  /** Number of eliminations this player caused */
+  kills: number;
+  placement: number | null;
+}
+
+// ===== Arena Room State =====
+
+export interface ArenaRoomState {
+  code: string;
+  name: string;
+  hostId: string;
+  players: ArenaPlayer[];
+  status: 'waiting' | 'countdown' | 'playing' | 'ended';
+  maxPlayers: number;
+  /** Current global BPM — authoritative from server */
+  bpm: number;
+  /** Current beat phase 0.0-1.0 for sync reference */
+  beatPhase: number;
+  /** Global chaos meter 0-100 */
+  chaosLevel: number;
+  /** Active gimmick, if any */
+  activeGimmick: ArenaGimmick | null;
+  /** Number of players still alive */
+  aliveCount: number;
+  /** Total elapsed time in ms since game start */
+  elapsedMs: number;
+}
+
+// ===== Gimmick System =====
+
+export type GimmickType =
+  | 'tempo_shift'      // BPM suddenly changes (faster or slower)
+  | 'gravity_surge'    // All pieces fall much faster
+  | 'mirror_mode'      // Controls are reversed for everyone
+  | 'garbage_rain'     // Everyone receives garbage lines
+  | 'blackout'         // Brief screen dimming / visibility reduction
+  | 'speed_frenzy'     // Everything speeds up dramatically
+  | 'freeze_frame'     // Brief input delay for all
+  | 'shuffle_preview'; // Next piece queues get shuffled
+
+export interface ArenaGimmick {
+  type: GimmickType;
+  /** Duration in milliseconds */
+  durationMs: number;
+  /** Intensity 1-3, affects severity */
+  intensity: number;
+  /** Timestamp when gimmick started */
+  startedAt: number;
+  /** Additional data depending on type */
+  data?: Record<string, number | string | boolean>;
+}
+
+export const GIMMICK_DURATIONS: Record<GimmickType, number> = {
+  tempo_shift: 8000,
+  gravity_surge: 5000,
+  mirror_mode: 6000,
+  garbage_rain: 1000, // Instant burst
+  blackout: 3000,
+  speed_frenzy: 5000,
+  freeze_frame: 2000,
+  shuffle_preview: 1000, // Instant
+};
+
+export const GIMMICK_WEIGHTS: Record<GimmickType, number> = {
+  tempo_shift: 20,
+  gravity_surge: 15,
+  mirror_mode: 10,
+  garbage_rain: 20,
+  blackout: 10,
+  speed_frenzy: 15,
+  freeze_frame: 5,
+  shuffle_preview: 5,
+};
+
+// ===== Action Types (player → server) =====
+
+export type ArenaActionType =
+  | 'piece_placed'
+  | 'line_clear'
+  | 'hard_drop'
+  | 'combo'
+  | 't_spin'
+  | 'tetris_clear'  // 4-line clear
+  | 'game_over';
+
+export interface ArenaAction {
+  action: ArenaActionType;
+  /** Beat phase when action occurred (client-reported) */
+  beatPhase: number;
+  /** Additional context */
+  value?: number;
+}
+
+// ===== Client → Server Messages =====
+
+export interface CreateArenaMessage {
+  type: 'create_arena';
+  playerName: string;
+  roomName?: string;
+}
+
+export interface JoinArenaMessage {
+  type: 'join_arena';
+  arenaCode: string;
+  playerName: string;
+}
+
+export interface QueueArenaMessage {
+  type: 'queue_arena';
+  playerName: string;
+}
+
+export interface CancelArenaQueueMessage {
+  type: 'cancel_arena_queue';
+}
+
+export interface ArenaReadyMessage {
+  type: 'arena_ready';
+  ready: boolean;
+}
+
+export interface ArenaStartMessage {
+  type: 'arena_start';
+}
+
+export interface ArenaActionMessage {
+  type: 'arena_action';
+  action: ArenaAction;
+}
+
+export interface ArenaRelayMessage {
+  type: 'arena_relay';
+  payload: ArenaBoardPayload;
+}
+
+export interface ArenaLeaveMessage {
+  type: 'arena_leave';
+}
+
+export type ArenaClientMessage =
+  | CreateArenaMessage
+  | JoinArenaMessage
+  | QueueArenaMessage
+  | CancelArenaQueueMessage
+  | ArenaReadyMessage
+  | ArenaStartMessage
+  | ArenaActionMessage
+  | ArenaRelayMessage
+  | ArenaLeaveMessage;
+
+// ===== Server → Client Messages =====
+
+export interface ArenaCreatedMessage {
+  type: 'arena_created';
+  arenaCode: string;
+  playerId: string;
+  reconnectToken: string;
+}
+
+export interface ArenaJoinedMessage {
+  type: 'arena_joined';
+  arenaCode: string;
+  playerId: string;
+  arenaState: ArenaRoomState;
+  reconnectToken: string;
+}
+
+export interface ArenaStateMessage {
+  type: 'arena_state';
+  arenaState: ArenaRoomState;
+}
+
+export interface ArenaPlayerJoinedMessage {
+  type: 'arena_player_joined';
+  player: ArenaPlayer;
+}
+
+export interface ArenaPlayerLeftMessage {
+  type: 'arena_player_left';
+  playerId: string;
+}
+
+export interface ArenaCountdownMessage {
+  type: 'arena_countdown';
+  count: number;
+}
+
+export interface ArenaStartedMessage {
+  type: 'arena_started';
+  gameSeed: number;
+  bpm: number;
+  serverTime: number;
+  players: string[];
+}
+
+export interface ArenaTempoMessage {
+  type: 'arena_tempo';
+  bpm: number;
+  beatPhase: number;
+  /** Server timestamp for sync calibration */
+  serverTime: number;
+}
+
+export interface ArenaGimmickMessage {
+  type: 'arena_gimmick';
+  gimmick: ArenaGimmick;
+}
+
+export interface ArenaChaosMessage {
+  type: 'arena_chaos';
+  chaosLevel: number;
+  /** Per-player sync accuracy array */
+  syncMap: Record<string, number>;
+}
+
+export interface ArenaPlayerActionMessage {
+  type: 'arena_player_action';
+  playerId: string;
+  playerName: string;
+  action: ArenaAction;
+  /** Whether this action was on-beat */
+  onBeat: boolean;
+}
+
+export interface ArenaPlayerEliminatedMessage {
+  type: 'arena_player_eliminated';
+  playerId: string;
+  playerName: string;
+  placement: number;
+  eliminatedBy: string | null;
+}
+
+export interface ArenaRelayedMessage {
+  type: 'arena_relayed';
+  fromPlayerId: string;
+  payload: ArenaBoardPayload;
+}
+
+export interface ArenaSessionEndMessage {
+  type: 'arena_session_end';
+  reason: 'last_standing' | 'tempo_collapse' | 'chaos_overload';
+  winnerId: string | null;
+  winnerName: string | null;
+  rankings: ArenaRanking[];
+  /** Final stats */
+  stats: ArenaSessionStats;
+}
+
+export interface ArenaQueuedMessage {
+  type: 'arena_queued';
+  position: number;
+  queueSize: number;
+}
+
+export interface ArenaTempoCollapseMessage {
+  type: 'arena_tempo_collapse';
+  /** Current average sync across all players */
+  avgSync: number;
+  /** How much BPM is deviating */
+  bpmDeviation: number;
+}
+
+export type ArenaServerMessage =
+  | ArenaCreatedMessage
+  | ArenaJoinedMessage
+  | ArenaStateMessage
+  | ArenaPlayerJoinedMessage
+  | ArenaPlayerLeftMessage
+  | ArenaCountdownMessage
+  | ArenaStartedMessage
+  | ArenaTempoMessage
+  | ArenaGimmickMessage
+  | ArenaChaosMessage
+  | ArenaPlayerActionMessage
+  | ArenaPlayerEliminatedMessage
+  | ArenaRelayedMessage
+  | ArenaSessionEndMessage
+  | ArenaQueuedMessage
+  | ArenaTempoCollapseMessage;
+
+// ===== Relay Payload =====
+
+export interface ArenaBoardPayload {
+  board: (BoardCell | null)[][];
+  score: number;
+  lines: number;
+  combo: number;
+  piece?: string;
+  hold?: string | null;
+  alive: boolean;
+}
+
+// ===== Session Stats =====
+
+export interface ArenaRanking {
+  playerId: string;
+  playerName: string;
+  placement: number;
+  score: number;
+  lines: number;
+  kills: number;
+  avgSync: number;
+}
+
+export interface ArenaSessionStats {
+  totalDurationMs: number;
+  peakChaos: number;
+  totalGimmicks: number;
+  tempoCollapses: number;
+  peakBpm: number;
+  lowestBpm: number;
+}


### PR DESCRIPTION
## Summary
Introduces a new "Mix Mode" game variant that combines vanilla terrain destruction mechanics with tower defense enemy spawning and combat. Players must simultaneously destroy terrain blocks and defend against enemies, with a mana system to manage bullet firing costs. After clearing all 5 worlds, players enter a pre-stage upgrade screen to choose between increasing max HP or max Mana before the next difficulty cycle begins.

## Key Changes

### New Game Mode: Mix Mode
- Added `'mix'` as a new `GameMode` type alongside vanilla and TD
- Mix mode spawns enemies at a reduced rate (every 2 beats vs. every beat in TD)
- Line clears damage terrain AND kill enemies simultaneously
- Introduced mana system: players gain mana from line clears and beat regeneration, spend mana to fire bullets

### Mana System (Mix Mode)
- Added mana state management (`mana`, `maxMana`) to `useGameState`
- Mana regenerates 3 points per beat
- Line clears grant 10 mana per line
- Bullets cost 15 mana each to fire
- Mana bar displayed alongside health HUD

### Pre-Stage Upgrade Screen
- New `PreStageScreen` component shown after clearing all 5 worlds
- Players choose between:
  - **Max HP +25**: Increases max health and restores to full
  - **Max Mana +25**: Increases max mana and restores to full
- Cycle counter increments; difficulty scales 15% harder per cycle
- Resets world index and clears enemies/bullets for fresh start

### UI & Visual Updates
- Added "MIX MODE" button to title screen with ⚔️ icon
- Mix mode terrain gauge displays with purple/orange gradient
- New `PRE_STAGE` game phase with golden "ALL WORLDS CLEARED" overlay
- Game phase indicator shows "UPGRADE" during pre-stage
- Cycle counter displayed during gameplay (after first cycle)
- New CSS styles for pre-stage buttons, overlay, and animations

### Constants & Configuration
- Added Mix Mode constants: enemy spawn rates, damage values, mana costs, upgrade bonuses, difficulty scaling
- Configurable via `MIX_*` constants in `constants.ts`

### Game Loop Integration
- Beat logic updated to handle Mix Mode: terrain destruction + enemy spawning + mana regen
- Bullet firing now checks mana availability in Mix Mode
- World transition messages updated to show "MIX" suffix and "ワールドクリア！" (World Clear!)
- Terrain progress component renders Mix Mode-specific gauge

## Implementation Details
- Mix mode uses `MIX_INITIAL_MAX_HP` (100) and `MIX_INITIAL_MAX_MANA` (100) as starting values
- Enemy spawn interval controlled by `mixBeatCountRef` counter
- Difficulty scaling applies to enemy speed/spawn rate per cycle via `MIX_DIFFICULTY_SCALE_PER_CYCLE`
- Pre-stage upgrade choice triggers `applyPreStageUpgrade` callback, which increments cycle and resets gameplay state
- Mana system uses refs (`manaRef`, `maxManaRef`) for efficient access in game loop callbacks

https://claude.ai/code/session_01HZCYEjCvGqScgy2qUHCiND