### PR TITLE
Broadcast online users list and refresh on profile updates

### DIFF
--- a/multiplayer-server.ts
+++ b/multiplayer-server.ts
@@ -127,11 +127,14 @@ function broadcastToRoom(roomCode: string, message: ServerMessage, excludePlayer
 
 function broadcastOnlineCount(): void {
   const count = playerConnections.size;
-  const message: ServerMessage = { type: 'online_count', count };
+  const users = getOnlineUsers();
+  const countMsg = JSON.stringify({ type: 'online_count', count } as ServerMessage);
+  const usersMsg = JSON.stringify({ type: 'online_users', users } as ServerMessage);
   playerConnections.forEach((conn) => {
     if (conn.ws.readyState === WebSocket.OPEN) {
       try {
-        conn.ws.send(JSON.stringify(message));
+        conn.ws.send(countMsg);
+        conn.ws.send(usersMsg);
       } catch {}
     }
   });
@@ -533,6 +536,8 @@ function handleMessage(playerId: string, raw: string): void {
       if (conn) {
         conn.profileName = (profileMsg.name || '').slice(0, 20);
         conn.profileIcon = (profileMsg.icon || '').slice(0, 30);
+        // Broadcast updated online users so all clients see the new profile
+        broadcastOnlineCount();
       }
       break;
     }


### PR DESCRIPTION
## Summary
Enhanced the multiplayer server to broadcast a list of online users to all connected clients and ensure this list is refreshed whenever a player updates their profile information.

## Key Changes
- Modified `broadcastOnlineCount()` to send both the online count and a list of online users with their profiles to all connected clients
- Added a call to `broadcastOnlineCount()` when a player updates their profile (name/icon) to ensure all clients see the updated user information immediately
- Refactored message serialization to pre-stringify messages before sending to avoid redundant JSON operations

## Implementation Details
- The `broadcastOnlineCount()` function now retrieves the list of online users via `getOnlineUsers()` and sends two separate messages: one for the count and one for the full user list
- Profile updates now trigger a broadcast so that when a player changes their name or icon, all other connected players immediately see the change reflected in the online users list
- Error handling is preserved with the existing try-catch block

https://claude.ai/code/session_01HbkgwTBJxpBC1Ho5eHwSog