### PR TITLE
Update logo colors: theme-aware text + red .net accent

### DIFF
--- a/src/components/rhythmia/rhythmia.module.css
+++ b/src/components/rhythmia/rhythmia.module.css
@@ -140,9 +140,10 @@
 }
 
 .logo {
+  font-family: 'Inter', var(--font-geist-sans), Arial, sans-serif;
   font-size: 1.1rem;
   font-weight: 700;
-  letter-spacing: 0.02em;
+  letter-spacing: -0.01em;
   color: #000000;
 }
 
@@ -151,7 +152,6 @@
 }
 
 .logoAccent {
-  font-weight: 400;
   color: #ec2828;
 }
 

--- a/src/components/rhythmia/rhythmia.module.css
+++ b/src/components/rhythmia/rhythmia.module.css
@@ -143,13 +143,16 @@
   font-size: 1.1rem;
   font-weight: 700;
   letter-spacing: 0.02em;
+  color: #000000;
+}
+
+:global(.dark) .logo {
   color: #ffffff;
-  opacity: 0.95;
 }
 
 .logoAccent {
   font-weight: 400;
-  opacity: 0.45;
+  color: #ec2828;
 }
 
 .statusBar {


### PR DESCRIPTION
- 'azuretier' text: white (#ffffff) in dark theme, black (#000000) in light theme
- '.net' accent: solid #ec2828 red in both themes
- Remove opacity on logo and accent for solid colors

https://claude.ai/code/session_01Haom9DkqkohZM8GD7Ew4Hf