### PR TITLE
Add inventory (E key), shop (L key), and configurable key bindings

### DIFF
--- a/src/components/rhythmia/tetris/VanillaGame.module.css
+++ b/src/components/rhythmia/tetris/VanillaGame.module.css
@@ -2404,3 +2404,1274 @@
     gap: 16px;
   }
 }
+
+/* ===================================================================
+   INVENTORY UI — Minecraft Dungeons Style
+   =================================================================== */
+.inventoryOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  background: rgba(10, 5, 20, 0.92);
+  backdrop-filter: blur(16px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  animation: invFadeIn 0.25s ease;
+}
+
+@keyframes invFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.inventoryPanel {
+  display: grid;
+  grid-template-columns: 220px 1fr 260px;
+  gap: 20px;
+  max-width: 960px;
+  width: 95vw;
+  max-height: 80vh;
+  padding: 24px;
+}
+
+/* --- Character Section (Left) --- */
+.invCharacterSection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 8px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+}
+
+.invLevelBadge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 8px 16px;
+  background: rgba(120, 60, 200, 0.15);
+  border: 1px solid rgba(120, 60, 200, 0.3);
+  border-radius: 20px;
+}
+
+.invLevelIcon {
+  color: rgba(160, 100, 255, 0.8);
+  font-size: 0.7rem;
+}
+
+.invLevelLabel {
+  font-size: 0.5rem;
+  color: rgba(255, 255, 255, 0.4);
+  letter-spacing: 0.2em;
+  font-weight: 600;
+}
+
+.invLevelValue {
+  font-size: 1.4rem;
+  font-weight: 200;
+  color: white;
+}
+
+.invCharacterArea {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+}
+
+.invEquipSlots {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
+}
+
+.invEquipRow {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.invCharacterIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.6;
+}
+
+.invEquipSlot {
+  width: 52px;
+  height: 52px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 2px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s;
+  position: relative;
+}
+
+.invEquipSlot:hover {
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.invEquipSmall {
+  width: 44px;
+  height: 44px;
+}
+
+.invEquipFilled {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.invEquipEmpty {
+  color: rgba(255, 255, 255, 0.12);
+  font-size: 1.2rem;
+  font-weight: 200;
+}
+
+.invEquipCount {
+  font-size: 0.45rem;
+  color: rgba(255, 215, 0, 0.7);
+  position: absolute;
+  bottom: 2px;
+  right: 3px;
+}
+
+.invPowerDisplay {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+}
+
+.invPowerIcon {
+  color: rgba(200, 200, 200, 0.5);
+  font-size: 0.7rem;
+}
+
+.invPowerLabel {
+  font-size: 0.5rem;
+  color: rgba(255, 255, 255, 0.35);
+  letter-spacing: 0.2em;
+  font-weight: 600;
+}
+
+.invPowerValue {
+  font-size: 1.1rem;
+  font-weight: 300;
+  color: white;
+}
+
+.invArtifactRow {
+  display: flex;
+  gap: 8px;
+}
+
+/* --- Grid Section (Center) --- */
+.invGridSection {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.invCategoryTabs {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 4px;
+}
+
+.invTabLabel {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.5);
+  letter-spacing: 0.1em;
+}
+
+.invTabIcons {
+  display: flex;
+  gap: 4px;
+}
+
+.invTabBtn {
+  width: 32px;
+  height: 28px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.invTabBtn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.invTabActive {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.2);
+  color: white;
+}
+
+.invGrid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 4px;
+  overflow-y: auto;
+  max-height: 55vh;
+  padding: 4px;
+}
+
+.invGridItem {
+  aspect-ratio: 1;
+  background: rgba(255, 255, 255, 0.03);
+  border: 2px solid rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.15s;
+  position: relative;
+  padding: 4px;
+}
+
+.invGridItem:hover {
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.06);
+  transform: scale(1.02);
+}
+
+.invGridItemSelected {
+  background: rgba(100, 200, 255, 0.08);
+  border-color: rgba(100, 200, 255, 0.4);
+}
+
+.invGridItemRarityBar {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 3px;
+  height: 14px;
+  border-radius: 0 2px 0 2px;
+  opacity: 0.7;
+}
+
+.invGridItemIcon {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.invGridItemCount {
+  font-size: 0.5rem;
+  color: rgba(255, 255, 255, 0.6);
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.invGridItemCountIcon {
+  font-size: 0.4rem;
+  color: rgba(255, 215, 0, 0.5);
+}
+
+.invGridItemEmpty {
+  aspect-ratio: 1;
+  background: rgba(255, 255, 255, 0.01);
+  border: 1px solid rgba(255, 255, 255, 0.03);
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.invGridEmptyX {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.06);
+}
+
+/* --- Detail Section (Right) --- */
+.invDetailSection {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  overflow-y: auto;
+  max-height: 70vh;
+}
+
+.invDetailHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.invDetailLevel {
+  font-size: 1.2rem;
+  font-weight: 200;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.invDetailRarity {
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.invDetailName {
+  font-size: 1.6rem;
+  font-weight: 300;
+  color: white;
+  letter-spacing: 0.08em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.invDetailIconWrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 8px;
+}
+
+.invDetailStats {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.invDetailStat {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.invDetailStatIcon {
+  color: rgba(100, 200, 100, 0.8);
+  font-size: 0.65rem;
+}
+
+.invDetailDesc {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.35);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.invDetailBars {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.invDetailBarRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.invDetailBarLabel {
+  font-size: 0.55rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.4);
+  letter-spacing: 0.1em;
+  width: 50px;
+}
+
+.invDetailBar {
+  flex: 1;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.invDetailBarFill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s;
+}
+
+.invDetailEnchants {
+  padding-top: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.invDetailEnchantsTitle {
+  font-size: 0.65rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.4);
+  letter-spacing: 0.15em;
+  margin: 0 0 8px 0;
+}
+
+.invDetailEnchantSlots {
+  display: flex;
+  gap: 10px;
+}
+
+.invDetailEnchantSlot {
+  width: 44px;
+  height: 44px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: rotate(45deg);
+}
+
+.invDetailEnchantIcon {
+  transform: rotate(-45deg);
+  color: #FFD700;
+  font-size: 1rem;
+}
+
+.invDetailEnchantEmpty {
+  transform: rotate(-45deg);
+  color: rgba(255, 255, 255, 0.1);
+  font-size: 1rem;
+}
+
+.invDetailEmpty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.invDetailEmptyText {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.25);
+  letter-spacing: 0.1em;
+}
+
+.invDetailEmptySubtext {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.12);
+}
+
+/* --- Bottom Action Bar --- */
+.invBottomBar {
+  display: flex;
+  gap: 32px;
+  padding: 16px 24px;
+  margin-top: 12px;
+}
+
+.invBottomAction {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.invBottomKey {
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.7);
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 4px;
+  padding: 3px 10px;
+  letter-spacing: 0.05em;
+}
+
+.invBottomLabel {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.45);
+  letter-spacing: 0.05em;
+}
+
+/* Inventory responsive */
+@media screen and (max-width: 768px) {
+  .inventoryPanel {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr auto;
+    max-height: 90vh;
+    padding: 12px;
+    gap: 12px;
+  }
+
+  .invCharacterSection {
+    flex-direction: row;
+    gap: 8px;
+    padding: 8px;
+  }
+
+  .invGrid {
+    grid-template-columns: repeat(4, 1fr);
+    max-height: 40vh;
+  }
+
+  .invBottomBar {
+    gap: 16px;
+    padding: 8px;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}
+
+/* ===================================================================
+   SHOP UI — League of Legends Style
+   =================================================================== */
+.shopOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  background: rgba(0, 8, 16, 0.95);
+  backdrop-filter: blur(12px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: shopFadeIn 0.2s ease;
+}
+
+@keyframes shopFadeIn {
+  from { opacity: 0; transform: scale(0.98); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+.shopPanel {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 0;
+  max-width: 1000px;
+  width: 95vw;
+  max-height: 85vh;
+  background: rgba(10, 18, 30, 0.95);
+  border: 1px solid rgba(0, 180, 200, 0.15);
+  border-radius: 4px;
+  overflow: hidden;
+  position: relative;
+}
+
+.shopClose {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 28px;
+  height: 28px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 50%;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.7rem;
+  cursor: pointer;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+}
+
+.shopClose:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: white;
+}
+
+/* --- Shop Left (Tabs + Items) --- */
+.shopLeft {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid rgba(0, 180, 200, 0.1);
+  overflow: hidden;
+}
+
+.shopTabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid rgba(0, 180, 200, 0.1);
+}
+
+.shopTab {
+  flex: 1;
+  padding: 10px 16px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  color: rgba(255, 255, 255, 0.4);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: all 0.15s;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+}
+
+.shopTab:hover {
+  color: rgba(255, 255, 255, 0.7);
+  background: rgba(0, 180, 200, 0.03);
+}
+
+.shopTabActive {
+  color: #C89B3C;
+  border-bottom-color: #C89B3C;
+}
+
+.shopSearchWrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: rgba(0, 0, 0, 0.3);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.shopSearchIcon {
+  font-size: 0.75rem;
+  opacity: 0.4;
+}
+
+.shopSearch {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.75rem;
+  outline: none;
+  letter-spacing: 0.05em;
+}
+
+.shopSearch::placeholder {
+  color: rgba(255, 255, 255, 0.2);
+}
+
+.shopSectionTitle {
+  padding: 8px 14px;
+  font-size: 0.55rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.3);
+  letter-spacing: 0.2em;
+}
+
+.shopItemGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  padding: 8px 12px;
+  overflow-y: auto;
+  max-height: 40vh;
+}
+
+.shopItemCard {
+  background: rgba(20, 30, 50, 0.7);
+  border: 1px solid rgba(0, 180, 200, 0.1);
+  border-radius: 4px;
+  padding: 10px 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+  position: relative;
+}
+
+.shopItemCard:hover {
+  border-color: rgba(0, 180, 200, 0.4);
+  background: rgba(0, 180, 200, 0.06);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 16px rgba(0, 180, 200, 0.1);
+}
+
+.shopItemSelected {
+  border-color: rgba(0, 220, 255, 0.6);
+  background: rgba(0, 220, 255, 0.08);
+  box-shadow: 0 0 20px rgba(0, 220, 255, 0.15), inset 0 0 16px rgba(0, 220, 255, 0.05);
+}
+
+.shopItemOwned {
+  opacity: 0.5;
+}
+
+.shopItemName {
+  font-size: 0.6rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.8);
+  text-align: center;
+  letter-spacing: 0.03em;
+  line-height: 1.2;
+  min-height: 24px;
+  display: flex;
+  align-items: center;
+}
+
+.shopItemIconWrap {
+  padding: 6px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+}
+
+.shopItemPrice {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.65rem;
+  color: #C89B3C;
+  font-weight: 500;
+}
+
+.shopGoldIcon {
+  color: #C89B3C;
+  font-size: 0.6rem;
+}
+
+.shopItemTag {
+  font-size: 0.5rem;
+  color: rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 2px 8px;
+  border-radius: 3px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.shopItemInfo {
+  position: absolute;
+  bottom: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.shopItemInfoIcon {
+  font-size: 0.65rem;
+  color: rgba(0, 180, 200, 0.4);
+}
+
+.shopItemRating {
+  font-size: 0.45rem;
+  color: rgba(255, 255, 255, 0.2);
+  letter-spacing: 0.05em;
+  margin-top: 2px;
+}
+
+/* Commonly Built */
+.shopCommonlyBuilt {
+  padding: 8px 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.shopCommonlyBuiltLabel {
+  font-size: 0.5rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.25);
+  letter-spacing: 0.15em;
+  margin-bottom: 6px;
+}
+
+.shopCommonlyBuiltItems {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+}
+
+.shopCommonItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 4px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.15s;
+  flex-shrink: 0;
+}
+
+.shopCommonItem:hover {
+  border-color: rgba(0, 180, 200, 0.3);
+}
+
+.shopCommonItemActive {
+  border-color: rgba(0, 220, 255, 0.5);
+  background: rgba(0, 220, 255, 0.06);
+}
+
+.shopCommonPrice {
+  font-size: 0.5rem;
+  color: #C89B3C;
+  font-weight: 600;
+}
+
+/* Bottom bar */
+.shopBottomBar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.shopSellBtn,
+.shopUndoBtn {
+  padding: 6px 16px;
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.shopSellBtn {
+  background: transparent;
+  border: 1px solid rgba(200, 60, 60, 0.3);
+  color: rgba(200, 60, 60, 0.7);
+}
+
+.shopSellBtn:hover {
+  background: rgba(200, 60, 60, 0.1);
+}
+
+.shopUndoBtn {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.shopUndoBtn:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.shopGoldDisplay {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.shopGoldAmount {
+  color: #C89B3C;
+  font-weight: 600;
+}
+
+/* --- Shop Right (Detail Panel) --- */
+.shopRight {
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  overflow-y: auto;
+  gap: 10px;
+  background: rgba(0, 10, 20, 0.5);
+}
+
+.shopBuildsIntoLabel {
+  font-size: 0.55rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.3);
+  letter-spacing: 0.15em;
+}
+
+.shopBuildsIntoGrid {
+  display: flex;
+  gap: 4px;
+}
+
+.shopBuildSlot {
+  width: 36px;
+  height: 36px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+}
+
+/* Build tree */
+.shopBuildTree {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 0;
+}
+
+.shopBuildTreeMain {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.shopBuildTreeIcon {
+  width: 64px;
+  height: 64px;
+  background: rgba(0, 180, 200, 0.06);
+  border: 2px solid rgba(0, 180, 200, 0.3);
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.shopBuildTreePrice {
+  font-size: 0.65rem;
+  color: #C89B3C;
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.shopBuildTreeLine {
+  width: 2px;
+  height: 20px;
+  background: rgba(0, 180, 200, 0.2);
+}
+
+.shopBuildTreeComponents {
+  display: flex;
+  gap: 12px;
+}
+
+.shopBuildTreeComp {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.shopBuildTreeCompIcon {
+  width: 44px;
+  height: 44px;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.shopBuildTreeCompPrice {
+  font-size: 0.55rem;
+  color: #C89B3C;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+/* Purchase button */
+.shopPurchaseBtn {
+  width: 100%;
+  padding: 10px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  background: rgba(50, 50, 50, 0.6);
+  border: 1px solid rgba(100, 100, 100, 0.3);
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.25);
+  cursor: not-allowed;
+  transition: all 0.2s;
+  text-transform: uppercase;
+}
+
+.shopPurchaseBtnActive {
+  cursor: pointer;
+  background: linear-gradient(180deg, rgba(0, 180, 160, 0.4), rgba(0, 120, 100, 0.6));
+  border-color: rgba(0, 200, 180, 0.5);
+  color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 0 12px rgba(0, 200, 180, 0.15);
+}
+
+.shopPurchaseBtnActive:hover {
+  background: linear-gradient(180deg, rgba(0, 200, 180, 0.5), rgba(0, 140, 120, 0.7));
+  box-shadow: 0 0 20px rgba(0, 200, 180, 0.25);
+  transform: translateY(-1px);
+}
+
+/* Detail panel */
+.shopDetailPanel {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 6px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.shopDetailHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.shopDetailIcon {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 4px;
+}
+
+.shopDetailInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.shopDetailName {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: white;
+  letter-spacing: 0.05em;
+}
+
+.shopDetailPrice {
+  font-size: 0.7rem;
+  color: #C89B3C;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.shopDetailStats {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.shopDetailStatRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.7rem;
+}
+
+.shopDetailStatIcon {
+  color: rgba(100, 200, 100, 0.7);
+  width: 12px;
+  text-align: center;
+}
+
+.shopDetailStatValue {
+  color: rgba(255, 255, 255, 0.8);
+  font-weight: 500;
+}
+
+.shopDetailStatLabel {
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.shopDetailPassive {
+  padding-top: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.shopDetailPassiveName {
+  font-size: 0.7rem;
+  color: rgba(200, 155, 60, 0.8);
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+.shopDetailPassiveDesc {
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.45);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.shopEmptyDetail {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  color: rgba(255, 255, 255, 0.2);
+  font-size: 0.8rem;
+}
+
+.shopEmptyDetailSub {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.1);
+}
+
+/* Shop responsive */
+@media screen and (max-width: 768px) {
+  .shopPanel {
+    grid-template-columns: 1fr;
+    max-height: 90vh;
+  }
+
+  .shopRight {
+    border-top: 1px solid rgba(0, 180, 200, 0.1);
+    max-height: 40vh;
+  }
+
+  .shopItemGrid {
+    grid-template-columns: repeat(2, 1fr);
+    max-height: 30vh;
+  }
+}
+
+/* ===================================================================
+   KEY BIND SETTINGS — Pause Menu Panel
+   =================================================================== */
+.keyBindPanel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  width: 280px;
+}
+
+.keyBindTitle {
+  font-size: 1.4rem;
+  font-weight: 200;
+  color: white;
+  letter-spacing: 0.3em;
+  margin: 0;
+}
+
+.keyBindSubtitle {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.3);
+  letter-spacing: 0.1em;
+  margin-top: -10px;
+}
+
+.keyBindList {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.keyBindRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
+}
+
+.keyBindLabelWrap {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.keyBindLabel {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.7);
+  font-weight: 500;
+  letter-spacing: 0.08em;
+}
+
+.keyBindLabelJa {
+  font-size: 0.55rem;
+  color: rgba(255, 255, 255, 0.25);
+}
+
+.keyBindKey {
+  padding: 6px 16px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.15s;
+  letter-spacing: 0.1em;
+  min-width: 60px;
+  text-align: center;
+}
+
+.keyBindKey:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.keyBindKeyListening {
+  background: rgba(0, 180, 200, 0.15);
+  border-color: rgba(0, 180, 200, 0.5);
+  color: rgba(0, 220, 255, 0.9);
+  animation: keyBindPulse 1s ease-in-out infinite alternate;
+}
+
+@keyframes keyBindPulse {
+  0% { box-shadow: 0 0 0 rgba(0, 180, 200, 0); }
+  100% { box-shadow: 0 0 12px rgba(0, 180, 200, 0.3); }
+}
+
+.keyBindActions {
+  display: flex;
+  gap: 8px;
+  width: 100%;
+}
+
+.keyBindResetBtn,
+.keyBindBackBtn {
+  flex: 1;
+  padding: 10px 16px;
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.keyBindResetBtn {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.keyBindResetBtn:hover {
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.keyBindBackBtn {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.9);
+  color: #000;
+}
+
+.keyBindBackBtn:hover {
+  background: rgba(255, 255, 255, 0.75);
+}

--- a/src/components/rhythmia/tetris/components/Board.tsx
+++ b/src/components/rhythmia/tetris/components/Board.tsx
@@ -4,7 +4,8 @@ import { getShape, isValidPosition, getGhostY } from '../utils/boardUtils';
 import { ADVANCEMENTS } from '@/lib/advancements/definitions';
 import { loadAdvancementState } from '@/lib/advancements/storage';
 import Advancements from '@/components/rhythmia/Advancements';
-import type { Piece, Board as BoardType } from '../types';
+import { KeyBindSettings } from './KeyBindSettings';
+import type { Piece, Board as BoardType, KeyBindings } from '../types';
 import styles from '../VanillaGame.module.css';
 
 interface BoardProps {
@@ -23,6 +24,8 @@ interface BoardProps {
     combo?: number;
     beatPhase?: number;
     boardElRef?: React.Ref<HTMLDivElement>;
+    keyBindings?: KeyBindings;
+    onKeyBindingsChange?: (bindings: KeyBindings) => void;
 }
 
 /**
@@ -45,9 +48,12 @@ export function Board({
     combo = 0,
     beatPhase = 0,
     boardElRef,
+    keyBindings,
+    onKeyBindingsChange,
 }: BoardProps) {
     const isFever = combo >= 10;
     const [showAdvancements, setShowAdvancements] = useState(false);
+    const [showKeyBinds, setShowKeyBinds] = useState(false);
     const [unlockedCount, setUnlockedCount] = useState(0);
 
     // Load advancement count when pause menu opens
@@ -57,6 +63,7 @@ export function Board({
             setUnlockedCount(state.unlockedIds.length);
         } else {
             setShowAdvancements(false);
+            setShowKeyBinds(false);
         }
     }, [isPaused, gameOver]);
 
@@ -165,10 +172,16 @@ export function Board({
                 </div>
             )}
 
-            {/* Overlay for Paused — main menu or advancements sub-panel */}
+            {/* Overlay for Paused — main menu, advancements, or key bindings sub-panel */}
             {isPaused && !gameOver && (
                 <div className={styles.gameover} style={{ display: 'flex' }}>
-                    {!showAdvancements ? (
+                    {showKeyBinds && keyBindings && onKeyBindingsChange ? (
+                        <KeyBindSettings
+                            bindings={keyBindings}
+                            onUpdate={onKeyBindingsChange}
+                            onBack={() => setShowKeyBinds(false)}
+                        />
+                    ) : !showAdvancements ? (
                         <>
                             <h2>PAUSED</h2>
                             <div className={styles.finalScore}>{score.toLocaleString()} pts</div>
@@ -188,6 +201,15 @@ export function Board({
                                         {unlockedCount}/{totalCount}
                                     </span>
                                 </button>
+                                {keyBindings && onKeyBindingsChange && (
+                                    <button
+                                        className={styles.pauseMenuBtn}
+                                        onClick={() => setShowKeyBinds(true)}
+                                    >
+                                        <span className={styles.pauseMenuBtnIcon}>⌨</span>
+                                        Key Bindings
+                                    </button>
+                                )}
                             </div>
 
                             {/* Theme selector */}

--- a/src/components/rhythmia/tetris/components/InventoryUI.tsx
+++ b/src/components/rhythmia/tetris/components/InventoryUI.tsx
@@ -1,0 +1,400 @@
+import React, { useState } from 'react';
+import type { InventoryItem, CraftedCard } from '../types';
+import { ITEM_MAP, WEAPON_CARD_MAP, ITEMS } from '../constants';
+import { ItemIcon, WeaponIcon } from './ItemIcon';
+import styles from '../VanillaGame.module.css';
+
+interface InventoryUIProps {
+    inventory: InventoryItem[];
+    craftedCards: CraftedCard[];
+    damageMultiplier: number;
+    level: number;
+    onClose: () => void;
+}
+
+const RARITY_COLORS: Record<string, string> = {
+    common: '#8B8B8B',
+    uncommon: '#4FC3F7',
+    rare: '#FFD700',
+    epic: '#9C27B0',
+    legendary: '#FFFFFF',
+};
+
+const RARITY_LABEL: Record<string, string> = {
+    common: 'COMMON',
+    uncommon: 'UNCOMMON',
+    rare: 'RARE',
+    epic: 'EPIC',
+    legendary: 'LEGENDARY',
+};
+
+// Equipment slot positions around character silhouette
+const EQUIP_SLOTS = [
+    { id: 'weapon', label: 'Weapon', x: 'left', y: 'top' },
+    { id: 'armor', label: 'Armor', x: 'right', y: 'top' },
+    { id: 'artifact1', label: 'Artifact', x: 'left', y: 'bottom' },
+    { id: 'artifact2', label: 'Artifact', x: 'center', y: 'bottom' },
+    { id: 'artifact3', label: 'Artifact', x: 'right', y: 'bottom' },
+];
+
+/**
+ * Full-screen inventory overlay styled like Minecraft Dungeons.
+ * - Left: Character silhouette with equipment slots
+ * - Center: Item grid
+ * - Right: Selected item detail panel
+ */
+export function InventoryUI({ inventory, craftedCards, damageMultiplier, level, onClose }: InventoryUIProps) {
+    const [selectedItem, setSelectedItem] = useState<string | null>(null);
+    const [selectedCategory, setSelectedCategory] = useState<'all' | 'materials' | 'weapons'>('all');
+
+    // Build combined item list for grid
+    const materialItems = inventory.map(inv => {
+        const item = ITEM_MAP[inv.itemId];
+        return item ? { type: 'material' as const, id: inv.itemId, count: inv.count, item } : null;
+    }).filter(Boolean);
+
+    const weaponItems = craftedCards.map(cc => {
+        const card = WEAPON_CARD_MAP[cc.cardId];
+        return card ? { type: 'weapon' as const, id: cc.cardId, count: 1, card } : null;
+    }).filter(Boolean);
+
+    const allItems = selectedCategory === 'materials' ? materialItems
+        : selectedCategory === 'weapons' ? weaponItems
+        : [...materialItems, ...weaponItems];
+
+    // Get selected item details
+    const selectedDetail = selectedItem ? (
+        ITEM_MAP[selectedItem] || WEAPON_CARD_MAP[selectedItem]
+    ) : null;
+
+    const isWeapon = selectedItem ? !!WEAPON_CARD_MAP[selectedItem] : false;
+    const selectedWeapon = isWeapon && selectedItem ? WEAPON_CARD_MAP[selectedItem] : null;
+    const selectedMaterial = !isWeapon && selectedItem ? ITEM_MAP[selectedItem] : null;
+
+    // Power level = sum of damage multipliers
+    const powerLevel = Math.round(damageMultiplier * 10);
+
+    return (
+        <div className={styles.inventoryOverlay} onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+            <div className={styles.inventoryPanel}>
+                {/* Left section: Character + Equipment */}
+                <div className={styles.invCharacterSection}>
+                    {/* Level badge */}
+                    <div className={styles.invLevelBadge}>
+                        <span className={styles.invLevelIcon}>◈</span>
+                        <span className={styles.invLevelLabel}>LEVEL</span>
+                        <span className={styles.invLevelValue}>{level}</span>
+                    </div>
+
+                    {/* Character silhouette area */}
+                    <div className={styles.invCharacterArea}>
+                        {/* Equipment slots around character */}
+                        <div className={styles.invEquipSlots}>
+                            {/* Top row: weapon + empty + armor */}
+                            <div className={styles.invEquipRow}>
+                                {craftedCards[0] ? (
+                                    <div
+                                        className={`${styles.invEquipSlot} ${styles.invEquipFilled}`}
+                                        onClick={() => setSelectedItem(craftedCards[0].cardId)}
+                                        style={{ borderColor: `${WEAPON_CARD_MAP[craftedCards[0].cardId]?.color || '#fff'}50` }}
+                                    >
+                                        <ItemIcon itemId={craftedCards[0].cardId} size={28} />
+                                        <span className={styles.invEquipCount}>♦ {
+                                            Math.round((WEAPON_CARD_MAP[craftedCards[0].cardId]?.damageMultiplier || 1) * 10)
+                                        }</span>
+                                    </div>
+                                ) : (
+                                    <div className={styles.invEquipSlot}>
+                                        <span className={styles.invEquipEmpty}>+</span>
+                                    </div>
+                                )}
+                                <div className={styles.invCharacterIcon}>
+                                    {/* Simple character silhouette */}
+                                    <svg width="48" height="64" viewBox="0 0 48 64" fill="none">
+                                        {/* Head */}
+                                        <rect x="14" y="0" width="20" height="20" rx="2" fill="rgba(255,255,255,0.15)" stroke="rgba(255,255,255,0.2)" strokeWidth="1" />
+                                        {/* Eyes */}
+                                        <rect x="18" y="8" width="3" height="3" fill="rgba(255,255,255,0.4)" />
+                                        <rect x="27" y="8" width="3" height="3" fill="rgba(255,255,255,0.4)" />
+                                        {/* Body */}
+                                        <rect x="10" y="22" width="28" height="22" rx="1" fill="rgba(255,255,255,0.1)" stroke="rgba(255,255,255,0.15)" strokeWidth="1" />
+                                        {/* Arms */}
+                                        <rect x="2" y="22" width="8" height="20" rx="1" fill="rgba(255,255,255,0.08)" stroke="rgba(255,255,255,0.12)" strokeWidth="1" />
+                                        <rect x="38" y="22" width="8" height="20" rx="1" fill="rgba(255,255,255,0.08)" stroke="rgba(255,255,255,0.12)" strokeWidth="1" />
+                                        {/* Legs */}
+                                        <rect x="14" y="46" width="8" height="18" rx="1" fill="rgba(255,255,255,0.08)" stroke="rgba(255,255,255,0.12)" strokeWidth="1" />
+                                        <rect x="26" y="46" width="8" height="18" rx="1" fill="rgba(255,255,255,0.08)" stroke="rgba(255,255,255,0.12)" strokeWidth="1" />
+                                    </svg>
+                                </div>
+                                {craftedCards[1] ? (
+                                    <div
+                                        className={`${styles.invEquipSlot} ${styles.invEquipFilled}`}
+                                        onClick={() => setSelectedItem(craftedCards[1].cardId)}
+                                        style={{ borderColor: `${WEAPON_CARD_MAP[craftedCards[1].cardId]?.color || '#fff'}50` }}
+                                    >
+                                        <ItemIcon itemId={craftedCards[1].cardId} size={28} />
+                                    </div>
+                                ) : (
+                                    <div className={styles.invEquipSlot}>
+                                        <span className={styles.invEquipEmpty}>+</span>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* Power display */}
+                    <div className={styles.invPowerDisplay}>
+                        <span className={styles.invPowerIcon}>◈</span>
+                        <span className={styles.invPowerLabel}>POWER</span>
+                        <span className={styles.invPowerValue}>{powerLevel}</span>
+                    </div>
+
+                    {/* Bottom artifact slots */}
+                    <div className={styles.invArtifactRow}>
+                        {[2, 3, 4].map(idx => (
+                            craftedCards[idx] ? (
+                                <div
+                                    key={idx}
+                                    className={`${styles.invEquipSlot} ${styles.invEquipSmall} ${styles.invEquipFilled}`}
+                                    onClick={() => setSelectedItem(craftedCards[idx].cardId)}
+                                >
+                                    <ItemIcon itemId={craftedCards[idx].cardId} size={22} />
+                                    <span className={styles.invEquipCount}>♦ {
+                                        Math.round((WEAPON_CARD_MAP[craftedCards[idx].cardId]?.damageMultiplier || 1) * 10)
+                                    }</span>
+                                </div>
+                            ) : (
+                                <div key={idx} className={`${styles.invEquipSlot} ${styles.invEquipSmall}`}>
+                                    <span className={styles.invEquipEmpty}>+</span>
+                                </div>
+                            )
+                        ))}
+                    </div>
+                </div>
+
+                {/* Center section: Item Grid */}
+                <div className={styles.invGridSection}>
+                    {/* Category tabs */}
+                    <div className={styles.invCategoryTabs}>
+                        <span className={styles.invTabLabel}>All</span>
+                        <div className={styles.invTabIcons}>
+                            <button
+                                className={`${styles.invTabBtn} ${selectedCategory === 'all' ? styles.invTabActive : ''}`}
+                                onClick={() => setSelectedCategory('all')}
+                                title="All Items"
+                            >
+                                ≡
+                            </button>
+                            <button
+                                className={`${styles.invTabBtn} ${selectedCategory === 'materials' ? styles.invTabActive : ''}`}
+                                onClick={() => setSelectedCategory('materials')}
+                                title="Materials"
+                            >
+                                ◆
+                            </button>
+                            <button
+                                className={`${styles.invTabBtn} ${selectedCategory === 'weapons' ? styles.invTabActive : ''}`}
+                                onClick={() => setSelectedCategory('weapons')}
+                                title="Weapons"
+                            >
+                                ⚔
+                            </button>
+                        </div>
+                    </div>
+
+                    {/* Item grid */}
+                    <div className={styles.invGrid}>
+                        {allItems.map((entry, idx) => {
+                            if (!entry) return null;
+                            const isMat = entry.type === 'material';
+                            const color = isMat ? entry.item.color : entry.card!.color;
+                            const rarity = isMat ? entry.item.rarity : 'common';
+                            const isSelected = selectedItem === entry.id;
+
+                            return (
+                                <div
+                                    key={`${entry.id}-${idx}`}
+                                    className={`${styles.invGridItem} ${isSelected ? styles.invGridItemSelected : ''}`}
+                                    style={{
+                                        borderColor: isSelected ? `${color}80` : undefined,
+                                        boxShadow: isSelected ? `0 0 12px ${color}30, inset 0 0 8px ${color}10` : undefined,
+                                    }}
+                                    onClick={() => setSelectedItem(entry.id)}
+                                >
+                                    <div className={styles.invGridItemRarityBar} style={{ background: RARITY_COLORS[rarity] || '#8B8B8B' }} />
+                                    <div className={styles.invGridItemIcon}>
+                                        <ItemIcon itemId={entry.id} size={30} />
+                                    </div>
+                                    {isMat && entry.count > 1 && (
+                                        <span className={styles.invGridItemCount}>
+                                            <span className={styles.invGridItemCountIcon}>◆</span> {entry.count}
+                                        </span>
+                                    )}
+                                    {!isMat && (
+                                        <span className={styles.invGridItemCount}>
+                                            <span className={styles.invGridItemCountIcon}>♦</span> {
+                                                Math.round((entry.card!.damageMultiplier || 1) * 10)
+                                            }
+                                        </span>
+                                    )}
+                                </div>
+                            );
+                        })}
+
+                        {/* Empty slots to fill grid */}
+                        {Array.from({ length: Math.max(0, 18 - allItems.length) }).map((_, i) => (
+                            <div key={`empty-${i}`} className={styles.invGridItemEmpty}>
+                                <span className={styles.invGridEmptyX}>✕</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Right section: Item Detail */}
+                <div className={styles.invDetailSection}>
+                    {selectedDetail ? (
+                        <>
+                            {/* Rarity + level */}
+                            <div className={styles.invDetailHeader}>
+                                <span className={styles.invDetailLevel}>{powerLevel}</span>
+                                <span
+                                    className={styles.invDetailRarity}
+                                    style={{ color: RARITY_COLORS[isWeapon ? 'rare' : (selectedMaterial?.rarity || 'common')] }}
+                                >
+                                    {RARITY_LABEL[isWeapon ? 'rare' : (selectedMaterial?.rarity || 'common')]}
+                                </span>
+                            </div>
+
+                            {/* Item name */}
+                            <h3 className={styles.invDetailName}>
+                                {isWeapon ? selectedWeapon?.name : selectedMaterial?.name}
+                            </h3>
+
+                            {/* Large icon preview */}
+                            <div className={styles.invDetailIconWrap}>
+                                <ItemIcon itemId={selectedItem!} size={64} />
+                            </div>
+
+                            {/* Stats */}
+                            {isWeapon && selectedWeapon && (
+                                <div className={styles.invDetailStats}>
+                                    <div className={styles.invDetailStat}>
+                                        <span className={styles.invDetailStatIcon}>⚔</span>
+                                        <span>{selectedWeapon.description}</span>
+                                    </div>
+                                    {selectedWeapon.specialEffect && (
+                                        <div className={styles.invDetailStat}>
+                                            <span className={styles.invDetailStatIcon}>◆</span>
+                                            <span>{selectedWeapon.specialEffect}</span>
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+
+                            {selectedMaterial && (
+                                <div className={styles.invDetailStats}>
+                                    <div className={styles.invDetailStat}>
+                                        <span className={styles.invDetailStatIcon}>◆</span>
+                                        <span>Rarity: {selectedMaterial.rarity}</span>
+                                    </div>
+                                </div>
+                            )}
+
+                            {/* Description */}
+                            <p className={styles.invDetailDesc}>
+                                {isWeapon ? selectedWeapon?.descriptionJa : selectedMaterial?.nameJa}
+                            </p>
+
+                            {/* Stat bars */}
+                            {isWeapon && selectedWeapon && (
+                                <div className={styles.invDetailBars}>
+                                    <div className={styles.invDetailBarRow}>
+                                        <span className={styles.invDetailBarLabel}>POWER</span>
+                                        <div className={styles.invDetailBar}>
+                                            <div
+                                                className={styles.invDetailBarFill}
+                                                style={{
+                                                    width: `${Math.min(100, (selectedWeapon.damageMultiplier - 1) * 200)}%`,
+                                                    background: '#e53935',
+                                                }}
+                                            />
+                                        </div>
+                                    </div>
+                                    <div className={styles.invDetailBarRow}>
+                                        <span className={styles.invDetailBarLabel}>SPEED</span>
+                                        <div className={styles.invDetailBar}>
+                                            <div
+                                                className={styles.invDetailBarFill}
+                                                style={{ width: '60%', background: '#4caf50' }}
+                                            />
+                                        </div>
+                                    </div>
+                                    <div className={styles.invDetailBarRow}>
+                                        <span className={styles.invDetailBarLabel}>AREA</span>
+                                        <div className={styles.invDetailBar}>
+                                            <div
+                                                className={styles.invDetailBarFill}
+                                                style={{
+                                                    width: selectedWeapon.specialEffect ? '70%' : '30%',
+                                                    background: '#e53935',
+                                                }}
+                                            />
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+
+                            {/* Enchantments (for weapons) */}
+                            {isWeapon && (
+                                <div className={styles.invDetailEnchants}>
+                                    <h4 className={styles.invDetailEnchantsTitle}>Enchantments</h4>
+                                    <div className={styles.invDetailEnchantSlots}>
+                                        <div className={styles.invDetailEnchantSlot}>
+                                            {selectedWeapon?.specialEffect ? (
+                                                <span className={styles.invDetailEnchantIcon}>✦</span>
+                                            ) : (
+                                                <span className={styles.invDetailEnchantEmpty}>◇</span>
+                                            )}
+                                        </div>
+                                        <div className={styles.invDetailEnchantSlot}>
+                                            <span className={styles.invDetailEnchantEmpty}>◇</span>
+                                        </div>
+                                        <div className={styles.invDetailEnchantSlot}>
+                                            <span className={styles.invDetailEnchantEmpty}>◇</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+                        </>
+                    ) : (
+                        <div className={styles.invDetailEmpty}>
+                            <span className={styles.invDetailEmptyText}>Select an item</span>
+                            <span className={styles.invDetailEmptySubtext}>アイテムを選択してください</span>
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            {/* Bottom action bar */}
+            <div className={styles.invBottomBar}>
+                <div className={styles.invBottomAction}>
+                    <span className={styles.invBottomKey}>ESC</span>
+                    <span className={styles.invBottomLabel}>Back</span>
+                </div>
+                <div className={styles.invBottomAction}>
+                    <span className={styles.invBottomKey}>E</span>
+                    <span className={styles.invBottomLabel}>Quick Equip</span>
+                </div>
+                <div className={styles.invBottomAction}>
+                    <span className={styles.invBottomKey}>X</span>
+                    <span className={styles.invBottomLabel}>Salvage</span>
+                </div>
+                <div className={styles.invBottomAction}>
+                    <span className={styles.invBottomKey}>A</span>
+                    <span className={styles.invBottomLabel}>Pick Up</span>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/rhythmia/tetris/components/KeyBindSettings.tsx
+++ b/src/components/rhythmia/tetris/components/KeyBindSettings.tsx
@@ -1,0 +1,101 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import type { KeyBindings } from '../types';
+import { DEFAULT_KEY_BINDINGS } from '../constants';
+import styles from '../VanillaGame.module.css';
+
+interface KeyBindSettingsProps {
+    bindings: KeyBindings;
+    onUpdate: (bindings: KeyBindings) => void;
+    onBack: () => void;
+}
+
+const BIND_LABELS: Record<keyof KeyBindings, { name: string; nameJa: string }> = {
+    inventory: { name: 'Inventory', nameJa: 'インベントリ' },
+    shop: { name: 'Shop', nameJa: 'ショップ' },
+    forge: { name: 'Forge', nameJa: '鍛造' },
+};
+
+function formatKey(key: string): string {
+    if (key === ' ') return 'Space';
+    if (key === 'Escape') return 'ESC';
+    if (key === 'Control') return 'Ctrl';
+    if (key === 'Shift') return 'Shift';
+    if (key.startsWith('Arrow')) return key.replace('Arrow', '');
+    return key.toUpperCase();
+}
+
+/**
+ * Key bindings settings panel for the pause menu.
+ * Allows remapping inventory (E), shop (L), and forge (F) keys.
+ */
+export function KeyBindSettings({ bindings, onUpdate, onBack }: KeyBindSettingsProps) {
+    const [listening, setListening] = useState<keyof KeyBindings | null>(null);
+    const [current, setCurrent] = useState<KeyBindings>({ ...bindings });
+
+    // Listen for key press when rebinding
+    useEffect(() => {
+        if (!listening) return;
+
+        const handleKey = (e: KeyboardEvent) => {
+            e.preventDefault();
+            e.stopPropagation();
+
+            // Escape cancels binding
+            if (e.key === 'Escape') {
+                setListening(null);
+                return;
+            }
+
+            // Don't allow binding game-critical keys
+            const forbidden = new Set(['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', ' ', 'p', 'P']);
+            if (forbidden.has(e.key)) return;
+
+            const newBindings = { ...current, [listening]: e.key.toLowerCase() };
+            setCurrent(newBindings);
+            onUpdate(newBindings);
+            setListening(null);
+        };
+
+        window.addEventListener('keydown', handleKey);
+        return () => window.removeEventListener('keydown', handleKey);
+    }, [listening, current, onUpdate]);
+
+    const resetDefaults = useCallback(() => {
+        const defaults = { ...DEFAULT_KEY_BINDINGS };
+        setCurrent(defaults);
+        onUpdate(defaults);
+    }, [onUpdate]);
+
+    return (
+        <div className={styles.keyBindPanel}>
+            <h3 className={styles.keyBindTitle}>KEY BINDINGS</h3>
+            <span className={styles.keyBindSubtitle}>キー設定</span>
+
+            <div className={styles.keyBindList}>
+                {(Object.keys(BIND_LABELS) as (keyof KeyBindings)[]).map(action => (
+                    <div key={action} className={styles.keyBindRow}>
+                        <div className={styles.keyBindLabelWrap}>
+                            <span className={styles.keyBindLabel}>{BIND_LABELS[action].name}</span>
+                            <span className={styles.keyBindLabelJa}>{BIND_LABELS[action].nameJa}</span>
+                        </div>
+                        <button
+                            className={`${styles.keyBindKey} ${listening === action ? styles.keyBindKeyListening : ''}`}
+                            onClick={() => setListening(listening === action ? null : action)}
+                        >
+                            {listening === action ? 'Press a key...' : formatKey(current[action])}
+                        </button>
+                    </div>
+                ))}
+            </div>
+
+            <div className={styles.keyBindActions}>
+                <button className={styles.keyBindResetBtn} onClick={resetDefaults}>
+                    Reset Defaults
+                </button>
+                <button className={styles.keyBindBackBtn} onClick={onBack}>
+                    Back
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/rhythmia/tetris/components/ShopUI.tsx
+++ b/src/components/rhythmia/tetris/components/ShopUI.tsx
@@ -1,0 +1,304 @@
+import React, { useState, useMemo } from 'react';
+import type { InventoryItem, CraftedCard } from '../types';
+import { SHOP_ITEMS, SHOP_ITEM_MAP, ITEM_MAP, WEAPON_CARD_MAP } from '../constants';
+import { ItemIcon } from './ItemIcon';
+import styles from '../VanillaGame.module.css';
+
+interface ShopUIProps {
+    gold: number;
+    inventory: InventoryItem[];
+    craftedCards: CraftedCard[];
+    onPurchase: (itemId: string, price: number) => boolean;
+    onClose: () => void;
+}
+
+const RARITY_COLORS: Record<string, string> = {
+    common: '#8B8B8B',
+    uncommon: '#4FC3F7',
+    rare: '#FFD700',
+    epic: '#9C27B0',
+    legendary: '#FFFFFF',
+};
+
+/**
+ * Full-screen shop overlay styled like League of Legends shop.
+ * - Left: Tabs + item grid with search
+ * - Right: Selected item details with build tree + purchase button
+ */
+export function ShopUI({ gold, inventory, craftedCards, onPurchase, onClose }: ShopUIProps) {
+    const [tab, setTab] = useState<'recommended' | 'all'>('recommended');
+    const [search, setSearch] = useState('');
+    const [selectedId, setSelectedId] = useState<string | null>(null);
+
+    // Recommended items = weapons the player hasn't crafted yet
+    const recommendedItems = useMemo(() => {
+        const craftedIds = new Set(craftedCards.map(cc => cc.cardId));
+        return SHOP_ITEMS.filter(item =>
+            item.category === 'weapon' && !craftedIds.has(item.id)
+        );
+    }, [craftedCards]);
+
+    // Filtered items based on tab and search
+    const displayItems = useMemo(() => {
+        const items = tab === 'recommended' ? recommendedItems : SHOP_ITEMS;
+        if (!search) return items;
+        const q = search.toLowerCase();
+        return items.filter(item =>
+            item.name.toLowerCase().includes(q) ||
+            item.nameJa.includes(q) ||
+            item.category.includes(q)
+        );
+    }, [tab, search, recommendedItems]);
+
+    // Selected item detail
+    const selected = selectedId ? SHOP_ITEM_MAP[selectedId] : null;
+    const alreadyOwned = selectedId ? (
+        WEAPON_CARD_MAP[selectedId]
+            ? craftedCards.some(cc => cc.cardId === selectedId)
+            : false
+    ) : false;
+    const canAfford = selected ? gold >= selected.price : false;
+
+    // "Commonly Built" — most popular weapons (the first 8)
+    const commonlyBuilt = SHOP_ITEMS.slice(0, 8);
+
+    const handlePurchase = () => {
+        if (!selected || alreadyOwned || !canAfford) return;
+        const success = onPurchase(selected.id, selected.price);
+        if (success && selected.category === 'weapon') {
+            // Weapon purchased — clear selection
+            setSelectedId(null);
+        }
+    };
+
+    return (
+        <div className={styles.shopOverlay} onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
+            <div className={styles.shopPanel}>
+                {/* Close button */}
+                <button className={styles.shopClose} onClick={onClose}>✕</button>
+
+                {/* Left section: Tabs + Items */}
+                <div className={styles.shopLeft}>
+                    {/* Tab bar */}
+                    <div className={styles.shopTabs}>
+                        <button
+                            className={`${styles.shopTab} ${tab === 'recommended' ? styles.shopTabActive : ''}`}
+                            onClick={() => setTab('recommended')}
+                        >
+                            RECOMMENDED
+                        </button>
+                        <button
+                            className={`${styles.shopTab} ${tab === 'all' ? styles.shopTabActive : ''}`}
+                            onClick={() => setTab('all')}
+                        >
+                            ALL ITEMS
+                        </button>
+                    </div>
+
+                    {/* Search bar */}
+                    <div className={styles.shopSearchWrap}>
+                        <span className={styles.shopSearchIcon}>🔍</span>
+                        <input
+                            className={styles.shopSearch}
+                            type="text"
+                            placeholder="Click Here to Search"
+                            value={search}
+                            onChange={e => setSearch(e.target.value)}
+                        />
+                    </div>
+
+                    {/* Item section header */}
+                    <div className={styles.shopSectionTitle}>
+                        SELECT AN ITEM TO BUILD
+                    </div>
+
+                    {/* Item cards grid */}
+                    <div className={styles.shopItemGrid}>
+                        {displayItems.map(item => {
+                            const isSelected = selectedId === item.id;
+                            const owned = item.category === 'weapon'
+                                ? craftedCards.some(cc => cc.cardId === item.id)
+                                : false;
+
+                            return (
+                                <div
+                                    key={item.id}
+                                    className={`${styles.shopItemCard} ${isSelected ? styles.shopItemSelected : ''} ${owned ? styles.shopItemOwned : ''}`}
+                                    onClick={() => setSelectedId(item.id)}
+                                >
+                                    {/* Item name */}
+                                    <div className={styles.shopItemName}>{item.name}</div>
+
+                                    {/* Item icon */}
+                                    <div className={styles.shopItemIconWrap}>
+                                        <ItemIcon itemId={item.id} size={48} />
+                                    </div>
+
+                                    {/* Price */}
+                                    <div className={styles.shopItemPrice}>
+                                        <span className={styles.shopGoldIcon}>⚙</span>
+                                        <span>{item.price.toLocaleString()}</span>
+                                    </div>
+
+                                    {/* Tag / category label */}
+                                    <div className={styles.shopItemTag}>
+                                        {item.category === 'weapon' ? item.stats?.[1]?.value || 'Weapon' : 'Material'}
+                                    </div>
+
+                                    {/* Info icon */}
+                                    <div className={styles.shopItemInfo}>
+                                        <span className={styles.shopItemInfoIcon}>ⓘ</span>
+                                    </div>
+
+                                    {/* Generally Good label */}
+                                    <div className={styles.shopItemRating}>Generally Good</div>
+                                </div>
+                            );
+                        })}
+                    </div>
+
+                    {/* Commonly Built bar */}
+                    <div className={styles.shopCommonlyBuilt}>
+                        <div className={styles.shopCommonlyBuiltLabel}>COMMONLY BUILT</div>
+                        <div className={styles.shopCommonlyBuiltItems}>
+                            {commonlyBuilt.map(item => (
+                                <div
+                                    key={item.id}
+                                    className={`${styles.shopCommonItem} ${selectedId === item.id ? styles.shopCommonItemActive : ''}`}
+                                    onClick={() => setSelectedId(item.id)}
+                                >
+                                    <ItemIcon itemId={item.id} size={28} />
+                                    <span className={styles.shopCommonPrice}>{item.price.toLocaleString()}</span>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+
+                    {/* Bottom bar: Sell, Undo, Gold */}
+                    <div className={styles.shopBottomBar}>
+                        <button className={styles.shopSellBtn}>SELL</button>
+                        <button className={styles.shopUndoBtn}>UNDO</button>
+                        <div className={styles.shopGoldDisplay}>
+                            <span className={styles.shopGoldIcon}>⚙</span>
+                            <span className={styles.shopGoldAmount}>{gold.toLocaleString()}</span>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Right section: Build tree + Details */}
+                <div className={styles.shopRight}>
+                    {selected ? (
+                        <>
+                            {/* BUILDS INTO header */}
+                            <div className={styles.shopBuildsIntoLabel}>BUILDS INTO</div>
+                            <div className={styles.shopBuildsIntoGrid}>
+                                {/* Placeholder build targets - show empty slots */}
+                                {Array.from({ length: 6 }).map((_, i) => (
+                                    <div key={i} className={styles.shopBuildSlot} />
+                                ))}
+                            </div>
+
+                            {/* Build tree visualization */}
+                            <div className={styles.shopBuildTree}>
+                                {/* Main item at top */}
+                                <div className={styles.shopBuildTreeMain}>
+                                    <div className={styles.shopBuildTreeIcon}>
+                                        <ItemIcon itemId={selected.id} size={48} />
+                                    </div>
+                                    <span className={styles.shopBuildTreePrice}>
+                                        <span className={styles.shopGoldIcon}>⚙</span>{selected.price.toLocaleString()}
+                                    </span>
+                                </div>
+
+                                {/* Connector lines */}
+                                {selected.buildsFrom && selected.buildsFrom.length > 0 && (
+                                    <>
+                                        <div className={styles.shopBuildTreeLine} />
+                                        <div className={styles.shopBuildTreeComponents}>
+                                            {selected.buildsFrom.map((comp, i) => {
+                                                const compItem = ITEM_MAP[comp.itemId] || SHOP_ITEM_MAP[comp.itemId];
+                                                if (!compItem) return null;
+                                                return (
+                                                    <div key={i} className={styles.shopBuildTreeComp}>
+                                                        <div className={styles.shopBuildTreeCompIcon}>
+                                                            <ItemIcon itemId={comp.itemId} size={32} />
+                                                        </div>
+                                                        <span className={styles.shopBuildTreeCompPrice}>
+                                                            <span className={styles.shopGoldIcon}>⚙</span>{comp.price.toLocaleString()}
+                                                        </span>
+                                                    </div>
+                                                );
+                                            })}
+                                            {/* Extra slot for recipe cost */}
+                                            <div className={styles.shopBuildTreeComp}>
+                                                <div className={styles.shopBuildTreeCompIcon} style={{ borderColor: 'rgba(255,215,0,0.3)' }}>
+                                                    <span style={{ fontSize: '16px', color: 'rgba(255,215,0,0.6)' }}>⚙</span>
+                                                </div>
+                                                <span className={styles.shopBuildTreeCompPrice}>
+                                                    <span className={styles.shopGoldIcon}>⚙</span>
+                                                    {(selected.price - (selected.buildsFrom?.reduce((s, c) => s + c.price, 0) || 0)).toLocaleString()}
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </>
+                                )}
+                            </div>
+
+                            {/* Purchase button */}
+                            <button
+                                className={`${styles.shopPurchaseBtn} ${canAfford && !alreadyOwned ? styles.shopPurchaseBtnActive : ''}`}
+                                disabled={!canAfford || alreadyOwned}
+                                onClick={handlePurchase}
+                            >
+                                {alreadyOwned ? 'OWNED' : 'PURCHASE ITEM'}
+                            </button>
+
+                            {/* Item detail panel */}
+                            <div className={styles.shopDetailPanel}>
+                                <div className={styles.shopDetailHeader}>
+                                    <div className={styles.shopDetailIcon}>
+                                        <ItemIcon itemId={selected.id} size={32} />
+                                    </div>
+                                    <div className={styles.shopDetailInfo}>
+                                        <span className={styles.shopDetailName}>{selected.name}</span>
+                                        <span className={styles.shopDetailPrice}>
+                                            <span className={styles.shopGoldIcon}>⚙</span> {selected.price.toLocaleString()}
+                                        </span>
+                                    </div>
+                                </div>
+
+                                {/* Stats */}
+                                {selected.stats && (
+                                    <div className={styles.shopDetailStats}>
+                                        {selected.stats.map((stat, i) => (
+                                            <div key={i} className={styles.shopDetailStatRow}>
+                                                <span className={styles.shopDetailStatIcon}>
+                                                    {stat.label === 'Damage' ? '⚔' :
+                                                     stat.label === 'Special' ? '◆' :
+                                                     stat.label === 'Type' ? '◉' : '○'}
+                                                </span>
+                                                <span className={styles.shopDetailStatValue}>{stat.value}</span>
+                                                <span className={styles.shopDetailStatLabel}>{stat.label}</span>
+                                            </div>
+                                        ))}
+                                    </div>
+                                )}
+
+                                {/* Description / passive */}
+                                <div className={styles.shopDetailPassive}>
+                                    <div className={styles.shopDetailPassiveName}>{selected.nameJa}</div>
+                                    <p className={styles.shopDetailPassiveDesc}>{selected.descriptionJa}</p>
+                                </div>
+                            </div>
+                        </>
+                    ) : (
+                        <div className={styles.shopEmptyDetail}>
+                            <span>Select an item to view details</span>
+                            <span className={styles.shopEmptyDetailSub}>アイテムを選択してください</span>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/rhythmia/tetris/components/index.ts
+++ b/src/components/rhythmia/tetris/components/index.ts
@@ -22,3 +22,6 @@ export { TerrainParticles } from './TerrainParticles';
 export { WorldTransition, GamePhaseIndicator } from './WorldTransition';
 export { HealthManaHUD } from './HealthManaHUD';
 export { TutorialGuide, hasTutorialBeenSeen } from './TutorialGuide';
+export { InventoryUI } from './InventoryUI';
+export { ShopUI } from './ShopUI';
+export { KeyBindSettings } from './KeyBindSettings';

--- a/src/components/rhythmia/tetris/constants.ts
+++ b/src/components/rhythmia/tetris/constants.ts
@@ -244,6 +244,122 @@ export const WEAPON_CARDS: WeaponCard[] = [
 
 export const WEAPON_CARD_MAP: Record<string, WeaponCard> = Object.fromEntries(WEAPON_CARDS.map(c => [c.id, c]));
 
+// ===== Shop Item Definitions =====
+import type { ShopItem, KeyBindings } from './types';
+
+export const SHOP_ITEMS: ShopItem[] = [
+    // Materials — buyable with gold (score)
+    {
+        id: 'stone', name: 'Stone Fragment', nameJa: '石片', category: 'material',
+        price: 100, icon: '🪨', color: '#8B8B8B', glowColor: '#A0A0A0', rarity: 'common',
+        description: 'A common stone fragment.', descriptionJa: '採掘で得られる一般的な石片。',
+        stats: [{ label: 'Type', value: 'Material' }, { label: 'Drop Rate', value: 'High' }],
+    },
+    {
+        id: 'iron', name: 'Iron Ore', nameJa: '鉄鉱石', category: 'material',
+        price: 200, icon: '⛏️', color: '#B87333', glowColor: '#D4956B', rarity: 'common',
+        description: 'Raw iron ore for forging.', descriptionJa: '鍛造に使われる鉄鉱石。',
+        stats: [{ label: 'Type', value: 'Material' }, { label: 'Drop Rate', value: 'Medium' }],
+    },
+    {
+        id: 'crystal', name: 'Crystal Shard', nameJa: '水晶片', category: 'material',
+        price: 500, icon: '💎', color: '#4FC3F7', glowColor: '#81D4FA', rarity: 'uncommon',
+        description: 'A glowing crystal shard.', descriptionJa: '輝く水晶の破片。',
+        stats: [{ label: 'Type', value: 'Material' }, { label: 'Drop Rate', value: 'Low' }],
+    },
+    {
+        id: 'gold', name: 'Gold Nugget', nameJa: '金塊', category: 'material',
+        price: 1000, icon: '✨', color: '#FFD700', glowColor: '#FFECB3', rarity: 'rare',
+        description: 'A rare gold nugget.', descriptionJa: '貴重な金の塊。',
+        stats: [{ label: 'Type', value: 'Material' }, { label: 'Drop Rate', value: 'Very Low' }],
+    },
+    {
+        id: 'obsidian', name: 'Obsidian Core', nameJa: '黒曜核', category: 'material',
+        price: 2500, icon: '🔮', color: '#9C27B0', glowColor: '#CE93D8', rarity: 'epic',
+        description: 'An obsidian core pulsing with energy.', descriptionJa: 'エネルギーが脈打つ黒曜核。',
+        stats: [{ label: 'Type', value: 'Material' }, { label: 'Drop Rate', value: 'Rare' }],
+    },
+    {
+        id: 'star', name: 'Star Fragment', nameJa: '星の欠片', category: 'material',
+        price: 5000, icon: '⭐', color: '#E0E0E0', glowColor: '#FFFFFF', rarity: 'legendary',
+        description: 'A fragment of a fallen star.', descriptionJa: '流れ星の欠片。',
+        stats: [{ label: 'Type', value: 'Material' }, { label: 'Drop Rate', value: 'Ultra Rare' }],
+    },
+    // Weapons — buyable directly with gold
+    {
+        id: 'stone_blade', name: 'Stone Blade', nameJa: '石の刃', category: 'weapon',
+        price: 500, icon: '🗡️', color: '#9E9E9E', glowColor: '#BDBDBD', rarity: 'common',
+        description: '+10% terrain damage', descriptionJa: '地形ダメージ+10%',
+        stats: [{ label: 'Damage', value: '+10%' }, { label: 'Type', value: 'Blade' }],
+        buildsFrom: [{ itemId: 'stone', price: 100 }],
+    },
+    {
+        id: 'iron_pickaxe', name: 'Iron Pickaxe', nameJa: '鉄のピッケル', category: 'weapon',
+        price: 800, icon: '⛏️', color: '#B87333', glowColor: '#D4956B', rarity: 'common',
+        description: '+20% terrain damage', descriptionJa: '地形ダメージ+20%',
+        stats: [{ label: 'Damage', value: '+20%' }, { label: 'Type', value: 'Pickaxe' }],
+        buildsFrom: [{ itemId: 'iron', price: 200 }],
+    },
+    {
+        id: 'crystal_wand', name: 'Crystal Wand', nameJa: '水晶の杖', category: 'weapon',
+        price: 1500, icon: '🪄', color: '#4FC3F7', glowColor: '#81D4FA', rarity: 'uncommon',
+        description: '+30% damage, wider beat window', descriptionJa: 'ダメージ+30%、ビート判定拡大',
+        stats: [{ label: 'Damage', value: '+30%' }, { label: 'Special', value: 'Wide Beat' }],
+        buildsFrom: [{ itemId: 'crystal', price: 500 }, { itemId: 'stone', price: 100 }],
+    },
+    {
+        id: 'gold_hammer', name: 'Gold Hammer', nameJa: '黄金のハンマー', category: 'weapon',
+        price: 2500, icon: '🔨', color: '#FFD700', glowColor: '#FFECB3', rarity: 'rare',
+        description: '+40% terrain damage', descriptionJa: '地形ダメージ+40%',
+        stats: [{ label: 'Damage', value: '+40%' }, { label: 'Type', value: 'Hammer' }],
+        buildsFrom: [{ itemId: 'gold', price: 1000 }, { itemId: 'iron', price: 200 }],
+    },
+    {
+        id: 'obsidian_edge', name: 'Obsidian Edge', nameJa: '黒曜の刃', category: 'weapon',
+        price: 4000, icon: '🌑', color: '#9C27B0', glowColor: '#CE93D8', rarity: 'epic',
+        description: '+60% damage, shatter effect', descriptionJa: 'ダメージ+60%、粉砕効果',
+        stats: [{ label: 'Damage', value: '+60%' }, { label: 'Special', value: 'Shatter' }],
+        buildsFrom: [{ itemId: 'obsidian', price: 2500 }, { itemId: 'iron', price: 200 }],
+    },
+    {
+        id: 'star_cannon', name: 'Star Cannon', nameJa: '星砲', category: 'weapon',
+        price: 8000, icon: '💫', color: '#E0E0E0', glowColor: '#FFFFFF', rarity: 'legendary',
+        description: '+80% damage, burst particles', descriptionJa: 'ダメージ+80%、爆発効果',
+        stats: [{ label: 'Damage', value: '+80%' }, { label: 'Special', value: 'Burst' }],
+        buildsFrom: [{ itemId: 'star', price: 5000 }, { itemId: 'crystal', price: 500 }],
+    },
+];
+
+export const SHOP_ITEM_MAP: Record<string, ShopItem> = Object.fromEntries(SHOP_ITEMS.map(i => [i.id, i]));
+
+// ===== Key Bindings =====
+export const DEFAULT_KEY_BINDINGS: KeyBindings = {
+    inventory: 'e',
+    shop: 'l',
+    forge: 'f',
+};
+
+const KEY_BINDINGS_STORAGE_KEY = 'rhythmia-keybindings';
+
+export function loadKeyBindings(): KeyBindings {
+    if (typeof window === 'undefined') return { ...DEFAULT_KEY_BINDINGS };
+    try {
+        const saved = localStorage.getItem(KEY_BINDINGS_STORAGE_KEY);
+        if (saved) {
+            const parsed = JSON.parse(saved);
+            return { ...DEFAULT_KEY_BINDINGS, ...parsed };
+        }
+    } catch { /* ignore */ }
+    return { ...DEFAULT_KEY_BINDINGS };
+}
+
+export function saveKeyBindings(bindings: KeyBindings): void {
+    if (typeof window === 'undefined') return;
+    try {
+        localStorage.setItem(KEY_BINDINGS_STORAGE_KEY, JSON.stringify(bindings));
+    } catch { /* ignore */ }
+}
+
 // Items dropped per terrain damage unit
 export const ITEMS_PER_TERRAIN_DAMAGE = 0.3;
 

--- a/src/components/rhythmia/tetris/hooks/useGameState.ts
+++ b/src/components/rhythmia/tetris/hooks/useGameState.ts
@@ -87,6 +87,11 @@ export function useGameState() {
     const [craftedCards, setCraftedCards] = useState<CraftedCard[]>([]);
     const [showCraftUI, setShowCraftUI] = useState(false);
 
+    // ===== Inventory & Shop UI =====
+    const [showInventory, setShowInventory] = useState(false);
+    const [showShop, setShowShop] = useState(false);
+    const [gold, setGold] = useState(0);
+
     // ===== Tower Defense =====
     const [enemies, setEnemies] = useState<Enemy[]>([]);
     const [bullets, setBullets] = useState<Bullet[]>([]);
@@ -203,9 +208,11 @@ export function useGameState() {
         });
     }, []);
 
-    // Update score with pop animation
+    // Update score with pop animation — also grants gold
     const updateScore = useCallback((newScore: number) => {
+        const earned = Math.max(0, newScore - scoreRef.current);
         setScore(newScore);
+        setGold(prev => prev + earned);
         setScorePop(true);
         setTimeout(() => setScorePop(false), 100);
     }, []);
@@ -641,6 +648,66 @@ export function useGameState() {
         }
     }, [showCraftUI]);
 
+    // Toggle inventory UI
+    const toggleInventory = useCallback(() => {
+        setShowInventory(prev => {
+            const next = !prev;
+            if (next) {
+                // Close other overlays
+                setShowShop(false);
+                setShowCraftUI(false);
+                setIsPaused(true);
+            } else {
+                setIsPaused(false);
+                setGamePhase('PLAYING');
+            }
+            return next;
+        });
+    }, []);
+
+    // Toggle shop UI
+    const toggleShop = useCallback(() => {
+        setShowShop(prev => {
+            const next = !prev;
+            if (next) {
+                // Close other overlays
+                setShowInventory(false);
+                setShowCraftUI(false);
+                setIsPaused(true);
+            } else {
+                setIsPaused(false);
+                setGamePhase('PLAYING');
+            }
+            return next;
+        });
+    }, []);
+
+    // Purchase item from shop using gold
+    const purchaseItem = useCallback((itemId: string, price: number): boolean => {
+        if (gold < price) return false;
+        setGold(prev => prev - price);
+
+        // Check if it's a weapon card
+        const weaponCard = WEAPON_CARD_MAP[itemId];
+        if (weaponCard) {
+            setCraftedCards(prev => [...prev, { cardId: itemId, craftedAt: Date.now() }]);
+            return true;
+        }
+
+        // It's a material — add to inventory
+        setInventory(prev => {
+            const updated = [...prev];
+            const existing = updated.find(i => i.itemId === itemId);
+            if (existing) {
+                existing.count += 1;
+            } else {
+                updated.push({ itemId, count: 1 });
+            }
+            return updated;
+        });
+        return true;
+    }, [gold, inventory]);
+
     // Set phase to PLAYING (after world creation animation)
     const enterPlayPhase = useCallback(() => {
         setGamePhase('PLAYING');
@@ -692,6 +759,9 @@ export function useGameState() {
         setFloatingItems([]);
         setTerrainParticles([]);
         setShowCraftUI(false);
+        setShowInventory(false);
+        setShowShop(false);
+        setGold(0);
 
         // Reset tower defense state (always reset, only used in TD mode)
         setEnemies([]);
@@ -774,6 +844,10 @@ export function useGameState() {
         craftedCards,
         showCraftUI,
         damageMultiplier,
+        // Inventory & Shop
+        showInventory,
+        showShop,
+        gold,
         // Game mode
         gameMode,
 
@@ -852,6 +926,9 @@ export function useGameState() {
         craftCard,
         canCraftCard,
         toggleCraftUI,
+        toggleInventory,
+        toggleShop,
+        purchaseItem,
         enterPlayPhase,
         triggerCollapse,
         triggerTransition,

--- a/src/components/rhythmia/tetris/types.ts
+++ b/src/components/rhythmia/tetris/types.ts
@@ -156,6 +156,30 @@ export type Bullet = {
     alive: boolean;
 };
 
+// ===== Shop System =====
+export type ShopItem = {
+    id: string;
+    name: string;
+    nameJa: string;
+    category: 'material' | 'weapon';
+    price: number;
+    icon: string;
+    color: string;
+    glowColor: string;
+    rarity: ItemRarity;
+    description: string;
+    descriptionJa: string;
+    stats?: { label: string; value: string }[];
+    buildsFrom?: { itemId: string; price: number }[];
+};
+
+// ===== Key Bindings =====
+export type KeyBindings = {
+    inventory: string;
+    shop: string;
+    forge: string;
+};
+
 // ===== Terrain Particle =====
 export type TerrainParticle = {
     id: number;


### PR DESCRIPTION
- Inventory UI: Full-screen Minecraft Dungeons-style overlay with character equipment slots, item grid, and detailed item info panel with stat bars and enchantment slots
- Shop UI: League of Legends-style shop with recommended/all items tabs, search bar, item cards with gold prices, build tree visualization, and purchase button. Gold is earned alongside score from line clears
- Key Bindings: Configurable in pause menu settings panel. Inventory (E), Shop (L), and Forge (F) keys can be rebound. Persisted to localStorage
- Game state: Added gold currency, showInventory/showShop states, purchase and toggle actions to useGameState hook
- Types: Added ShopItem, KeyBindings types and shop item definitions with material and weapon categories

https://claude.ai/code/session_01KSna3iAxpVjZ6mBJLS6eXT