### PR TITLE
Notify players when others leave rooms and sync player lists

### DIFF
--- a/multiplayer-server.ts
+++ b/multiplayer-server.ts
@@ -409,11 +409,21 @@ function createRankedRoom(
   clearRankedTimer(player1Id);
   clearRankedTimer(player2Id);
 
-  // Leave any existing rooms
+  // Leave any existing rooms and notify their players
   const existing1 = roomManager.getRoomByPlayerId(player1Id);
-  if (existing1) roomManager.removePlayerFromRoom(player1Id);
+  if (existing1) {
+    const oldCode1 = existing1.code;
+    roomManager.removePlayerFromRoom(player1Id);
+    broadcastToRoom(oldCode1, { type: 'player_left', playerId: player1Id, reason: 'left' });
+    sendRoomState(oldCode1);
+  }
   const existing2 = roomManager.getRoomByPlayerId(player2Id);
-  if (existing2) roomManager.removePlayerFromRoom(player2Id);
+  if (existing2) {
+    const oldCode2 = existing2.code;
+    roomManager.removePlayerFromRoom(player2Id);
+    broadcastToRoom(oldCode2, { type: 'player_left', playerId: player2Id, reason: 'left' });
+    sendRoomState(oldCode2);
+  }
 
   // Create room with player1 as host
   const { roomCode } = roomManager.createRoom(player1Id, player1.playerName, 'Ranked Match', false, 2);
@@ -467,9 +477,14 @@ function spawnAIMatch(playerId: string): void {
   rankedQueue.delete(playerId);
   clearRankedTimer(playerId);
 
-  // Leave any existing room
+  // Leave any existing room and notify its players
   const existing = roomManager.getRoomByPlayerId(playerId);
-  if (existing) roomManager.removePlayerFromRoom(playerId);
+  if (existing) {
+    const oldCode = existing.code;
+    roomManager.removePlayerFromRoom(playerId);
+    broadcastToRoom(oldCode, { type: 'player_left', playerId, reason: 'left' });
+    sendRoomState(oldCode);
+  }
 
   // Create room with player as host
   const { roomCode } = roomManager.createRoom(playerId, queued.playerName, 'Ranked Match', false, 2);
@@ -544,10 +559,17 @@ function handleMessage(playerId: string, raw: string): void {
     }
 
     case 'create_room': {
-      // Leave any existing room
+      // Leave any existing room and notify its players
       const existing = roomManager.getRoomByPlayerId(playerId);
       if (existing) {
+        const oldRoomCode = existing.code;
         roomManager.removePlayerFromRoom(playerId);
+        broadcastToRoom(oldRoomCode, {
+          type: 'player_left',
+          playerId,
+          reason: 'left',
+        });
+        sendRoomState(oldRoomCode);
       }
 
       const { roomCode, player } = roomManager.createRoom(
@@ -572,10 +594,17 @@ function handleMessage(playerId: string, raw: string): void {
     }
 
     case 'join_room': {
-      // Leave any existing room
+      // Leave any existing room and notify its players
       const existing = roomManager.getRoomByPlayerId(playerId);
       if (existing) {
+        const oldRoomCode = existing.code;
         roomManager.removePlayerFromRoom(playerId);
+        broadcastToRoom(oldRoomCode, {
+          type: 'player_left',
+          playerId,
+          reason: 'left',
+        });
+        sendRoomState(oldRoomCode);
       }
 
       const result = roomManager.joinRoom(message.roomCode, playerId, message.playerName);
@@ -756,10 +785,17 @@ function handleMessage(playerId: string, raw: string): void {
     }
 
     case 'queue_ranked': {
-      // Remove from any existing room
+      // Remove from any existing room and notify its players
       const existing = roomManager.getRoomByPlayerId(playerId);
       if (existing) {
+        const oldRoomCode = existing.code;
         roomManager.removePlayerFromRoom(playerId);
+        broadcastToRoom(oldRoomCode, {
+          type: 'player_left',
+          playerId,
+          reason: 'left',
+        });
+        sendRoomState(oldRoomCode);
       }
 
       // Remove from queue if already in it
@@ -823,7 +859,15 @@ function handleMessage(playerId: string, raw: string): void {
 
     case 'create_arena': {
       const existing = arenaManager.getRoomByPlayerId(playerId);
-      if (existing) arenaManager.removePlayer(playerId);
+      if (existing) {
+        const oldArenaCode = existing.code;
+        arenaManager.removePlayer(playerId);
+        broadcastToArena(oldArenaCode, {
+          type: 'arena_player_left',
+          playerId,
+        } as unknown as ServerMessage);
+        sendArenaState(oldArenaCode);
+      }
 
       const { roomCode, player } = arenaManager.createRoom(
         playerId,
@@ -846,7 +890,15 @@ function handleMessage(playerId: string, raw: string): void {
 
     case 'join_arena': {
       const existing = arenaManager.getRoomByPlayerId(playerId);
-      if (existing) arenaManager.removePlayer(playerId);
+      if (existing) {
+        const oldArenaCode = existing.code;
+        arenaManager.removePlayer(playerId);
+        broadcastToArena(oldArenaCode, {
+          type: 'arena_player_left',
+          playerId,
+        } as unknown as ServerMessage);
+        sendArenaState(oldArenaCode);
+      }
 
       const arenaMsg = message as unknown as { arenaCode: string; playerName: string };
       const result = arenaManager.joinRoom(arenaMsg.arenaCode, playerId, arenaMsg.playerName);
@@ -882,7 +934,15 @@ function handleMessage(playerId: string, raw: string): void {
 
     case 'queue_arena': {
       const existing = arenaManager.getRoomByPlayerId(playerId);
-      if (existing) arenaManager.removePlayer(playerId);
+      if (existing) {
+        const oldArenaCode = existing.code;
+        arenaManager.removePlayer(playerId);
+        broadcastToArena(oldArenaCode, {
+          type: 'arena_player_left',
+          playerId,
+        } as unknown as ServerMessage);
+        sendArenaState(oldArenaCode);
+      }
 
       arenaQueue.delete(playerId);
       clearArenaTimer(playerId);
@@ -1004,7 +1064,15 @@ function handleMessage(playerId: string, raw: string): void {
     case 'mc_create_room': {
       const mcMsg = message as unknown as { playerName: string; roomName?: string };
       const existing = mcBoardManager.getRoomByPlayerId(playerId);
-      if (existing) mcBoardManager.removePlayer(playerId);
+      if (existing) {
+        const oldMcCode = existing.code;
+        mcBoardManager.removePlayer(playerId);
+        broadcastToMCBoard(oldMcCode, {
+          type: 'mc_player_left',
+          playerId,
+        } as unknown as ServerMessage);
+        sendMCBoardRoomState(oldMcCode);
+      }
 
       const { roomCode, player } = mcBoardManager.createRoom(
         playerId,
@@ -1028,7 +1096,15 @@ function handleMessage(playerId: string, raw: string): void {
     case 'mc_join_room': {
       const mcMsg = message as unknown as { roomCode: string; playerName: string };
       const existing = mcBoardManager.getRoomByPlayerId(playerId);
-      if (existing) mcBoardManager.removePlayer(playerId);
+      if (existing) {
+        const oldMcCode = existing.code;
+        mcBoardManager.removePlayer(playerId);
+        broadcastToMCBoard(oldMcCode, {
+          type: 'mc_player_left',
+          playerId,
+        } as unknown as ServerMessage);
+        sendMCBoardRoomState(oldMcCode);
+      }
 
       const result = mcBoardManager.joinRoom(mcMsg.roomCode, playerId, (mcMsg.playerName || 'Player').slice(0, 16));
       if (!result.success || !result.player) {

--- a/server.ts
+++ b/server.ts
@@ -89,6 +89,10 @@ app.prepare().then(() => {
           socket.to(result.roomId!).emit('room:player-joined', player);
         }
 
+        // Broadcast full player list to ensure all clients are in sync
+        const allPlayers = gameManager.getPlayersArray(result.room!);
+        io.to(result.roomId!).emit('room:players-sync', allPlayers);
+
         console.log(`${playerName} joined room: ${roomCode}`);
       } catch (error) {
         console.error('Error joining room:', error);

--- a/src/hooks/useGameSocket.ts
+++ b/src/hooks/useGameSocket.ts
@@ -79,11 +79,18 @@ export function useGameSocket(): UseGameSocketReturn {
     });
 
     socketInstance.on('room:player-joined', (player) => {
-      setPlayers((prev) => [...prev, player]);
+      setPlayers((prev) => {
+        const exists = prev.some((p) => p.id === player.id);
+        return exists ? prev : [...prev, player];
+      });
     });
 
     socketInstance.on('room:player-left', (playerId) => {
       setPlayers((prev) => prev.filter((p) => p.id !== playerId));
+    });
+
+    socketInstance.on('room:players-sync', (syncedPlayers) => {
+      setPlayers(syncedPlayers);
     });
 
     socketInstance.on('room:player-disconnected', (playerId) => {

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -44,6 +44,7 @@ export interface ServerToClientEvents {
   }) => void;
   'room:player-joined': (player: Player) => void;
   'room:player-left': (playerId: string) => void;
+  'room:players-sync': (players: Player[]) => void;
   'room:player-disconnected': (playerId: string) => void;
   'room:player-reconnected': (playerId: string) => void;
   'room:state-changed': (state: RoomState) => void;


### PR DESCRIPTION
## Summary
This PR improves room state consistency by notifying remaining players when someone leaves a room and implementing a player list synchronization mechanism to prevent desynchronization issues.

## Key Changes

**Multiplayer Server (`multiplayer-server.ts`)**
- Added notifications to remaining players when a player leaves a room across all room-leaving scenarios:
  - `createRankedRoom()`: Notifies old room when players leave to join ranked match
  - `spawnAIMatch()`: Notifies old room when player leaves to join AI match
  - `create_room` handler: Notifies old room when player creates new room
  - `join_room` handler: Notifies old room when player joins different room
  - `queue_ranked` handler: Notifies old room when player queues for ranked
  - Arena operations (`create_arena`, `join_arena`, `queue_arena`): Similar notifications for arena rooms
  - MC Board operations (`mc_create_room`, `mc_join_room`): Similar notifications for MC board rooms

- Each notification includes:
  - `player_left` event with playerId and reason
  - Updated room state broadcast to remaining players

**Client Socket Hook (`useGameSocket.ts`)**
- Added deduplication logic to `room:player-joined` handler to prevent duplicate players in the list
- Added new `room:players-sync` event listener to receive full player list synchronization from server

**Server (`server.ts`)**
- Added full player list broadcast (`room:players-sync`) after a player joins to ensure all clients have consistent state

**Types (`src/types/game.ts`)**
- Added `'room:players-sync'` event to `ServerToClientEvents` interface

## Implementation Details
- The changes follow a consistent pattern: capture the old room code before removal, remove the player, then broadcast notifications and updated state
- Player list deduplication on the client prevents issues from race conditions or duplicate join events
- The synchronization event provides a fallback mechanism to ensure eventual consistency even if individual join/leave events are missed

https://claude.ai/code/session_017CePHw6jBQHA7AP3Qe7vub