### PR TITLE
Integrate Tetris game engine into Arena multiplayer mode

### DIFF
--- a/src/components/arena/ArenaGame.module.css
+++ b/src/components/arena/ArenaGame.module.css
@@ -801,3 +801,83 @@
     grid-template-columns: repeat(2, 1fr);
   }
 }
+
+/* ===== Arena Game Side Panels (Hold / Next) ===== */
+.arenaSidePanel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  min-width: 60px;
+}
+
+.arenaSidePanelLabel {
+  font-size: 0.55rem;
+  color: rgba(255, 255, 255, 0.3);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+/* Piece preview grid (used for hold/next display) */
+.piecePreviewGrid {
+  display: flex;
+  flex-direction: column;
+}
+
+.piecePreviewRow {
+  display: flex;
+}
+
+.piecePreviewCell {
+  width: 12px;
+  height: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.03);
+  box-sizing: border-box;
+}
+
+.piecePreviewCell.filled {
+  border-color: rgba(0, 0, 0, 0.2);
+}
+
+.piecePreviewEmpty {
+  width: 48px;
+  height: 48px;
+}
+
+/* Game stats in HUD */
+.arenaGameStats {
+  display: flex;
+  gap: 16px;
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.5);
+  letter-spacing: 0.05em;
+}
+
+.arenaGameStats span {
+  font-variant-numeric: tabular-nums;
+}
+
+.arenaStatValue {
+  color: var(--arena-accent);
+  font-weight: 500;
+}
+
+/* Game over overlay on board */
+.boardGameOver {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 10;
+}
+
+.boardGameOverText {
+  font-size: 1.2rem;
+  font-weight: 300;
+  color: var(--arena-danger);
+  letter-spacing: 0.3em;
+  text-shadow: 0 0 20px rgba(255, 51, 102, 0.3);
+}

--- a/src/components/arena/ArenaGame.tsx
+++ b/src/components/arena/ArenaGame.tsx
@@ -3,8 +3,20 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useArenaSocket } from '@/hooks/useArenaSocket';
 import { useTranslations } from 'next-intl';
-import type { ArenaGimmick, ArenaBoardPayload } from '@/types/arena';
-import { ARENA_MAX_PLAYERS, GIMMICK_DURATIONS } from '@/types/arena';
+import type { ArenaBoardPayload } from '@/types/arena';
+import { ARENA_MAX_PLAYERS } from '@/types/arena';
+
+// Tetris engine
+import { useGameState } from '@/components/rhythmia/tetris/hooks';
+import {
+  BOARD_HEIGHT, BOARD_WIDTH, COLORS, LOCK_DELAY, MAX_LOCK_MOVES,
+} from '@/components/rhythmia/tetris/constants';
+import {
+  isValidPosition, lockPiece, clearLines, getShape,
+  createSpawnPiece, tryRotation, getGhostY,
+} from '@/components/rhythmia/tetris/utils/boardUtils';
+import type { Piece } from '@/components/rhythmia/tetris/types';
+
 import styles from './ArenaGame.module.css';
 
 const GIMMICK_LABELS: Record<string, string> = {
@@ -20,7 +32,6 @@ const GIMMICK_LABELS: Record<string, string> = {
 
 // Mini board renderer for opponent preview
 function MiniBoardView({ board }: { board: (null | { color: string })[][] }) {
-  // Only show bottom 16 rows for mini preview
   const visibleRows = board.slice(Math.max(0, board.length - 16));
 
   return (
@@ -40,8 +51,31 @@ function MiniBoardView({ board }: { board: (null | { color: string })[][] }) {
   );
 }
 
+// Small piece preview for next/hold display
+function PiecePreview({ pieceType }: { pieceType: string | null }) {
+  if (!pieceType) return <div className={styles.piecePreviewEmpty} />;
+  const shape = getShape(pieceType, 0);
+  return (
+    <div className={styles.piecePreviewGrid}>
+      {shape.map((row, ri) => (
+        <div key={ri} className={styles.piecePreviewRow}>
+          {row.map((cell, ci) => (
+            <div
+              key={ci}
+              className={`${styles.piecePreviewCell} ${cell ? styles.filled : ''}`}
+              style={cell ? { background: COLORS[pieceType] } : undefined}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export default function ArenaGame() {
   const t = useTranslations('arena');
+
+  // ===== Arena Socket =====
   const {
     connectionStatus,
     connectWebSocket,
@@ -76,6 +110,21 @@ export default function ArenaGame() {
     leaveArena,
   } = useArenaSocket();
 
+  // ===== Tetris Game State =====
+  const gs = useGameState();
+  const {
+    board, currentPiece, nextPiece, holdPiece, canHold,
+    score, combo, lines, level, gameOver, isPlaying,
+    boardRef, currentPieceRef, scoreRef, comboRef,
+    linesRef, levelRef, gameOverRef, isPausedRef,
+    keyStatesRef, gameLoopRef, lastGravityRef,
+    dasRef, arrRef, sdfRef,
+    setBoard, setCurrentPiece, setHoldPiece, setCanHold,
+    setScore, setCombo, setLines, setLevel,
+    spawnPiece, initGame,
+  } = gs;
+
+  // ===== UI State =====
   const [playerName, setPlayerName] = useState('');
   const [joinCode, setJoinCode] = useState('');
   const [showElimBanner, setShowElimBanner] = useState(false);
@@ -83,13 +132,16 @@ export default function ArenaGame() {
   const elimTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const collapseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Lock delay
+  const lockStartTimeRef = useRef<number | null>(null);
+  const lockMovesRef = useRef(0);
+
+  // Game init tracking
+  const gameInitRef = useRef(false);
+
   // Beat indicator
   const onBeat = beatPhase > 0.75 || beatPhase < 0.15;
-
-  // My sync accuracy
   const mySync = syncMap[playerId] ?? 1.0;
-
-  // Chaos bar class
   const chaosClass = chaosLevel >= 75 ? styles.chaosHigh
     : chaosLevel >= 40 ? styles.chaosMedium : styles.chaosLow;
 
@@ -123,7 +175,7 @@ export default function ArenaGame() {
   const allReady = arenaState?.players.every(p => p.ready || p.id === arenaState.hostId)
     && (arenaState?.players.length ?? 0) >= 3;
 
-  // ===== Handlers =====
+  // ===== Lobby Handlers =====
   const handleNameSubmit = useCallback(() => {
     if (playerName.trim().length < 2) return;
     const next = sessionStorage.getItem('arena_nextMode');
@@ -133,7 +185,6 @@ export default function ArenaGame() {
     } else if (next === 'create') {
       createArena(playerName.trim());
     } else {
-      // Default: go to queue
       queueForArena(playerName.trim());
     }
   }, [playerName, queueForArena, createArena]);
@@ -147,22 +198,429 @@ export default function ArenaGame() {
     joinArena(code, playerName.trim());
   }, [joinCode, joinArena, playerName, setError]);
 
-  // ===== Simulated board for demo (the actual game engine would plug in here) =====
-  // In a full implementation, this would use the tetris engine from components/rhythmia/tetris
-  // For now, we render the arena structure and opponent boards from relayed data
+  // ===== Game Engine Integration =====
 
-  // Empty 10x20 board for display
-  const emptyBoard = useMemo(() => {
-    const board: (null | { color: string })[][] = [];
-    for (let r = 0; r < 20; r++) {
-      const row: (null | { color: string })[] = [];
-      for (let c = 0; c < 10; c++) {
-        row.push(null);
-      }
-      board.push(row);
+  // Initialize game when arena phase becomes 'playing'
+  useEffect(() => {
+    if (phase === 'playing' && !gameInitRef.current) {
+      gameInitRef.current = true;
+      lockStartTimeRef.current = null;
+      lockMovesRef.current = 0;
+      initGame('vanilla');
     }
-    return board;
-  }, []);
+    if (phase !== 'playing' && phase !== 'ended') {
+      gameInitRef.current = false;
+    }
+  }, [phase, initGame]);
+
+  // ===== Game Mechanics =====
+
+  const movePiece = useCallback((dx: number, dy: number): boolean => {
+    const piece = currentPieceRef.current;
+    if (!piece || gameOverRef.current) return false;
+    const newPiece: Piece = { ...piece, x: piece.x + dx, y: piece.y + dy };
+    if (isValidPosition(newPiece, boardRef.current)) {
+      setCurrentPiece(newPiece);
+      currentPieceRef.current = newPiece;
+      return true;
+    }
+    return false;
+  }, [setCurrentPiece, currentPieceRef, boardRef, gameOverRef]);
+
+  const moveHorizontal = useCallback((dx: number): boolean => {
+    const result = movePiece(dx, 0);
+    if (result && lockStartTimeRef.current !== null) {
+      const piece = currentPieceRef.current;
+      if (piece) {
+        if (isValidPosition({ ...piece, y: piece.y + 1 }, boardRef.current)) {
+          lockStartTimeRef.current = null;
+        } else if (lockMovesRef.current < MAX_LOCK_MOVES) {
+          lockMovesRef.current++;
+          lockStartTimeRef.current = performance.now();
+        }
+      }
+    }
+    return result;
+  }, [movePiece, currentPieceRef, boardRef]);
+
+  const rotatePiece = useCallback((direction: 1 | -1) => {
+    const piece = currentPieceRef.current;
+    if (!piece || gameOverRef.current) return;
+    const rotated = tryRotation(piece, direction, boardRef.current);
+    if (rotated) {
+      setCurrentPiece(rotated);
+      currentPieceRef.current = rotated;
+      if (lockStartTimeRef.current !== null) {
+        if (isValidPosition({ ...rotated, y: rotated.y + 1 }, boardRef.current)) {
+          lockStartTimeRef.current = null;
+        } else if (lockMovesRef.current < MAX_LOCK_MOVES) {
+          lockMovesRef.current++;
+          lockStartTimeRef.current = performance.now();
+        }
+      }
+    }
+  }, [setCurrentPiece, currentPieceRef, boardRef, gameOverRef]);
+
+  // Stable ref for beatPhase to avoid stale closure in handlePieceLock
+  const beatPhaseRef = useRef(beatPhase);
+  beatPhaseRef.current = beatPhase;
+
+  // Stable ref for holdPiece
+  const holdPieceRef = useRef(holdPiece);
+  holdPieceRef.current = holdPiece;
+
+  const handlePieceLock = useCallback((piece: Piece, dropDistance = 0) => {
+    lockStartTimeRef.current = null;
+    lockMovesRef.current = 0;
+
+    const newBoard = lockPiece(piece, boardRef.current);
+    const { newBoard: clearedBoard, clearedLines: cleared } = clearLines(newBoard);
+
+    setBoard(clearedBoard);
+    boardRef.current = clearedBoard;
+
+    // Beat judgment
+    const bp = beatPhaseRef.current;
+    const beatHit = bp > 0.75 || bp < 0.15;
+    const mult = beatHit ? 2 : 1;
+    if (beatHit) {
+      setCombo(prev => prev + 1);
+    } else {
+      setCombo(0);
+    }
+
+    // Score calculation
+    const base = dropDistance * 2 + [0, 100, 300, 500, 800][cleared] * levelRef.current;
+    const finalScore = base * mult * Math.max(1, comboRef.current);
+    setScore(prev => prev + finalScore);
+
+    setLines(prev => {
+      const newLines = prev + cleared;
+      setLevel(Math.floor(newLines / 10) + 1);
+      return newLines;
+    });
+
+    // Send to arena server
+    sendAction({ action: 'piece_placed', beatPhase: bp, value: 0 });
+    if (cleared > 0) {
+      sendAction({ action: 'line_clear', beatPhase: bp, value: cleared });
+      if (cleared === 4) {
+        sendAction({ action: 'tetris_clear', beatPhase: bp, value: 4 });
+      }
+    }
+
+    // Relay board state (convert piece types to colors for multiplayer protocol)
+    const relayBoard = clearedBoard.map(row =>
+      row.map(cell => cell ? { color: COLORS[cell] || '#ffffff' } : null)
+    );
+    sendBoardRelay({
+      board: relayBoard,
+      score: scoreRef.current + finalScore,
+      lines: linesRef.current + cleared,
+      combo: comboRef.current,
+      piece: undefined,
+      hold: holdPieceRef.current,
+      alive: true,
+    });
+
+    // Spawn next piece
+    const spawned = spawnPiece();
+    if (spawned) {
+      setCurrentPiece(spawned);
+      currentPieceRef.current = spawned;
+    }
+    // If spawned is null, spawnPiece sets gameOver = true
+  }, [
+    boardRef, levelRef, comboRef, scoreRef, linesRef,
+    setBoard, setCombo, setScore, setLines, setLevel, setCurrentPiece,
+    currentPieceRef, spawnPiece, sendAction, sendBoardRelay,
+  ]);
+
+  const handlePieceLockRef = useRef(handlePieceLock);
+  handlePieceLockRef.current = handlePieceLock;
+
+  const hardDrop = useCallback(() => {
+    const piece = currentPieceRef.current;
+    if (!piece || gameOverRef.current) return;
+    const newPiece = { ...piece };
+    let dropDist = 0;
+    while (isValidPosition({ ...newPiece, y: newPiece.y + 1 }, boardRef.current)) {
+      newPiece.y++;
+      dropDist++;
+    }
+    lockStartTimeRef.current = null;
+    lockMovesRef.current = 0;
+    sendAction({ action: 'hard_drop', beatPhase: beatPhaseRef.current, value: dropDist });
+    handlePieceLock(newPiece, dropDist);
+  }, [currentPieceRef, gameOverRef, boardRef, handlePieceLock, sendAction]);
+
+  const holdCurrentPiece = useCallback(() => {
+    if (!currentPiece || gameOver || !canHold) return;
+    lockStartTimeRef.current = null;
+    lockMovesRef.current = 0;
+    const currentType = currentPiece.type;
+    if (holdPiece === null) {
+      setHoldPiece(currentType);
+      const spawned = spawnPiece();
+      if (spawned) {
+        setCurrentPiece(spawned);
+        currentPieceRef.current = spawned;
+      }
+    } else {
+      const heldType = holdPiece;
+      setHoldPiece(currentType);
+      const newPiece = createSpawnPiece(heldType);
+      if (isValidPosition(newPiece, board)) {
+        setCurrentPiece(newPiece);
+        currentPieceRef.current = newPiece;
+      } else {
+        setHoldPiece(heldType);
+        return;
+      }
+    }
+    setCanHold(false);
+  }, [currentPiece, gameOver, canHold, holdPiece, board,
+    setHoldPiece, setCurrentPiece, setCanHold, spawnPiece, currentPieceRef]);
+
+  const tick = useCallback(() => {
+    const piece = currentPieceRef.current;
+    if (!piece || gameOverRef.current) return;
+    const newPiece: Piece = { ...piece, y: piece.y + 1 };
+    if (isValidPosition(newPiece, boardRef.current)) {
+      setCurrentPiece(newPiece);
+      currentPieceRef.current = newPiece;
+    }
+  }, [currentPieceRef, gameOverRef, boardRef, setCurrentPiece]);
+
+  // DAS/ARR processing
+  const processHorizontalDasArr = useCallback((direction: 'left' | 'right', currentTime: number) => {
+    const state = keyStatesRef.current[direction];
+    if (!state.pressed || gameOverRef.current) return;
+    const dx = direction === 'left' ? -1 : 1;
+    const timeSincePress = currentTime - state.pressTime;
+    const currentDas = dasRef.current;
+    const currentArr = arrRef.current;
+
+    if (!state.dasCharged) {
+      if (timeSincePress >= currentDas) {
+        state.dasCharged = true;
+        state.lastMoveTime = currentTime;
+        if (currentArr === 0) {
+          while (moveHorizontal(dx)) { /* instant */ }
+        } else {
+          moveHorizontal(dx);
+        }
+      }
+    } else {
+      if (currentArr === 0) {
+        while (moveHorizontal(dx)) { /* instant */ }
+      } else if (currentTime - state.lastMoveTime >= currentArr) {
+        moveHorizontal(dx);
+        state.lastMoveTime = currentTime;
+      }
+    }
+  }, [moveHorizontal, keyStatesRef, gameOverRef, dasRef, arrRef]);
+
+  const processSoftDrop = useCallback((currentTime: number) => {
+    const state = keyStatesRef.current.down;
+    if (!state.pressed || gameOverRef.current) return;
+    const currentSdf = sdfRef.current;
+    if (currentSdf === 0) {
+      while (movePiece(0, 1)) { setScore(prev => prev + 1); }
+    } else if (currentTime - state.lastMoveTime >= currentSdf) {
+      if (movePiece(0, 1)) setScore(prev => prev + 1);
+      state.lastMoveTime = currentTime;
+    }
+  }, [movePiece, setScore, keyStatesRef, gameOverRef, sdfRef]);
+
+  // ===== Game Loop =====
+  useEffect(() => {
+    if (phase !== 'playing' || !isPlaying || gameOver) return;
+
+    const gameLoop = (currentTime: number) => {
+      if (!gameOverRef.current) {
+        processHorizontalDasArr('left', currentTime);
+        processHorizontalDasArr('right', currentTime);
+        processSoftDrop(currentTime);
+
+        const speed = Math.max(100, 1000 - (levelRef.current - 1) * 100);
+        if (currentTime - lastGravityRef.current >= speed) {
+          tick();
+          lastGravityRef.current = currentTime;
+        }
+
+        // Lock delay
+        const piece = currentPieceRef.current;
+        if (piece) {
+          const onGround = !isValidPosition({ ...piece, y: piece.y + 1 }, boardRef.current);
+          if (onGround) {
+            if (lockStartTimeRef.current === null) {
+              lockStartTimeRef.current = currentTime;
+            } else if (currentTime - lockStartTimeRef.current >= LOCK_DELAY) {
+              handlePieceLockRef.current(piece);
+            }
+          } else {
+            lockStartTimeRef.current = null;
+          }
+        }
+      }
+      gameLoopRef.current = requestAnimationFrame(gameLoop);
+    };
+
+    lastGravityRef.current = performance.now();
+    gameLoopRef.current = requestAnimationFrame(gameLoop);
+
+    return () => {
+      if (gameLoopRef.current) cancelAnimationFrame(gameLoopRef.current);
+    };
+  }, [phase, isPlaying, gameOver, tick, processHorizontalDasArr, processSoftDrop,
+    gameOverRef, levelRef, lastGravityRef, gameLoopRef, currentPieceRef, boardRef]);
+
+  // ===== Keyboard Input =====
+  useEffect(() => {
+    if (phase !== 'playing' || !isPlaying || gameOver) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.repeat) return;
+      const currentTime = performance.now();
+
+      switch (e.key) {
+        case 'ArrowLeft':
+          e.preventDefault();
+          if (!keyStatesRef.current.left.pressed) {
+            keyStatesRef.current.right = { pressed: false, dasCharged: false, lastMoveTime: 0, pressTime: 0 };
+            keyStatesRef.current.left = { pressed: true, dasCharged: false, lastMoveTime: currentTime, pressTime: currentTime };
+            moveHorizontal(-1);
+          }
+          break;
+        case 'ArrowRight':
+          e.preventDefault();
+          if (!keyStatesRef.current.right.pressed) {
+            keyStatesRef.current.left = { pressed: false, dasCharged: false, lastMoveTime: 0, pressTime: 0 };
+            keyStatesRef.current.right = { pressed: true, dasCharged: false, lastMoveTime: currentTime, pressTime: currentTime };
+            moveHorizontal(1);
+          }
+          break;
+        case 'ArrowDown':
+          e.preventDefault();
+          if (!keyStatesRef.current.down.pressed) {
+            keyStatesRef.current.down = { pressed: true, dasCharged: false, lastMoveTime: currentTime, pressTime: currentTime };
+            if (movePiece(0, 1)) setScore(prev => prev + 1);
+          }
+          break;
+        case 'ArrowUp':
+        case 'x':
+        case 'X':
+          e.preventDefault();
+          rotatePiece(1);
+          break;
+        case 'z':
+        case 'Z':
+        case 'Control':
+          e.preventDefault();
+          rotatePiece(-1);
+          break;
+        case 'c':
+        case 'C':
+        case 'Shift':
+          e.preventDefault();
+          holdCurrentPiece();
+          break;
+        case ' ':
+          e.preventDefault();
+          hardDrop();
+          break;
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case 'ArrowLeft':
+          keyStatesRef.current.left = { pressed: false, dasCharged: false, lastMoveTime: 0, pressTime: 0 };
+          break;
+        case 'ArrowRight':
+          keyStatesRef.current.right = { pressed: false, dasCharged: false, lastMoveTime: 0, pressTime: 0 };
+          break;
+        case 'ArrowDown':
+          keyStatesRef.current.down = { pressed: false, dasCharged: false, lastMoveTime: 0, pressTime: 0 };
+          break;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [phase, isPlaying, gameOver, moveHorizontal, movePiece, rotatePiece,
+    hardDrop, holdCurrentPiece, setScore, keyStatesRef]);
+
+  // ===== Game Over → Notify Arena Server =====
+  useEffect(() => {
+    if (gameOver && phase === 'playing') {
+      const relayBoard = boardRef.current.map(row =>
+        row.map(cell => cell ? { color: COLORS[cell] || '#ffffff' } : null)
+      );
+      sendAction({ action: 'game_over', beatPhase: beatPhaseRef.current, value: scoreRef.current });
+      sendBoardRelay({
+        board: relayBoard,
+        score: scoreRef.current,
+        lines: linesRef.current,
+        combo: 0,
+        alive: false,
+      });
+    }
+  }, [gameOver, phase, sendAction, sendBoardRelay, scoreRef, boardRef, linesRef]);
+
+  // ===== Visual Board (board + ghost + current piece) =====
+  const visualBoard = useMemo(() => {
+    const result: (null | { color: string })[][] = [];
+    for (let r = 0; r < BOARD_HEIGHT; r++) {
+      const row: (null | { color: string })[] = [];
+      for (let c = 0; c < BOARD_WIDTH; c++) {
+        const cell = board[r]?.[c];
+        row.push(cell ? { color: COLORS[cell] || '#ffffff' } : null);
+      }
+      result.push(row);
+    }
+
+    if (currentPiece) {
+      // Ghost piece
+      const ghostY = getGhostY(currentPiece, board);
+      if (ghostY !== currentPiece.y) {
+        const shape = getShape(currentPiece.type, currentPiece.rotation);
+        const ghostColor = (COLORS[currentPiece.type] || '#ffffff') + '30';
+        for (let y = 0; y < shape.length; y++) {
+          for (let x = 0; x < shape[y].length; x++) {
+            if (shape[y][x]) {
+              const by = ghostY + y;
+              const bx = currentPiece.x + x;
+              if (by >= 0 && by < BOARD_HEIGHT && bx >= 0 && bx < BOARD_WIDTH && !result[by][bx]) {
+                result[by][bx] = { color: ghostColor };
+              }
+            }
+          }
+        }
+      }
+
+      // Current piece
+      const shape = getShape(currentPiece.type, currentPiece.rotation);
+      for (let y = 0; y < shape.length; y++) {
+        for (let x = 0; x < shape[y].length; x++) {
+          if (shape[y][x]) {
+            const by = currentPiece.y + y;
+            const bx = currentPiece.x + x;
+            if (by >= 0 && by < BOARD_HEIGHT && bx >= 0 && bx < BOARD_WIDTH) {
+              result[by][bx] = { color: COLORS[currentPiece.type] || '#ffffff' };
+            }
+          }
+        }
+      }
+    }
+
+    return result;
+  }, [board, currentPiece]);
 
   return (
     <div className={styles.container}>
@@ -195,7 +653,7 @@ export default function ArenaGame() {
       {error && (
         <div className={styles.errorBanner}>
           {error}
-          <button className={styles.errorClose} onClick={() => setError(null)}>×</button>
+          <button className={styles.errorClose} onClick={() => setError(null)}>x</button>
         </div>
       )}
 
@@ -423,6 +881,13 @@ export default function ArenaGame() {
               </div>
             )}
 
+            <div className={styles.arenaGameStats}>
+              <span><span className={styles.arenaStatValue}>{score}</span> PTS</span>
+              <span><span className={styles.arenaStatValue}>{lines}</span> LINES</span>
+              <span><span className={styles.arenaStatValue}>{combo}</span> COMBO</span>
+              <span>LV <span className={styles.arenaStatValue}>{level}</span></span>
+            </div>
+
             <div className={styles.tempoDisplay}>
               <div className={`${styles.beatIndicator} ${onBeat ? styles.onBeat : ''}`} />
               <div className={styles.bpmValue}>{Math.round(bpm)}</div>
@@ -432,10 +897,17 @@ export default function ArenaGame() {
 
           {/* Main Content: My Board + Opponents */}
           <div className={styles.arenaContent}>
-            {/* My board */}
+            {/* My board with hold/next side panels */}
             <div className={styles.myBoardArea}>
+              {/* Hold piece */}
+              <div className={styles.arenaSidePanel}>
+                <div className={styles.arenaSidePanelLabel}>HOLD</div>
+                <PiecePreview pieceType={holdPiece} />
+              </div>
+
+              {/* Game board */}
               <div className={styles.myBoard} style={{ '--cell-size': '24px' } as React.CSSProperties}>
-                {emptyBoard.map((row, ri) => (
+                {visualBoard.map((row, ri) => (
                   <div key={ri} className={styles.boardRow}>
                     {row.map((cell, ci) => (
                       <div
@@ -446,13 +918,26 @@ export default function ArenaGame() {
                     ))}
                   </div>
                 ))}
+
+                {/* Game over overlay */}
+                {gameOver && (
+                  <div className={styles.boardGameOver}>
+                    <div className={styles.boardGameOverText}>GAME OVER</div>
+                  </div>
+                )}
+              </div>
+
+              {/* Next piece */}
+              <div className={styles.arenaSidePanel}>
+                <div className={styles.arenaSidePanelLabel}>NEXT</div>
+                <PiecePreview pieceType={nextPiece || null} />
               </div>
             </div>
 
             {/* Opponents mini boards */}
             <div className={styles.opponentsSidebar}>
               {opponents.map((opp) => {
-                const board = opponentBoards.get(opp.id);
+                const oppBoard = opponentBoards.get(opp.id);
                 const oppSync = syncMap[opp.id] ?? 1.0;
 
                 return (
@@ -461,8 +946,8 @@ export default function ArenaGame() {
                     className={`${styles.opponentMini} ${!opp.alive ? styles.eliminated : ''}`}
                   >
                     <div className={styles.opponentName}>{opp.name}</div>
-                    {board ? (
-                      <MiniBoardView board={board.board} />
+                    {oppBoard ? (
+                      <MiniBoardView board={oppBoard.board} />
                     ) : (
                       <div className={styles.opponentMiniBoard}>
                         {Array.from({ length: 10 }).map((_, ri) => (
@@ -475,8 +960,8 @@ export default function ArenaGame() {
                       </div>
                     )}
                     <div className={styles.opponentStats}>
-                      <span>{board?.score ?? 0}</span>
-                      <span>{board?.lines ?? 0}L</span>
+                      <span>{oppBoard?.score ?? 0}</span>
+                      <span>{oppBoard?.lines ?? 0}L</span>
                     </div>
                     <div className={styles.opponentSync}>
                       <div


### PR DESCRIPTION
## Summary
This PR integrates the Tetris game engine into the Arena multiplayer game mode, replacing the placeholder empty board with a fully functional Tetris implementation. Players can now play Tetris competitively in the Arena with real-time board synchronization, beat-based scoring, and multiplayer state management.

## Key Changes

- **Game Engine Integration**: Connected the `useGameState` hook from the Tetris engine to manage board state, pieces, scoring, and game lifecycle
- **Game Mechanics Implementation**:
  - Piece movement (horizontal, vertical, rotation) with DAS/ARR input handling
  - Lock delay system with move counter to prevent infinite lock delays
  - Hard drop and hold piece functionality
  - Gravity-based piece falling with level-based speed progression
  - Line clearing with beat-based combo multiplier system
  
- **Input Handling**: Full keyboard support for Tetris controls (arrow keys, X/Z for rotation, C for hold, space for hard drop)

- **Visual Enhancements**:
  - Replaced empty board with actual game board rendering
  - Added ghost piece preview showing where piece will land
  - Added hold and next piece preview panels with `PiecePreview` component
  - Added game stats display (score, lines, combo, level) in the HUD
  - Added game over overlay on the board

- **Multiplayer Integration**:
  - Board state relay to other players with piece colors converted to hex format
  - Action tracking (piece placement, line clears, Tetris clears, hard drops, game over)
  - Beat phase synchronization for scoring multipliers
  - Alive/dead status tracking for elimination

- **Game Loop**: Implemented requestAnimationFrame-based game loop with gravity, lock delay, and input processing

- **Styling**: Added CSS for side panels, piece previews, game stats, and game over overlay

## Notable Implementation Details

- Lock delay uses both time-based (500ms) and move-based (15 moves) constraints to prevent infinite lock delays
- Beat judgment (within 0.75-1.0 or 0.0-0.15 of beat phase) doubles score and increments combo
- Soft drop awards 1 point per cell dropped
- Line clear scoring: 100/300/500/800 points for 1/2/3/4 lines, multiplied by level and combo
- Piece preview grid uses 12px cells for compact display in hold/next panels
- Board relay converts internal piece type strings to color hex values for multiplayer protocol compatibility

https://claude.ai/code/session_01QuPNWnyqfywGtF1HbZemNp