### PR TITLE
Implement lock delay mechanics for Tetris gameplay

### DIFF
--- a/src/components/rhythmia/tetris/constants.ts
+++ b/src/components/rhythmia/tetris/constants.ts
@@ -136,6 +136,10 @@ export const DEFAULT_ARR = 33;   // Auto Repeat Rate - delay between each auto-r
 // Set to 0 for instant movement (common in competitive play)
 export const DEFAULT_SDF = 50;   // Soft Drop Factor - soft drop speed in ms
 
+// ===== Lock Delay Settings =====
+export const LOCK_DELAY = 500;     // Grace period (ms) after piece lands before locking
+export const MAX_LOCK_MOVES = 15;  // Max moves/rotations on ground before forced lock
+
 // ===== Terrain Settings =====
 // Voxel blocks destroyed per cleared line (multiplied by beat multiplier)
 export const TERRAIN_DAMAGE_PER_LINE = 4;

--- a/src/components/rhythmia/tetris/tetris.tsx
+++ b/src/components/rhythmia/tetris/tetris.tsx
@@ -5,7 +5,7 @@ import dynamic from 'next/dynamic';
 import styles from './VanillaGame.module.css';
 
 // Constants and Types
-import { WORLDS, BOARD_WIDTH, BOARD_HEIGHT, TERRAIN_DAMAGE_PER_LINE, TERRAIN_PARTICLES_PER_LINE, ENEMIES_PER_BEAT, ENEMIES_KILLED_PER_LINE, ENEMY_REACH_DAMAGE, MAX_HEALTH, BULLET_FIRE_INTERVAL } from './constants';
+import { WORLDS, BOARD_WIDTH, BOARD_HEIGHT, TERRAIN_DAMAGE_PER_LINE, TERRAIN_PARTICLES_PER_LINE, ENEMIES_PER_BEAT, ENEMIES_KILLED_PER_LINE, ENEMY_REACH_DAMAGE, MAX_HEALTH, BULLET_FIRE_INTERVAL, LOCK_DELAY, MAX_LOCK_MOVES } from './constants';
 import type { Piece, GameMode } from './types';
 
 // Advancements
@@ -112,6 +112,10 @@ export default function Rhythmia() {
   const advRecordedRef = useRef(false);
   const liveNotifiedRef = useRef<Set<string>>(new Set());
   const [toastIds, setToastIds] = useState<string[]>([]);
+
+  // Lock delay — grace period after piece lands before locking
+  const lockStartTimeRef = useRef<number | null>(null);
+  const lockMovesRef = useRef(0);
 
   // Stable refs for callbacks used inside setInterval (avoids stale closures + dep churn)
   const vfxEmitRef = useRef(vfx.emit);
@@ -279,6 +283,25 @@ export default function Rhythmia() {
     return false;
   }, [currentPiece, gameOver, isPaused, setCurrentPiece, currentPieceRef, boardRef]);
 
+  // Horizontal move with lock delay reset
+  const moveHorizontal = useCallback((dx: number): boolean => {
+    const result = movePiece(dx, 0);
+    if (result && lockStartTimeRef.current !== null) {
+      const piece = currentPieceRef.current;
+      if (piece) {
+        if (isValidPosition({ ...piece, y: piece.y + 1 }, boardRef.current)) {
+          // Moved off ground
+          lockStartTimeRef.current = null;
+        } else if (lockMovesRef.current < MAX_LOCK_MOVES) {
+          // Still on ground — reset lock timer
+          lockMovesRef.current++;
+          lockStartTimeRef.current = performance.now();
+        }
+      }
+    }
+    return result;
+  }, [movePiece, currentPieceRef, boardRef]);
+
   // Rotate piece
   const rotatePiece = useCallback((direction: 1 | -1) => {
     if (!currentPiece || gameOver || isPaused) return;
@@ -300,6 +323,18 @@ export default function Rhythmia() {
       setCurrentPiece(rotatedPiece);
       currentPieceRef.current = rotatedPiece;
       playRotateSound();
+
+      // Reset lock delay on successful rotation
+      if (lockStartTimeRef.current !== null) {
+        if (isValidPosition({ ...rotatedPiece, y: rotatedPiece.y + 1 }, boardRef.current)) {
+          // Rotation moved piece off ground (e.g. wall kick)
+          lockStartTimeRef.current = null;
+        } else if (lockMovesRef.current < MAX_LOCK_MOVES) {
+          // Still on ground — reset lock timer
+          lockMovesRef.current++;
+          lockStartTimeRef.current = performance.now();
+        }
+      }
     }
   }, [currentPiece, gameOver, isPaused, setCurrentPiece, currentPieceRef, boardRef, gameOverRef, isPausedRef, playRotateSound]);
 
@@ -319,23 +354,23 @@ export default function Rhythmia() {
         state.lastMoveTime = currentTime;
 
         if (currentArr === 0) {
-          while (movePiece(dx, 0)) { }
+          while (moveHorizontal(dx)) { }
         } else {
-          movePiece(dx, 0);
+          moveHorizontal(dx);
         }
       }
     } else {
       if (currentArr === 0) {
-        while (movePiece(dx, 0)) { }
+        while (moveHorizontal(dx)) { }
       } else {
         const timeSinceLastMove = currentTime - state.lastMoveTime;
         if (timeSinceLastMove >= currentArr) {
-          movePiece(dx, 0);
+          moveHorizontal(dx);
           state.lastMoveTime = currentTime;
         }
       }
     }
-  }, [movePiece, keyStatesRef, isPausedRef, gameOverRef, dasRef, arrRef]);
+  }, [moveHorizontal, keyStatesRef, isPausedRef, gameOverRef, dasRef, arrRef]);
 
   // Process soft drop (SDF)
   const processSoftDrop = useCallback((currentTime: number) => {
@@ -379,6 +414,10 @@ export default function Rhythmia() {
 
   // Handle piece locking and game advancement — branches by game mode
   const handlePieceLock = useCallback((piece: Piece, dropDistance = 0) => {
+    // Clear lock state for new piece
+    lockStartTimeRef.current = null;
+    lockMovesRef.current = 0;
+
     const mode = gameModeRef.current;
 
     // Beat judgment
@@ -509,6 +548,10 @@ export default function Rhythmia() {
     getBoardCenter, spawnTerrainParticles, spawnItemDrops, pushLiveAdvancementCheck,
   ]);
 
+  // Stable ref for handlePieceLock — used in game loop to avoid dep churn
+  const handlePieceLockRef = useRef(handlePieceLock);
+  handlePieceLockRef.current = handlePieceLock;
+
   // Hard drop
   const hardDrop = useCallback(() => {
     if (!currentPiece || gameOver || isPaused) return;
@@ -537,6 +580,10 @@ export default function Rhythmia() {
       });
     }
 
+    // Hard drop bypasses lock delay — lock immediately
+    lockStartTimeRef.current = null;
+    lockMovesRef.current = 0;
+
     playHardDropSound();
     handlePieceLock(newPiece, dropDistance);
   }, [currentPiece, gameOver, isPaused, currentPieceRef, gameOverRef, isPausedRef, boardRef, handlePieceLock, playHardDropSound]);
@@ -544,6 +591,10 @@ export default function Rhythmia() {
   // Hold current piece
   const holdCurrentPiece = useCallback(() => {
     if (!currentPiece || gameOver || isPaused || !canHold) return;
+
+    // Clear lock state — swapping to a new piece
+    lockStartTimeRef.current = null;
+    lockMovesRef.current = 0;
 
     const currentType = currentPiece.type;
 
@@ -575,7 +626,7 @@ export default function Rhythmia() {
     currentPieceRef, playRotateSound,
   ]);
 
-  // Gravity tick
+  // Gravity tick — moves piece down; lock delay is handled in the game loop
   const tick = useCallback(() => {
     if (!currentPiece || gameOver || isPaused) return;
     const piece = currentPieceRef.current;
@@ -589,10 +640,9 @@ export default function Rhythmia() {
     if (isValidPosition(newPiece, boardRef.current)) {
       setCurrentPiece(newPiece);
       currentPieceRef.current = newPiece;
-    } else {
-      handlePieceLock(piece);
     }
-  }, [currentPiece, gameOver, isPaused, currentPieceRef, gameOverRef, isPausedRef, boardRef, setCurrentPiece, handlePieceLock]);
+    // If piece can't move down, do nothing — lock delay check in game loop handles it
+  }, [currentPiece, gameOver, isPaused, currentPieceRef, gameOverRef, isPausedRef, boardRef, setCurrentPiece]);
 
   // Stable callback for toast dismiss — avoids resetting the toast timer on every render
   const dismissToast = useCallback(() => setToastIds([]), []);
@@ -611,6 +661,8 @@ export default function Rhythmia() {
     gameWorldsClearedRef.current = 0;
     advRecordedRef.current = false;
     liveNotifiedRef.current = new Set();
+    lockStartTimeRef.current = null;
+    lockMovesRef.current = 0;
     setToastIds([]);
   }, [initAudio, initGame]);
 
@@ -639,6 +691,10 @@ export default function Rhythmia() {
   useEffect(() => {
     if (!isPaused && isPlaying && !gameOver) {
       lastBeatRef.current = Date.now();
+      // Reset lock delay timer on unpause to prevent instant lock from elapsed time
+      if (lockStartTimeRef.current !== null) {
+        lockStartTimeRef.current = performance.now();
+      }
     }
   }, [isPaused, isPlaying, gameOver, lastBeatRef]);
 
@@ -781,6 +837,21 @@ export default function Rhythmia() {
           tick();
           lastGravityRef.current = currentTime;
         }
+
+        // Lock delay check — piece gets a grace period on ground before locking
+        const piece = currentPieceRef.current;
+        if (piece) {
+          const onGround = !isValidPosition({ ...piece, y: piece.y + 1 }, boardRef.current);
+          if (onGround) {
+            if (lockStartTimeRef.current === null) {
+              lockStartTimeRef.current = currentTime;
+            } else if (currentTime - lockStartTimeRef.current >= LOCK_DELAY) {
+              handlePieceLockRef.current(piece);
+            }
+          } else {
+            lockStartTimeRef.current = null;
+          }
+        }
       }
 
       gameLoopRef.current = requestAnimationFrame(gameLoop);
@@ -832,7 +903,7 @@ export default function Rhythmia() {
               lastMoveTime: currentTime,
               pressTime: currentTime,
             };
-            if (!isPaused) movePiece(-1, 0);
+            if (!isPaused) moveHorizontal(-1);
           }
           break;
 
@@ -846,7 +917,7 @@ export default function Rhythmia() {
               lastMoveTime: currentTime,
               pressTime: currentTime,
             };
-            if (!isPaused) movePiece(1, 0);
+            if (!isPaused) moveHorizontal(1);
           }
           break;
 
@@ -924,7 +995,7 @@ export default function Rhythmia() {
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('keyup', handleKeyUp);
     };
-  }, [isPlaying, isPaused, gameOver, showCraftUI, movePiece, rotatePiece, hardDrop, holdCurrentPiece, setScore, setIsPaused, keyStatesRef, toggleCraftUI]);
+  }, [isPlaying, isPaused, gameOver, showCraftUI, moveHorizontal, movePiece, rotatePiece, hardDrop, holdCurrentPiece, setScore, setIsPaused, keyStatesRef, toggleCraftUI]);
 
   const world = WORLDS[worldIdx];
 
@@ -1031,8 +1102,8 @@ export default function Rhythmia() {
           </div>
 
           <TouchControls
-            onMoveLeft={() => movePiece(-1, 0)}
-            onMoveRight={() => movePiece(1, 0)}
+            onMoveLeft={() => moveHorizontal(-1)}
+            onMoveRight={() => moveHorizontal(1)}
             onMoveDown={() => movePiece(0, 1)}
             onRotateCW={() => rotatePiece(1)}
             onRotateCCW={() => rotatePiece(-1)}


### PR DESCRIPTION
## Summary
Adds lock delay mechanics to the Tetris game, giving players a grace period after a piece lands before it automatically locks in place. This is a standard Tetris feature that allows for last-second positioning adjustments and prevents pieces from locking too quickly.

## Key Changes

- **New Constants**: Added `LOCK_DELAY` (500ms grace period) and `MAX_LOCK_MOVES` (15 moves/rotations allowed on ground) to `constants.ts`

- **Lock State Management**: Introduced refs to track lock delay state:
  - `lockStartTimeRef`: Timestamp when piece first touches ground
  - `lockMovesRef`: Counter for moves/rotations performed while on ground

- **New `moveHorizontal()` Function**: Wraps `movePiece()` to reset lock delay when moving horizontally on the ground, with a move counter limit to prevent infinite delays

- **Rotation Lock Reset**: Updated `rotatePiece()` to reset lock delay on successful rotations (including wall kicks), respecting the move counter limit

- **Game Loop Lock Check**: Added lock delay logic to the main game loop that:
  - Starts the lock timer when a piece first touches ground
  - Locks the piece if the timer exceeds `LOCK_DELAY` without player input
  - Clears the timer if the piece moves away from ground

- **Lock State Cleanup**: Clear lock state when:
  - Piece is locked (new piece spawns)
  - Hard drop is performed (immediate lock)
  - Hold piece is used (swapping to new piece)
  - Game is reset or unpaused

- **Gravity Tick Refactor**: Removed immediate locking from `tick()` — lock delay is now handled exclusively in the game loop

## Implementation Details

- Lock delay resets on horizontal moves and rotations (up to `MAX_LOCK_MOVES`) to allow player control
- Hard drop bypasses lock delay entirely for immediate placement
- Unpause resets the lock timer to prevent instant locks from elapsed pause time
- Uses `performance.now()` for precise timing of the grace period

https://claude.ai/code/session_01QAGVra6b88yg6CfUaT9j4Q