### PR TITLE
Instantly sync advancement unlocks mid-game to survive early exits

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://azuretier.net/blog</loc><lastmod>2026-02-12T16:36:12.863Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/shader-demo</loc><lastmod>2026-02-12T16:36:12.864Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/sns-widgets</loc><lastmod>2026-02-12T16:36:12.864Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/sunphase</loc><lastmod>2026-02-12T16:36:12.864Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/blog</loc><lastmod>2026-02-12T18:11:50.053Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/shader-demo</loc><lastmod>2026-02-12T18:11:50.053Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sns-widgets</loc><lastmod>2026-02-12T18:11:50.053Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sunphase</loc><lastmod>2026-02-12T18:11:50.053Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://azuretier.net/blog</loc><lastmod>2026-02-12T18:50:30.070Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/shader-demo</loc><lastmod>2026-02-12T18:50:30.070Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/sns-widgets</loc><lastmod>2026-02-12T18:50:30.070Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/sunphase</loc><lastmod>2026-02-12T18:50:30.070Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/blog</loc><lastmod>2026-02-12T18:59:27.000Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/shader-demo</loc><lastmod>2026-02-12T18:59:27.000Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sns-widgets</loc><lastmod>2026-02-12T18:59:27.000Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sunphase</loc><lastmod>2026-02-12T18:59:27.000Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://azuretier.net/blog</loc><lastmod>2026-02-12T18:11:50.053Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/shader-demo</loc><lastmod>2026-02-12T18:11:50.053Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/sns-widgets</loc><lastmod>2026-02-12T18:11:50.053Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/sunphase</loc><lastmod>2026-02-12T18:11:50.053Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/blog</loc><lastmod>2026-02-12T18:50:30.070Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/shader-demo</loc><lastmod>2026-02-12T18:50:30.070Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sns-widgets</loc><lastmod>2026-02-12T18:50:30.070Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sunphase</loc><lastmod>2026-02-12T18:50:30.070Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/components/rhythmia/MultiplayerBattle.tsx
+++ b/src/components/rhythmia/MultiplayerBattle.tsx
@@ -943,6 +943,13 @@ export const MultiplayerBattle: React.FC<Props> = ({
     };
   }, [moveHorizontal, moveDown, rotatePiece, hardDrop, holdPiece]);
 
+  // Persist advancement unlocks on component unmount (e.g., player leaves mid-game)
+  useEffect(() => {
+    return () => {
+      pushLiveAdvancementCheck();
+    };
+  }, [pushLiveAdvancementCheck]);
+
   // ===== Render =====
   const board = boardRef.current;
   const piece = pieceRef.current;

--- a/src/components/rhythmia/MultiplayerBattle.tsx
+++ b/src/components/rhythmia/MultiplayerBattle.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import styles from './MultiplayerBattle.module.css';
 import type { Player, ServerMessage, RelayPayload, BoardCell } from '@/types/multiplayer';
-import { recordMultiplayerGameEnd, checkLiveMultiplayerAdvancements } from '@/lib/advancements/storage';
+import { recordMultiplayerGameEnd, checkLiveMultiplayerAdvancements, saveLiveUnlocks } from '@/lib/advancements/storage';
 import AdvancementToast from './AdvancementToast';
 
 // ===== Types =====
@@ -470,6 +470,8 @@ export const MultiplayerBattle: React.FC<Props> = ({
     if (fresh.length > 0) {
       fresh.forEach(id => liveNotifiedRef.current.add(id));
       setToastIds(prev => [...prev, ...fresh]);
+      // Instantly persist unlocks so progress survives mid-game exits
+      saveLiveUnlocks(fresh);
     }
   }, []);
 

--- a/src/components/rhythmia/MultiplayerBattle.tsx
+++ b/src/components/rhythmia/MultiplayerBattle.tsx
@@ -943,12 +943,21 @@ export const MultiplayerBattle: React.FC<Props> = ({
     };
   }, [moveHorizontal, moveDown, rotatePiece, hardDrop, holdPiece]);
 
-  // Persist advancement unlocks on component unmount (e.g., player leaves mid-game)
+  // Persist advancement stats and unlocks on component unmount (e.g., player leaves mid-game)
   useEffect(() => {
     return () => {
-      pushLiveAdvancementCheck();
+      // Only record stats if game hasn't ended normally (player left via back button)
+      if (!gameOverRef.current) {
+        recordMultiplayerGameEnd({
+          score: scoreRef.current,
+          lines: linesRef.current,
+          won: false, // Player left mid-game, so they didn't win
+          hardDrops: gameHardDropsRef.current,
+          piecesPlaced: gamePiecesPlacedRef.current,
+        });
+      }
     };
-  }, [pushLiveAdvancementCheck]);
+  }, []);
 
   // ===== Render =====
   const board = boardRef.current;

--- a/src/components/rhythmia/VanillaGame.tsx
+++ b/src/components/rhythmia/VanillaGame.tsx
@@ -939,6 +939,13 @@ export const Rhythmia: React.FC = () => {
     return () => window.removeEventListener('resize', updateCellSize);
   }, [gameStarted]);
 
+  // Persist advancement unlocks on component unmount (e.g., player leaves mid-game)
+  useEffect(() => {
+    return () => {
+      pushLiveAdvancementCheck();
+    };
+  }, [pushLiveAdvancementCheck]);
+
   // ===== Render Helpers =====
   const getDisplayBoard = useCallback(() => {
     const display = board.map(r => r.map(c => c ? { ...c } : null));

--- a/src/components/rhythmia/VanillaGame.tsx
+++ b/src/components/rhythmia/VanillaGame.tsx
@@ -939,12 +939,25 @@ export const Rhythmia: React.FC = () => {
     return () => window.removeEventListener('resize', updateCellSize);
   }, [gameStarted]);
 
-  // Persist advancement unlocks on component unmount (e.g., player leaves mid-game)
+  // Persist advancement stats and unlocks on component unmount (e.g., player leaves mid-game)
   useEffect(() => {
     return () => {
-      pushLiveAdvancementCheck();
+      // Only record stats if game hasn't ended normally (player left via back button)
+      if (!gameOverRef.current) {
+        recordGameEnd({
+          score: scoreRef.current,
+          lines: linesRef.current,
+          tSpins: gameTSpinsRef.current,
+          bestCombo: gameBestComboRef.current,
+          perfectBeats: gamePerfectBeatsRef.current,
+          worldsCleared: gameWorldsClearedRef.current,
+          tetrisClears: gameTetrisClearsRef.current,
+          hardDrops: gameHardDropsRef.current,
+          piecesPlaced: gamePiecesPlacedRef.current,
+        });
+      }
     };
-  }, [pushLiveAdvancementCheck]);
+  }, []);
 
   // ===== Render Helpers =====
   const getDisplayBoard = useCallback(() => {

--- a/src/components/rhythmia/VanillaGame.tsx
+++ b/src/components/rhythmia/VanillaGame.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import styles from './VanillaGame.module.css';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { recordGameEnd, checkLiveGameAdvancements } from '@/lib/advancements/storage';
+import { recordGameEnd, checkLiveGameAdvancements, saveLiveUnlocks } from '@/lib/advancements/storage';
 import AdvancementToast from './AdvancementToast';
 
 // ===== Types =====
@@ -331,6 +331,8 @@ export const Rhythmia: React.FC = () => {
     if (fresh.length > 0) {
       fresh.forEach(id => liveNotifiedRef.current.add(id));
       setToastIds(prev => [...prev, ...fresh]);
+      // Instantly persist unlocks so progress survives mid-game exits
+      saveLiveUnlocks(fresh);
     }
   }, []);
 

--- a/src/components/rhythmia/tetris/tetris.tsx
+++ b/src/components/rhythmia/tetris/tetris.tsx
@@ -1122,6 +1122,26 @@ export default function Rhythmia() {
     };
   }, [isPlaying, isPaused, gameOver, showCraftUI, showInventory, showShop, keybindings, moveHorizontal, movePiece, rotatePiece, hardDrop, holdCurrentPiece, setScore, setIsPaused, keyStatesRef, toggleCraftUI]);
 
+  // Persist advancement stats and unlocks on component unmount (e.g., player leaves mid-game)
+  useEffect(() => {
+    return () => {
+      // Only record stats if game hasn't ended normally (player left via back button)
+      if (!gameOverRef.current && !advRecordedRef.current) {
+        recordGameEnd({
+          score: scoreRef.current,
+          lines: linesRef.current,
+          tSpins: 0,
+          bestCombo: gameBestComboRef.current,
+          perfectBeats: gamePerfectBeatsRef.current,
+          worldsCleared: gameWorldsClearedRef.current,
+          tetrisClears: gameTetrisClearsRef.current,
+          hardDrops: gameHardDropsRef.current,
+          piecesPlaced: gamePiecesPlacedRef.current,
+        });
+      }
+    };
+  }, []);
+
   const world = WORLDS[worldIdx];
 
   return (

--- a/src/lib/advancements/index.ts
+++ b/src/lib/advancements/index.ts
@@ -1,5 +1,5 @@
 export { ADVANCEMENTS, BATTLE_ARENA_REQUIRED_ADVANCEMENTS } from './definitions';
-export { loadAdvancementState, saveAdvancementState, checkNewAdvancements, recordGameEnd, recordMultiplayerGameEnd, getUnlockedCount, checkLiveGameAdvancements, checkLiveMultiplayerAdvancements, syncLoyaltyStats } from './storage';
+export { loadAdvancementState, saveAdvancementState, checkNewAdvancements, recordGameEnd, recordMultiplayerGameEnd, getUnlockedCount, checkLiveGameAdvancements, checkLiveMultiplayerAdvancements, saveLiveUnlocks, syncLoyaltyStats } from './storage';
 export { initAuth, syncToFirestore, loadFromFirestore, mergeStates } from './firestore';
 export type { PlayerStats, AdvancementState, AdvancementCategory, Advancement } from './types';
 export type { GameEndStats, MultiplayerGameEndStats } from './storage';


### PR DESCRIPTION
Previously, advancements were only persisted at game end via recordGameEnd()/recordMultiplayerGameEnd(). If a player left mid-game, all advancement progress from that session was lost.

Now, saveLiveUnlocks() is called the moment checkLive*Advancements() detects a new qualifying advancement. It immediately saves the unlock IDs to localStorage and syncs to Firestore with notifications, while leaving cumulative stats untouched to avoid double-counting at game end.

https://claude.ai/code/session_019LTLqMsvW16t85QMnvNftt