### PR TITLE
Add profile tab with skin customization for site-wide color theming

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -818,5 +818,11 @@
         "onlineTitle": "Online Players",
         "onlineCount": "{count} online",
         "noOnlineUsers": "No players online right now"
+    },
+    "skin": {
+        "title": "Profile & Skin",
+        "selectSkin": "Select Color Skin",
+        "currentSkin": "Current Skin",
+        "profileButton": "Profile"
     }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -554,5 +554,11 @@
         "wiki": "Wiki",
         "updates": "Actualizaciones",
         "lobby": "Lobby"
+    },
+    "skin": {
+        "title": "Perfil y Skin",
+        "selectSkin": "Seleccionar Skin de Color",
+        "currentSkin": "Skin Actual",
+        "profileButton": "Perfil"
     }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -554,5 +554,11 @@
         "wiki": "Wiki",
         "updates": "Mises à jour",
         "lobby": "Lobby"
+    },
+    "skin": {
+        "title": "Profil & Skin",
+        "selectSkin": "Choisir un Skin de Couleur",
+        "currentSkin": "Skin Actuel",
+        "profileButton": "Profil"
     }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -818,5 +818,11 @@
         "onlineTitle": "オンラインのプレイヤー",
         "onlineCount": "{count}人がオンライン",
         "noOnlineUsers": "現在オンラインのプレイヤーはいません"
+    },
+    "skin": {
+        "title": "プロフィール & スキン",
+        "selectSkin": "カラースキンを選択",
+        "currentSkin": "現在のスキン",
+        "profileButton": "プロフィール"
     }
 }

--- a/messages/th.json
+++ b/messages/th.json
@@ -554,5 +554,11 @@
         "wiki": "วิกิ",
         "updates": "อัปเดต",
         "lobby": "ล็อบบี้"
+    },
+    "skin": {
+        "title": "โปรไฟล์ & สกิน",
+        "selectSkin": "เลือกสกินสี",
+        "currentSkin": "สกินปัจจุบัน",
+        "profileButton": "โปรไฟล์"
     }
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -9,6 +9,7 @@ import { routing } from '@/i18n/routing';
 import Provider from '../provider';
 import { VersionProvider } from '@/lib/version/context';
 import { ProfileProvider } from '@/lib/profile/context';
+import { SkinProvider } from '@/lib/skin/context';
 
 import { GoogleAnalytics } from "@next/third-parties/google";
 
@@ -123,11 +124,13 @@ export default async function LocaleLayout({ children, params }: Props) {
             <body className={`${geistSans.variable} ${geistMono.variable} antialiased`} style={{ overflowX: 'hidden' }}>
                 <NextIntlClientProvider messages={messages}>
                     <ProfileProvider>
-                        <VersionProvider>
-                            <Provider>
-                                {children}
-                            </Provider>
-                        </VersionProvider>
+                        <SkinProvider>
+                            <VersionProvider>
+                                <Provider>
+                                    {children}
+                                </Provider>
+                            </VersionProvider>
+                        </SkinProvider>
                     </ProfileProvider>
                 </NextIntlClientProvider>
                 {gaId && <GoogleAnalytics gaId={gaId} />}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -11,6 +11,7 @@ import Advancements from '../../components/rhythmia/Advancements';
 import ForYouTab from '../../components/rhythmia/ForYouTab';
 import ProfileSetup from '../../components/profile/ProfileSetup';
 import OnlineUsers from '../../components/profile/OnlineUsers';
+import SkinCustomizer from '../../components/profile/SkinCustomizer';
 import rhythmiaConfig from '../../../rhythmia.config.json';
 import styles from '../../components/rhythmia/rhythmia.module.css';
 import onlineStyles from '../../components/profile/OnlineUsers.module.css';
@@ -31,6 +32,7 @@ export default function RhythmiaPage() {
     const [showOnlineUsers, setShowOnlineUsers] = useState(false);
     const [onlineUsers, setOnlineUsers] = useState<OnlineUser[]>([]);
     const [unlockedCount, setUnlockedCount] = useState(0);
+    const [showSkinCustomizer, setShowSkinCustomizer] = useState(false);
     const wsRef = useRef<WebSocket | null>(null);
     const profileSentRef = useRef(false);
 
@@ -236,6 +238,13 @@ export default function RhythmiaPage() {
                 )}
             </AnimatePresence>
 
+            {/* Skin customizer panel */}
+            <AnimatePresence>
+                {showSkinCustomizer && (
+                    <SkinCustomizer onClose={() => setShowSkinCustomizer(false)} />
+                )}
+            </AnimatePresence>
+
             <div className={styles.container}>
                 <motion.header
                     className={styles.header}
@@ -272,6 +281,12 @@ export default function RhythmiaPage() {
                             onClick={() => router.push('/updates')}
                         >
                             {t('nav.updates')}
+                        </button>
+                        <button
+                            className={styles.advButton}
+                            onClick={() => setShowSkinCustomizer(true)}
+                        >
+                            {t('skin.profileButton')}
                         </button>
                         <LocaleSwitcher />
                         <a

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,4 +16,23 @@ body {
     height: 100%;
 }
 
+/* Skin CSS variables — defaults (Azure theme) */
+:root {
+    --skin-accent: #007FFF;
+    --skin-accent-light: #3399FF;
+    --skin-accent-dim: rgba(0, 127, 255, 0.15);
+    --skin-background: #000000;
+    --skin-surface: rgba(255, 255, 255, 0.03);
+    --skin-foreground: #ffffff;
+    --skin-subtext: rgba(255, 255, 255, 0.45);
+    --skin-border: rgba(255, 255, 255, 0.08);
+    --skin-border-hover: rgba(255, 255, 255, 0.18);
+
+    /* Tailwind mapping */
+    --background: var(--skin-background);
+    --foreground: var(--skin-foreground);
+    --border: var(--skin-border);
+    --subtext: var(--skin-subtext);
+}
+
 /* Existing CSS content below */

--- a/src/components/profile/SkinCustomizer.module.css
+++ b/src/components/profile/SkinCustomizer.module.css
@@ -1,0 +1,291 @@
+/* Skin Customizer Panel */
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.85);
+  backdrop-filter: blur(8px);
+  z-index: 300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.panel {
+  width: 100%;
+  max-width: 640px;
+  max-height: 85vh;
+  overflow-y: auto;
+  background: var(--skin-background, #000000);
+  border: 1px solid var(--skin-border, rgba(255, 255, 255, 0.08));
+  border-radius: 16px;
+  padding: 0;
+}
+
+.panel::-webkit-scrollbar {
+  width: 4px;
+}
+
+.panel::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.panel::-webkit-scrollbar-thumb {
+  background: var(--skin-border, rgba(255, 255, 255, 0.1));
+  border-radius: 2px;
+}
+
+/* Header */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 24px 28px;
+  border-bottom: 1px solid var(--skin-border, rgba(255, 255, 255, 0.06));
+}
+
+.headerLeft {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.profileIcon {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.headerText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--skin-foreground, #ffffff);
+  letter-spacing: 0.02em;
+  margin: 0;
+}
+
+.profileName {
+  font-size: 0.7rem;
+  color: var(--skin-subtext, rgba(255, 255, 255, 0.4));
+  letter-spacing: 0.05em;
+}
+
+.closeButton {
+  padding: 8px;
+  background: transparent;
+  border: 1px solid var(--skin-border, rgba(255, 255, 255, 0.1));
+  border-radius: 8px;
+  color: var(--skin-subtext, rgba(255, 255, 255, 0.5));
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.closeButton:hover {
+  color: var(--skin-foreground, #ffffff);
+  border-color: var(--skin-border-hover, rgba(255, 255, 255, 0.2));
+  background: var(--skin-surface, rgba(255, 255, 255, 0.03));
+}
+
+/* Section label */
+.sectionLabel {
+  padding: 20px 28px 12px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--skin-subtext, rgba(255, 255, 255, 0.35));
+}
+
+/* Skin grid */
+.skinGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  padding: 0 28px 24px;
+}
+
+/* Individual skin card */
+.skinCard {
+  position: relative;
+  background: var(--skin-surface, rgba(255, 255, 255, 0.03));
+  border: 2px solid var(--skin-border, rgba(255, 255, 255, 0.06));
+  border-radius: 10px;
+  padding: 10px;
+  cursor: pointer;
+  transition: all 0.25s ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.skinCard:hover {
+  border-color: var(--skin-border-hover, rgba(255, 255, 255, 0.15));
+  background: var(--skin-accent-dim, rgba(255, 255, 255, 0.04));
+}
+
+.skinCardActive {
+  border-color: var(--skin-accent, #007FFF) !important;
+  background: var(--skin-accent-dim, rgba(0, 127, 255, 0.08)) !important;
+}
+
+/* Miniature preview swatch */
+.swatchPreview {
+  width: 100%;
+  aspect-ratio: 4/3;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.swatchBg {
+  width: 100%;
+  height: 100%;
+  background: var(--swatch-bg, #000);
+  display: flex;
+  flex-direction: column;
+  padding: 6px;
+  gap: 4px;
+}
+
+.swatchHeader {
+  height: 4px;
+  width: 60%;
+  border-radius: 2px;
+  background: var(--swatch-accent, #007FFF);
+  opacity: 0.8;
+}
+
+.swatchCards {
+  flex: 1;
+  display: flex;
+  gap: 3px;
+}
+
+.swatchCard {
+  flex: 1;
+  border-radius: 3px;
+  border: 1px solid var(--swatch-border, rgba(255, 255, 255, 0.08));
+  background: var(--swatch-surface, rgba(255, 255, 255, 0.03));
+}
+
+.swatchButton {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--swatch-accent, #007FFF);
+  opacity: 0.9;
+}
+
+/* Skin name */
+.skinInfo {
+  text-align: center;
+  width: 100%;
+}
+
+.skinName {
+  font-size: 0.65rem;
+  font-weight: 500;
+  color: var(--skin-foreground, #ffffff);
+  letter-spacing: 0.03em;
+  line-height: 1.2;
+}
+
+.skinNameJa {
+  font-size: 0.55rem;
+  color: var(--skin-subtext, rgba(255, 255, 255, 0.35));
+  letter-spacing: 0.02em;
+}
+
+/* Active badge */
+.activeBadge {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--skin-accent, #007FFF);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Current skin info */
+.currentInfo {
+  padding: 16px 28px 24px;
+  border-top: 1px solid var(--skin-border, rgba(255, 255, 255, 0.06));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.currentLabel {
+  font-size: 0.65rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--skin-subtext, rgba(255, 255, 255, 0.35));
+}
+
+.currentName {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--skin-foreground, #ffffff);
+  letter-spacing: 0.03em;
+}
+
+.currentDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .panel {
+    max-height: 90vh;
+  }
+
+  .skinGrid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+    padding: 0 20px 20px;
+  }
+
+  .header {
+    padding: 20px;
+  }
+
+  .sectionLabel {
+    padding: 16px 20px 10px;
+  }
+
+  .currentInfo {
+    padding: 12px 20px 20px;
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-start;
+  }
+}

--- a/src/components/profile/SkinCustomizer.tsx
+++ b/src/components/profile/SkinCustomizer.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { motion, AnimatePresence } from 'framer-motion';
+import { useTranslations } from 'next-intl';
+import { useSkin } from '@/lib/skin/context';
+import { useProfile } from '@/lib/profile/context';
+import { getIconById } from '@/lib/profile/types';
+import type { Skin } from '@/lib/skin/types';
+import styles from './SkinCustomizer.module.css';
+
+interface SkinCustomizerProps {
+  onClose: () => void;
+}
+
+function SkinSwatch({ skin, isActive, onSelect }: { skin: Skin; isActive: boolean; onSelect: () => void }) {
+  return (
+    <motion.button
+      className={`${styles.skinCard} ${isActive ? styles.skinCardActive : ''}`}
+      onClick={onSelect}
+      whileHover={{ scale: 1.03 }}
+      whileTap={{ scale: 0.97 }}
+      style={{
+        '--swatch-accent': skin.colors.accent,
+        '--swatch-bg': skin.colors.background,
+        '--swatch-surface': skin.colors.surface,
+        '--swatch-fg': skin.colors.foreground,
+        '--swatch-border': skin.colors.border,
+      } as React.CSSProperties}
+    >
+      <div className={styles.swatchPreview}>
+        <div className={styles.swatchBg}>
+          <div className={styles.swatchHeader} />
+          <div className={styles.swatchCards}>
+            <div className={styles.swatchCard} />
+            <div className={styles.swatchCard} />
+          </div>
+          <div className={styles.swatchButton} />
+        </div>
+      </div>
+      <div className={styles.skinInfo}>
+        <div className={styles.skinName}>{skin.name}</div>
+        <div className={styles.skinNameJa}>{skin.nameJa}</div>
+      </div>
+      {isActive && (
+        <div className={styles.activeBadge}>
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        </div>
+      )}
+    </motion.button>
+  );
+}
+
+export default function SkinCustomizer({ onClose }: SkinCustomizerProps) {
+  const t = useTranslations('skin');
+  const { currentSkin, setSkin, skins } = useSkin();
+  const { profile } = useProfile();
+
+  const iconData = profile ? getIconById(profile.icon) : null;
+
+  return (
+    <motion.div
+      className={styles.overlay}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.25 }}
+    >
+      <motion.div
+        className={styles.panel}
+        initial={{ opacity: 0, y: 40, scale: 0.95 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
+        exit={{ opacity: 0, y: 40, scale: 0.95 }}
+        transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
+      >
+        {/* Header with profile info */}
+        <div className={styles.header}>
+          <div className={styles.headerLeft}>
+            {profile && iconData && (
+              <div
+                className={styles.profileIcon}
+                style={{ backgroundColor: iconData.bgColor, color: iconData.color }}
+              >
+                {iconData.emoji}
+              </div>
+            )}
+            <div className={styles.headerText}>
+              <h2 className={styles.title}>{t('title')}</h2>
+              {profile && (
+                <div className={styles.profileName}>{profile.name}</div>
+              )}
+            </div>
+          </div>
+          <button className={styles.closeButton} onClick={onClose}>
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Section label */}
+        <div className={styles.sectionLabel}>{t('selectSkin')}</div>
+
+        {/* Skin grid */}
+        <div className={styles.skinGrid}>
+          {skins.map((skin) => (
+            <SkinSwatch
+              key={skin.id}
+              skin={skin}
+              isActive={currentSkin.id === skin.id}
+              onSelect={() => setSkin(skin.id)}
+            />
+          ))}
+        </div>
+
+        {/* Current skin info */}
+        <div className={styles.currentInfo}>
+          <div className={styles.currentLabel}>{t('currentSkin')}</div>
+          <div className={styles.currentName}>
+            <span
+              className={styles.currentDot}
+              style={{ background: currentSkin.colors.accent }}
+            />
+            {currentSkin.name} — {currentSkin.nameJa}
+          </div>
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/components/rhythmia/rhythmia.module.css
+++ b/src/components/rhythmia/rhythmia.module.css
@@ -1,13 +1,13 @@
-/* Minimal Black & White Theme */
+/* Skin-aware Theme */
 .page {
   font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
-  background: #000000;
+  background: var(--skin-background, #000000);
   min-height: 100vh;
   height: 100vh;
   max-width: 100%;
   overflow-x: hidden;
   overflow-y: auto;
-  color: #ffffff;
+  color: var(--skin-foreground, #ffffff);
   position: relative;
   box-sizing: border-box;
 }
@@ -19,7 +19,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background: #000000;
+  background: var(--skin-background, #000000);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -30,8 +30,8 @@
 .loader {
   width: 32px;
   height: 32px;
-  border: 1.5px solid rgba(255, 255, 255, 0.1);
-  border-top-color: #ffffff;
+  border: 1.5px solid var(--skin-border, rgba(255, 255, 255, 0.1));
+  border-top-color: var(--skin-accent, #ffffff);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
 }
@@ -90,7 +90,7 @@
   width: 6px;
   height: 6px;
   border-radius: 3px;
-  background: rgba(255, 255, 255, 0.2);
+  background: var(--skin-border, rgba(255, 255, 255, 0.2));
   border: none;
   padding: 0;
   cursor: pointer;
@@ -99,7 +99,7 @@
 
 .slideDotActive {
   height: 20px;
-  background: rgba(255, 255, 255, 0.7);
+  background: var(--skin-accent, rgba(255, 255, 255, 0.7));
 }
 
 .scrollHint {
@@ -107,7 +107,7 @@
   bottom: 32px;
   left: 50%;
   transform: translateX(-50%);
-  color: rgba(255, 255, 255, 0.3);
+  color: var(--skin-subtext, rgba(255, 255, 255, 0.3));
   z-index: 10;
   animation: scrollBounce 2s ease-in-out infinite;
 }
@@ -143,7 +143,7 @@
   font-size: 1.1rem;
   font-weight: 700;
   letter-spacing: 0.02em;
-  color: #ffffff;
+  color: var(--skin-foreground, #ffffff);
   opacity: 0.95;
 }
 
@@ -169,7 +169,7 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: #ffffff;
+  background: var(--skin-accent, #ffffff);
   opacity: 0.6;
   animation: statusPulse 2.5s ease-in-out infinite;
 }
@@ -188,12 +188,12 @@
 .discordLink {
   display: flex;
   align-items: center;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--skin-subtext, rgba(255, 255, 255, 0.7));
   transition: color 0.25s, transform 0.25s;
 }
 
 .discordLink:hover {
-  color: #ffffff;
+  color: var(--skin-foreground, #ffffff);
   transform: scale(1.15);
 }
 
@@ -216,7 +216,7 @@
   font-weight: 300;
   letter-spacing: 0.3em;
   margin-bottom: 12px;
-  color: #ffffff;
+  color: var(--skin-foreground, #ffffff);
 }
 
 .heroText p {
@@ -241,8 +241,8 @@
 /* Server card - minimal glassmorphism */
 .serverCard {
   position: relative;
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--skin-surface, rgba(255, 255, 255, 0.03));
+  border: 1px solid var(--skin-border, rgba(255, 255, 255, 0.08));
   border-radius: 12px;
   padding: 28px 24px;
   cursor: pointer;
@@ -260,7 +260,7 @@
   border-radius: 12px;
   background: linear-gradient(
     135deg,
-    rgba(255, 255, 255, 0.02) 0%,
+    var(--skin-accent-dim, rgba(255, 255, 255, 0.02)) 0%,
     transparent 100%
   );
   opacity: 0;
@@ -269,8 +269,8 @@
 }
 
 .serverCard:hover {
-  border-color: rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--skin-border-hover, rgba(255, 255, 255, 0.18));
+  background: var(--skin-accent-dim, rgba(255, 255, 255, 0.05));
 }
 
 .serverCard:hover::before {
@@ -279,11 +279,11 @@
 
 /* Card color accents (subtle) */
 .serverCard.vanilla {
-  --card-accent: rgba(255, 255, 255, 0.7);
+  --card-accent: var(--skin-accent, rgba(255, 255, 255, 0.7));
 }
 
 .serverCard.multiplayer {
-  --card-accent: rgba(255, 255, 255, 0.7);
+  --card-accent: var(--skin-accent, rgba(255, 255, 255, 0.7));
 }
 
 .cardBadge {
@@ -295,15 +295,15 @@
   font-weight: 600;
   letter-spacing: 0.15em;
   text-transform: uppercase;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--skin-border-hover, rgba(255, 255, 255, 0.2));
   border-radius: 4px;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--skin-subtext, rgba(255, 255, 255, 0.6));
   background: transparent;
 }
 
 .cardBadge.new {
-  border-color: rgba(255, 255, 255, 0.35);
-  color: rgba(255, 255, 255, 0.8);
+  border-color: var(--skin-accent, rgba(255, 255, 255, 0.35));
+  color: var(--skin-accent-light, rgba(255, 255, 255, 0.8));
 }
 
 .cardTitle {
@@ -311,7 +311,7 @@
   font-weight: 500;
   letter-spacing: 0.15em;
   margin-bottom: 6px;
-  color: #ffffff;
+  color: var(--skin-foreground, #ffffff);
 }
 
 .cardSubtitle {
@@ -341,8 +341,8 @@
 .featureTag {
   padding: 4px 10px;
   font-size: 0.65rem;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--skin-surface, rgba(255, 255, 255, 0.04));
+  border: 1px solid var(--skin-border, rgba(255, 255, 255, 0.08));
   border-radius: 4px;
   opacity: 0.5;
   letter-spacing: 0.05em;
@@ -352,7 +352,7 @@
   display: flex;
   gap: 24px;
   padding-top: 16px;
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  border-top: 1px solid var(--skin-border, rgba(255, 255, 255, 0.06));
 }
 
 .stat {
@@ -362,7 +362,7 @@
 .statValue {
   font-size: 1rem;
   font-weight: 500;
-  color: #ffffff;
+  color: var(--skin-foreground, #ffffff);
   opacity: 0.8;
   font-variant-numeric: tabular-nums;
 }
@@ -383,8 +383,8 @@
   font-weight: 500;
   letter-spacing: 0.25em;
   text-transform: uppercase;
-  color: #000000;
-  background: #ffffff;
+  color: var(--skin-background, #000000);
+  background: var(--skin-accent, #ffffff);
   border: none;
   border-radius: 6px;
   cursor: pointer;
@@ -392,7 +392,7 @@
 }
 
 .playButton:hover {
-  background: rgba(255, 255, 255, 0.85);
+  background: var(--skin-accent-light, rgba(255, 255, 255, 0.85));
   transform: none;
 }
 
@@ -413,7 +413,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background: #000000;
+  background: var(--skin-background, #000000);
   z-index: 500;
   display: none;
   flex-direction: column;
@@ -428,8 +428,8 @@
   justify-content: space-between;
   align-items: center;
   padding: 12px 24px;
-  background: rgba(0, 0, 0, 0.95);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  background: var(--skin-background, rgba(0, 0, 0, 0.95));
+  border-bottom: 1px solid var(--skin-border, rgba(255, 255, 255, 0.06));
 }
 
 .gameTitle {
@@ -446,18 +446,18 @@
   padding: 8px 16px;
   font-size: 0.75rem;
   letter-spacing: 0.08em;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--skin-subtext, rgba(255, 255, 255, 0.6));
   background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--skin-border, rgba(255, 255, 255, 0.12));
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.25s;
 }
 
 .backButton:hover {
-  color: #ffffff;
-  border-color: rgba(255, 255, 255, 0.3);
-  background: rgba(255, 255, 255, 0.05);
+  color: var(--skin-foreground, #ffffff);
+  border-color: var(--skin-border-hover, rgba(255, 255, 255, 0.3));
+  background: var(--skin-surface, rgba(255, 255, 255, 0.05));
 }
 
 /* Online indicator */
@@ -466,14 +466,14 @@
   align-items: center;
   gap: 6px;
   font-size: 0.7rem;
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--skin-subtext, rgba(255, 255, 255, 0.4));
   margin-top: 10px;
 }
 
 .onlineDot {
   width: 5px;
   height: 5px;
-  background: #ffffff;
+  background: var(--skin-accent, #ffffff);
   border-radius: 50%;
   opacity: 0.5;
   animation: onlinePulse 2s ease-in-out infinite;
@@ -495,18 +495,18 @@
   font-size: 0.65rem;
   font-weight: 500;
   letter-spacing: 0.08em;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--skin-subtext, rgba(255, 255, 255, 0.5));
   background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--skin-border, rgba(255, 255, 255, 0.12));
   border-radius: 4px;
   cursor: pointer;
   transition: all 0.25s;
 }
 
 .advButton:hover {
-  color: #ffffff;
-  border-color: rgba(255, 255, 255, 0.3);
-  background: rgba(255, 255, 255, 0.05);
+  color: var(--skin-foreground, #ffffff);
+  border-color: var(--skin-border-hover, rgba(255, 255, 255, 0.3));
+  background: var(--skin-surface, rgba(255, 255, 255, 0.05));
 }
 
 /* Advancement overlay (main menu) */
@@ -555,12 +555,12 @@
 .lockIcon {
   width: 36px;
   height: 36px;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--skin-subtext, rgba(255, 255, 255, 0.5));
 }
 
 .lockText {
   font-size: 0.7rem;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--skin-subtext, rgba(255, 255, 255, 0.5));
   letter-spacing: 0.08em;
   text-align: center;
   max-width: 200px;
@@ -568,8 +568,8 @@
 }
 
 .lockedButton {
-  background: rgba(255, 255, 255, 0.15) !important;
-  color: rgba(255, 255, 255, 0.3) !important;
+  background: var(--skin-surface, rgba(255, 255, 255, 0.15)) !important;
+  color: var(--skin-subtext, rgba(255, 255, 255, 0.3)) !important;
   cursor: not-allowed !important;
   pointer-events: none;
 }
@@ -580,7 +580,7 @@
   max-width: 900px;
   margin-top: 48px;
   padding-top: 40px;
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  border-top: 1px solid var(--skin-border, rgba(255, 255, 255, 0.06));
 }
 
 /* Responsive */

--- a/src/lib/skin/context.tsx
+++ b/src/lib/skin/context.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
+import type { Skin, SkinColors } from './types';
+import { SKIN_PRESETS, DEFAULT_SKIN_ID, getSkinById } from './types';
+import { getStoredSkinId, setStoredSkinId } from './storage';
+
+interface SkinContextType {
+  currentSkin: Skin;
+  setSkin: (skinId: string) => void;
+  skins: Skin[];
+}
+
+const SkinContext = createContext<SkinContextType | undefined>(undefined);
+
+function applySkinToDocument(colors: SkinColors) {
+  const root = document.documentElement;
+  root.style.setProperty('--skin-accent', colors.accent);
+  root.style.setProperty('--skin-accent-light', colors.accentLight);
+  root.style.setProperty('--skin-accent-dim', colors.accentDim);
+  root.style.setProperty('--skin-background', colors.background);
+  root.style.setProperty('--skin-surface', colors.surface);
+  root.style.setProperty('--skin-foreground', colors.foreground);
+  root.style.setProperty('--skin-subtext', colors.subtext);
+  root.style.setProperty('--skin-border', colors.border);
+  root.style.setProperty('--skin-border-hover', colors.borderHover);
+
+  // Also set the generic CSS variables used by Tailwind
+  root.style.setProperty('--background', colors.background);
+  root.style.setProperty('--foreground', colors.foreground);
+  root.style.setProperty('--border', colors.border);
+  root.style.setProperty('--subtext', colors.subtext);
+}
+
+export function SkinProvider({ children }: { children: ReactNode }) {
+  const [currentSkin, setCurrentSkin] = useState<Skin>(
+    () => getSkinById(DEFAULT_SKIN_ID)!
+  );
+
+  useEffect(() => {
+    const storedId = getStoredSkinId();
+    const skin = storedId ? getSkinById(storedId) : null;
+    if (skin) {
+      setCurrentSkin(skin);
+      applySkinToDocument(skin.colors);
+    } else {
+      applySkinToDocument(currentSkin.colors);
+    }
+  }, []);
+
+  const setSkin = useCallback((skinId: string) => {
+    const skin = getSkinById(skinId);
+    if (!skin) return;
+    setCurrentSkin(skin);
+    setStoredSkinId(skinId);
+    applySkinToDocument(skin.colors);
+  }, []);
+
+  return (
+    <SkinContext.Provider value={{ currentSkin, setSkin, skins: SKIN_PRESETS }}>
+      {children}
+    </SkinContext.Provider>
+  );
+}
+
+export function useSkin() {
+  const context = useContext(SkinContext);
+  if (context === undefined) {
+    throw new Error('useSkin must be used within a SkinProvider');
+  }
+  return context;
+}

--- a/src/lib/skin/storage.ts
+++ b/src/lib/skin/storage.ts
@@ -1,0 +1,19 @@
+const SKIN_STORAGE_KEY = 'azuret_skin';
+
+export function getStoredSkinId(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(SKIN_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function setStoredSkinId(skinId: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(SKIN_STORAGE_KEY, skinId);
+  } catch {
+    // localStorage may be full or disabled
+  }
+}

--- a/src/lib/skin/types.ts
+++ b/src/lib/skin/types.ts
@@ -1,0 +1,164 @@
+export interface SkinColors {
+  /** Primary accent color (e.g. #007FFF) */
+  accent: string;
+  /** Lighter variant of accent for hover states */
+  accentLight: string;
+  /** Dimmed accent for subtle highlights */
+  accentDim: string;
+  /** Page background */
+  background: string;
+  /** Slightly elevated surface (cards, panels) */
+  surface: string;
+  /** Primary text color */
+  foreground: string;
+  /** Secondary/muted text */
+  subtext: string;
+  /** Border color for cards and dividers */
+  border: string;
+  /** Hover border color */
+  borderHover: string;
+}
+
+export interface Skin {
+  id: string;
+  name: string;
+  nameJa: string;
+  colors: SkinColors;
+}
+
+export const SKIN_PRESETS: Skin[] = [
+  {
+    id: 'azure',
+    name: 'Azure',
+    nameJa: 'アズール',
+    colors: {
+      accent: '#007FFF',
+      accentLight: '#3399FF',
+      accentDim: 'rgba(0, 127, 255, 0.15)',
+      background: '#000000',
+      surface: 'rgba(255, 255, 255, 0.03)',
+      foreground: '#ffffff',
+      subtext: 'rgba(255, 255, 255, 0.45)',
+      border: 'rgba(255, 255, 255, 0.08)',
+      borderHover: 'rgba(255, 255, 255, 0.18)',
+    },
+  },
+  {
+    id: 'sakura',
+    name: 'Sakura',
+    nameJa: '桜',
+    colors: {
+      accent: '#FF6B9D',
+      accentLight: '#FF8BB5',
+      accentDim: 'rgba(255, 107, 157, 0.15)',
+      background: '#0A0008',
+      surface: 'rgba(255, 200, 220, 0.03)',
+      foreground: '#fff0f5',
+      subtext: 'rgba(255, 240, 245, 0.45)',
+      border: 'rgba(255, 200, 220, 0.08)',
+      borderHover: 'rgba(255, 200, 220, 0.18)',
+    },
+  },
+  {
+    id: 'emerald',
+    name: 'Emerald',
+    nameJa: 'エメラルド',
+    colors: {
+      accent: '#00C896',
+      accentLight: '#33D4AA',
+      accentDim: 'rgba(0, 200, 150, 0.15)',
+      background: '#000A06',
+      surface: 'rgba(200, 255, 230, 0.03)',
+      foreground: '#f0fff8',
+      subtext: 'rgba(240, 255, 248, 0.45)',
+      border: 'rgba(200, 255, 230, 0.08)',
+      borderHover: 'rgba(200, 255, 230, 0.18)',
+    },
+  },
+  {
+    id: 'sunset',
+    name: 'Sunset',
+    nameJa: 'サンセット',
+    colors: {
+      accent: '#FF8C00',
+      accentLight: '#FFA033',
+      accentDim: 'rgba(255, 140, 0, 0.15)',
+      background: '#0A0500',
+      surface: 'rgba(255, 220, 180, 0.03)',
+      foreground: '#fff5eb',
+      subtext: 'rgba(255, 245, 235, 0.45)',
+      border: 'rgba(255, 220, 180, 0.08)',
+      borderHover: 'rgba(255, 220, 180, 0.18)',
+    },
+  },
+  {
+    id: 'amethyst',
+    name: 'Amethyst',
+    nameJa: 'アメジスト',
+    colors: {
+      accent: '#9C5FFF',
+      accentLight: '#B07FFF',
+      accentDim: 'rgba(156, 95, 255, 0.15)',
+      background: '#06000A',
+      surface: 'rgba(220, 200, 255, 0.03)',
+      foreground: '#f5f0ff',
+      subtext: 'rgba(245, 240, 255, 0.45)',
+      border: 'rgba(220, 200, 255, 0.08)',
+      borderHover: 'rgba(220, 200, 255, 0.18)',
+    },
+  },
+  {
+    id: 'crimson',
+    name: 'Crimson',
+    nameJa: 'クリムゾン',
+    colors: {
+      accent: '#FF3B5C',
+      accentLight: '#FF5C78',
+      accentDim: 'rgba(255, 59, 92, 0.15)',
+      background: '#0A0002',
+      surface: 'rgba(255, 200, 200, 0.03)',
+      foreground: '#fff0f0',
+      subtext: 'rgba(255, 240, 240, 0.45)',
+      border: 'rgba(255, 200, 200, 0.08)',
+      borderHover: 'rgba(255, 200, 200, 0.18)',
+    },
+  },
+  {
+    id: 'arctic',
+    name: 'Arctic',
+    nameJa: 'アークティック',
+    colors: {
+      accent: '#00D4FF',
+      accentLight: '#33DDFF',
+      accentDim: 'rgba(0, 212, 255, 0.15)',
+      background: '#000508',
+      surface: 'rgba(200, 240, 255, 0.03)',
+      foreground: '#f0faff',
+      subtext: 'rgba(240, 250, 255, 0.45)',
+      border: 'rgba(200, 240, 255, 0.08)',
+      borderHover: 'rgba(200, 240, 255, 0.18)',
+    },
+  },
+  {
+    id: 'gold',
+    name: 'Gold',
+    nameJa: 'ゴールド',
+    colors: {
+      accent: '#FFD700',
+      accentLight: '#FFDF33',
+      accentDim: 'rgba(255, 215, 0, 0.15)',
+      background: '#0A0800',
+      surface: 'rgba(255, 240, 200, 0.03)',
+      foreground: '#fffbf0',
+      subtext: 'rgba(255, 251, 240, 0.45)',
+      border: 'rgba(255, 240, 200, 0.08)',
+      borderHover: 'rgba(255, 240, 200, 0.18)',
+    },
+  },
+];
+
+export function getSkinById(id: string): Skin | undefined {
+  return SKIN_PRESETS.find(skin => skin.id === id);
+}
+
+export const DEFAULT_SKIN_ID = 'azure';


### PR DESCRIPTION
Introduces a skin/color theme system that lets users customize the color palette applied across the entire website. Includes 8 skin presets (Azure, Sakura, Emerald, Sunset, Amethyst, Crimson, Arctic, Gold) with persisted selection via localStorage.

- Add SkinProvider context with CSS variable injection on document root
- Add skin type definitions, presets, and localStorage persistence
- Create SkinCustomizer UI panel with miniature theme previews
- Convert rhythmia.module.css to use --skin-* CSS variables throughout
- Define default CSS variables in globals.css
- Add Profile button to lobby header opening the skin customizer
- Integrate SkinProvider into the layout provider hierarchy
- Add i18n translations for all 5 locales (ja, en, th, es, fr)

https://claude.ai/code/session_01RXdNFWPWoEkT2oy6JYB658