### PR TITLE
Rebrand to azuretier.net and redesign game mode selection UI

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -9,8 +9,8 @@
     },
     "lobby": {
         "loading": "LOADING",
-        "selectServer": "SELECT SERVER",
-        "chooseMode": "Choose your mode",
+        "selectServer": "SELECT MODE",
+        "chooseMode": "Choose your game mode",
         "play": "PLAY",
         "battle": "BATTLE",
         "back": "← Back",
@@ -18,15 +18,17 @@
         "onlineCount": "{count} online"
     },
     "vanilla": {
-        "badge": "OFFICIAL",
-        "title": "Single Player",
-        "gameTitle": "RHYTHMIA — VANILLA"
+        "badge": "SOLO",
+        "title": "RHYTHMIA",
+        "subtitle": "Classic Rhythm Puzzle",
+        "description": "Drop blocks to the beat. Clear lines, build combos, and chase high scores in the original solo mode.",
+        "gameTitle": "RHYTHMIA"
     },
     "multiplayer": {
         "badge": "1v1",
-        "title": "BATTLE ARENA",
-        "gameTitle": "BATTLE ARENA — 1v1",
-        "subtitle": "Multiplayer 1v1",
+        "title": "1v1 BATTLE",
+        "gameTitle": "1v1 BATTLE",
+        "subtitle": "Ranked Multiplayer",
         "description": "Real-time 1v1 battles. Send garbage lines to your opponent. Last one standing wins.",
         "features": {
             "vs": "1v1",
@@ -94,8 +96,20 @@
         "mp_games_50": { "name": "Arena Veteran", "desc": "Play 50 multiplayer matches" }
     },
     "arena": {
-        "title": "ARENA",
-        "subtitle": "9-PLAYER RHYTHM BATTLE",
+        "badge": "9P",
+        "title": "RHYTHM ARENA",
+        "subtitle": "9-Player Battle Royale",
+        "description": "9 players, 1 rhythm. Shared chaos, synced tempo, random gimmicks. Stay on beat or the tempo collapses.",
+        "features": {
+            "players": "9 Players",
+            "chaos": "Chaos",
+            "sync": "Rhythm Sync"
+        },
+        "stats": {
+            "players": "Players",
+            "bpm": "BPM",
+            "status": "Status"
+        },
         "maxPlayers": "{count} Players Max",
         "quickMatch": "QUICK MATCH",
         "createArena": "Create Arena",
@@ -144,7 +158,7 @@
         "backToLobby": "Back to Lobby"
     },
     "footer": {
-        "copyright": "RHYTHMIA © 2025"
+        "copyright": "azuretier.net © 2025"
     },
     "localeSwitcher": {
         "label": "Language",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -9,8 +9,8 @@
     },
     "lobby": {
         "loading": "読み込み中",
-        "selectServer": "サーバーを選択",
-        "chooseMode": "モードを選択してください",
+        "selectServer": "モード選択",
+        "chooseMode": "ゲームモードを選択してください",
         "play": "プレイ",
         "battle": "バトル",
         "back": "← 戻る",
@@ -18,15 +18,17 @@
         "onlineCount": "{count} オンライン"
     },
     "vanilla": {
-        "badge": "公式",
-        "title": "Single Player",
-        "gameTitle": "RHYTHMIA — VANILLA"
+        "badge": "ソロ",
+        "title": "RHYTHMIA",
+        "subtitle": "クラシック リズムパズル",
+        "description": "ビートに合わせてブロックを落とそう。ライン消去、コンボ、ハイスコアを目指すソロモード。",
+        "gameTitle": "RHYTHMIA"
     },
     "multiplayer": {
         "badge": "1v1",
-        "title": "BATTLE ARENA",
-        "gameTitle": "BATTLE ARENA — 1v1",
-        "subtitle": "マルチプレイヤー 1v1",
+        "title": "1v1 バトル",
+        "gameTitle": "1v1 バトル",
+        "subtitle": "ランクマッチ",
         "description": "リアルタイム1v1バトル。相手にお邪魔ラインを送り込もう。最後まで立っていた者が勝利。",
         "features": {
             "vs": "1v1",
@@ -94,8 +96,20 @@
         "mp_games_50": { "name": "アリーナベテラン", "desc": "マルチプレイヤー50戦" }
     },
     "arena": {
-        "title": "ARENA",
-        "subtitle": "9人リズムバトル",
+        "badge": "9P",
+        "title": "リズムアリーナ",
+        "subtitle": "9人バトルロイヤル",
+        "description": "9人で1つのリズム。共有カオス、同期テンポ、ランダムギミック。ビートを外せばテンポが崩壊する。",
+        "features": {
+            "players": "9人対戦",
+            "chaos": "カオス",
+            "sync": "リズム同期"
+        },
+        "stats": {
+            "players": "人数",
+            "bpm": "BPM",
+            "status": "状態"
+        },
         "maxPlayers": "最大{count}人",
         "quickMatch": "クイックマッチ",
         "createArena": "アリーナ作成",
@@ -144,7 +158,7 @@
         "backToLobby": "ロビーに戻る"
     },
     "footer": {
-        "copyright": "RHYTHMIA © 2025"
+        "copyright": "azuretier.net © 2025"
     },
     "localeSwitcher": {
         "label": "言語",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -177,7 +177,7 @@ export default function RhythmiaPage() {
                     animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? -20 : 0 }}
                     transition={{ duration: 0.6, delay: 0.1 }}
                 >
-                    <div className={styles.logo}>RHYTHMIA</div>
+                    <div className={styles.logo}>azuretier<span className={styles.logoAccent}>.net</span></div>
                     <div className={styles.statusBar}>
                         <button
                             className={styles.advButton}
@@ -229,7 +229,7 @@ export default function RhythmiaPage() {
                     </motion.div>
 
                     <div className={styles.serverGrid}>
-                        {/* Vanilla Server */}
+                        {/* Rhythmia (Solo Mode) */}
                         <motion.div
                             className={`${styles.serverCard} ${styles.vanilla}`}
                             onClick={() => launchGame('vanilla')}
@@ -240,6 +240,8 @@ export default function RhythmiaPage() {
                         >
                             <span className={styles.cardBadge}>{t('vanilla.badge')}</span>
                             <h2 className={styles.cardTitle}>{t('vanilla.title')}</h2>
+                            <p className={styles.cardSubtitle}>{t('vanilla.subtitle')}</p>
+                            <p className={styles.cardDescription}>{t('vanilla.description')}</p>
                             <button className={styles.playButton}>{t('lobby.play')}</button>
                         </motion.div>
 
@@ -305,29 +307,29 @@ export default function RhythmiaPage() {
                             transition={{ duration: 0.6, delay: 0.6 }}
                             whileHover={{ y: -8, transition: { duration: 0.25 } }}
                         >
-                            <span className={`${styles.cardBadge} ${styles.new}`}>9P</span>
+                            <span className={`${styles.cardBadge} ${styles.new}`}>{t('arena.badge')}</span>
                             <h2 className={styles.cardTitle}>{t('arena.title')}</h2>
                             <p className={styles.cardSubtitle}>{t('arena.subtitle')}</p>
                             <p className={styles.cardDescription}>
-                                9 players, 1 rhythm. Shared chaos, synced tempo, random gimmicks. Stay on beat or the tempo collapses.
+                                {t('arena.description')}
                             </p>
                             <div className={styles.cardFeatures}>
-                                <span className={styles.featureTag}>9 Players</span>
-                                <span className={styles.featureTag}>Chaos</span>
-                                <span className={styles.featureTag}>Rhythm Sync</span>
+                                <span className={styles.featureTag}>{t('arena.features.players')}</span>
+                                <span className={styles.featureTag}>{t('arena.features.chaos')}</span>
+                                <span className={styles.featureTag}>{t('arena.features.sync')}</span>
                             </div>
                             <div className={styles.cardStats}>
                                 <div className={styles.stat}>
                                     <div className={styles.statValue}>9</div>
-                                    <div className={styles.statLabel}>Players</div>
+                                    <div className={styles.statLabel}>{t('arena.stats.players')}</div>
                                 </div>
                                 <div className={styles.stat}>
                                     <div className={styles.statValue}>120+</div>
-                                    <div className={styles.statLabel}>BPM</div>
+                                    <div className={styles.statLabel}>{t('arena.stats.bpm')}</div>
                                 </div>
                                 <div className={styles.stat}>
                                     <div className={styles.statValue}>LIVE</div>
-                                    <div className={styles.statLabel}>Status</div>
+                                    <div className={styles.statLabel}>{t('arena.stats.status')}</div>
                                 </div>
                             </div>
                             <button className={styles.playButton}>{t('arena.quickMatch')}</button>

--- a/src/components/main/UpdatesPage.tsx
+++ b/src/components/main/UpdatesPage.tsx
@@ -76,7 +76,7 @@ export default function UpdatesPage() {
           <button className={styles.backBtn} onClick={() => router.push('/')}>
             {ja ? '← ロビー' : '← Lobby'}
           </button>
-          <span className={styles.logo}>RHYTHMIA</span>
+          <span className={styles.logo}>azuretier.net</span>
           <span className={styles.updatesLabel}>{ja ? 'アップデート' : 'UPDATES'}</span>
         </div>
         <div className={styles.headerRight}>

--- a/src/components/rhythmia/rhythmia.module.css
+++ b/src/components/rhythmia/rhythmia.module.css
@@ -140,11 +140,16 @@
 }
 
 .logo {
-  font-size: 1rem;
-  font-weight: 600;
-  letter-spacing: 0.35em;
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
   color: #ffffff;
-  opacity: 0.9;
+  opacity: 0.95;
+}
+
+.logoAccent {
+  font-weight: 400;
+  opacity: 0.45;
 }
 
 .statusBar {
@@ -226,10 +231,11 @@
 /* Server selection grid */
 .serverGrid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(280px, 420px));
-  gap: 24px;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
   width: 100%;
-  max-width: 900px;
+  max-width: 1080px;
+  align-items: start;
   justify-content: center;
 }
 
@@ -239,7 +245,7 @@
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 12px;
-  padding: 36px 28px;
+  padding: 28px 24px;
   cursor: pointer;
   transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
   overflow: hidden;
@@ -580,6 +586,8 @@
   .serverGrid {
     grid-template-columns: 1fr;
     padding: 0 16px;
+    max-width: 420px;
+    margin: 0 auto;
   }
 
   .heroText h1 {

--- a/src/components/wiki/WikiPage.tsx
+++ b/src/components/wiki/WikiPage.tsx
@@ -206,7 +206,7 @@ export default function WikiPage() {
           <button className={styles.backBtn} onClick={() => router.push('/')}>
             {ja ? '← ロビー' : '← Lobby'}
           </button>
-          <span className={styles.logo}>RHYTHMIA</span>
+          <span className={styles.logo}>azuretier.net</span>
           <span className={styles.wikiLabel}>WIKI</span>
         </div>
         <div className={styles.headerRight}>


### PR DESCRIPTION
## Summary
This PR rebrand the application from "RHYTHMIA" to "azuretier.net" and redesigns the game mode selection interface with improved layout, typography, and content presentation.

## Key Changes

**Branding Updates:**
- Changed logo from "RHYTHMIA" to "azuretier.net" with accent styling for the domain extension
- Updated footer copyright to reflect new branding
- Updated all page headers (Updates, Wiki) to use new branding

**Game Mode Selection UI Redesign:**
- Changed server grid layout from 2-column to 3-column responsive design
- Adjusted grid spacing and max-width for better visual balance
- Updated card padding and sizing for improved density
- Enhanced logo styling with increased font weight and adjusted letter-spacing

**Content & Localization Improvements:**
- Added subtitle and description fields to vanilla (solo) mode card
- Expanded arena mode with new badge, subtitle, description, features, and stats sections
- Updated all mode titles and subtitles for clarity:
  - "Single Player" → "RHYTHMIA" (vanilla)
  - "BATTLE ARENA" → "1v1 BATTLE" (multiplayer)
  - "ARENA" → "RHYTHM ARENA" (9-player)
- Updated badge labels: "OFFICIAL" → "SOLO", "BATTLE ARENA — 1v1" → "1v1 BATTLE"
- Localized all new content strings in both English and Japanese

**Component Updates:**
- Added `.logoAccent` CSS class for styling domain extension
- Updated vanilla card to display subtitle and description
- Replaced hardcoded arena content with translation keys for full i18n support
- Improved responsive behavior with centered mobile layout

## Implementation Details
- All new content is fully localized in `messages/en.json` and `messages/ja.json`
- CSS changes maintain existing animation and transition effects
- Mobile responsiveness preserved with updated grid constraints
- Translation keys used throughout for maintainability

https://claude.ai/code/session_014mxKjPXG2XEgDCNq3h4P9r