### PR TITLE
Add private profile feature

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -817,7 +817,11 @@
         "back": "Back",
         "onlineTitle": "Online Players",
         "onlineCount": "{count} online",
-        "noOnlineUsers": "No players online right now"
+        "noOnlineUsers": "No players online right now",
+        "privateProfile": "Private Profile",
+        "privateProfileDesc": "Your name and icon are hidden from the online players list",
+        "publicProfile": "Public Profile",
+        "publicProfileDesc": "Your name and icon are visible to other players online"
     },
     "skin": {
         "title": "Profile & Skin",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -817,7 +817,11 @@
         "back": "もどる",
         "onlineTitle": "オンラインのプレイヤー",
         "onlineCount": "{count}人がオンライン",
-        "noOnlineUsers": "現在オンラインのプレイヤーはいません"
+        "noOnlineUsers": "現在オンラインのプレイヤーはいません",
+        "privateProfile": "非公開プロフィール",
+        "privateProfileDesc": "名前とアイコンがオンラインプレイヤー一覧に表示されません",
+        "publicProfile": "公開プロフィール",
+        "publicProfileDesc": "名前とアイコンが他のプレイヤーに表示されます"
     },
     "skin": {
         "title": "プロフィール & スキン",

--- a/multiplayer-server.ts
+++ b/multiplayer-server.ts
@@ -49,6 +49,7 @@ interface PlayerConnection {
   reconnectToken?: string;
   profileName?: string;
   profileIcon?: string;
+  profilePrivate?: boolean;
 }
 
 // Ranked matchmaking queue
@@ -143,7 +144,7 @@ function broadcastOnlineCount(): void {
 function getOnlineUsers(): { name: string; icon: string }[] {
   const users: { name: string; icon: string }[] = [];
   playerConnections.forEach((conn) => {
-    if (conn.profileName && conn.ws.readyState === WebSocket.OPEN) {
+    if (conn.profileName && conn.ws.readyState === WebSocket.OPEN && !conn.profilePrivate) {
       users.push({ name: conn.profileName, icon: conn.profileIcon || '' });
     }
   });
@@ -547,10 +548,11 @@ function handleMessage(playerId: string, raw: string): void {
     }
 
     case 'set_profile': {
-      const profileMsg = message as unknown as { name: string; icon: string };
+      const profileMsg = message as unknown as { name: string; icon: string; isPrivate?: boolean };
       if (conn) {
         conn.profileName = (profileMsg.name || '').slice(0, 20);
         conn.profileIcon = (profileMsg.icon || '').slice(0, 30);
+        conn.profilePrivate = !!profileMsg.isPrivate;
         // Broadcast updated online users so all clients see the new profile
         broadcastOnlineCount();
       }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -130,6 +130,18 @@ export default function RhythmiaPage() {
         sendProfileToWs();
     }, [sendProfileToWs]);
 
+    // Re-send profile to WS when privacy setting changes
+    useEffect(() => {
+        if (profile && wsRef.current?.readyState === WebSocket.OPEN && profileSentRef.current) {
+            wsRef.current.send(JSON.stringify({
+                type: 'set_profile',
+                name: profile.name,
+                icon: profile.icon,
+                isPrivate: profile.isPrivate,
+            }));
+        }
+    }, [profile?.isPrivate]); // eslint-disable-line react-hooks/exhaustive-deps
+
     const requestOnlineUsers = () => {
         if (wsRef.current?.readyState === WebSocket.OPEN) {
             wsRef.current.send(JSON.stringify({ type: 'get_online_users' }));

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -65,6 +65,7 @@ export default function RhythmiaPage() {
                 type: 'set_profile',
                 name: profile.name,
                 icon: profile.icon,
+                isPrivate: profile.isPrivate,
             }));
             profileSentRef.current = true;
         }
@@ -86,6 +87,7 @@ export default function RhythmiaPage() {
                     type: 'set_profile',
                     name: profile.name,
                     icon: profile.icon,
+                    isPrivate: profile.isPrivate,
                 }));
                 profileSentRef.current = true;
             }

--- a/src/components/profile/ProfileSetup.module.css
+++ b/src/components/profile/ProfileSetup.module.css
@@ -282,6 +282,64 @@
   letter-spacing: 0.08em;
 }
 
+/* Privacy Toggle */
+.privacyToggle {
+  width: 100%;
+  max-width: 400px;
+  padding: 14px 18px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 2px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  margin-bottom: 40px;
+  text-align: left;
+  color: #ffffff;
+}
+
+.privacyToggle:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.privacyToggleActive {
+  border-color: #0ab9e6;
+  background: rgba(10, 185, 230, 0.08);
+}
+
+.privacyIcon {
+  font-size: 1.3rem;
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.privacyText {
+  flex: 1;
+  min-width: 0;
+}
+
+.privacyLabel {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #ffffff;
+  letter-spacing: 0.03em;
+  margin-bottom: 2px;
+}
+
+.privacyDesc {
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.35);
+  letter-spacing: 0.03em;
+  line-height: 1.4;
+}
+
 /* Navigation Buttons */
 .buttons {
   display: flex;

--- a/src/components/profile/ProfileSetup.tsx
+++ b/src/components/profile/ProfileSetup.tsx
@@ -26,6 +26,7 @@ export default function ProfileSetup() {
   const [selectedIcon, setSelectedIcon] = useState<string>('icon_rhythm');
   const [name, setName] = useState('');
   const [selectedLocale, setSelectedLocale] = useState<'ja' | 'en'>(locale === 'en' ? 'en' : 'ja');
+  const [isPrivate, setIsPrivate] = useState(false);
 
   const friendCode = useMemo(() => generateFriendCode(), []);
 
@@ -66,21 +67,24 @@ export default function ProfileSetup() {
       icon: selectedIcon,
       friendCode,
       locale: selectedLocale,
+      isPrivate,
       createdAt: Date.now(),
     };
     setProfile(profile);
 
-    // Log site entry to Discord (fire-and-forget)
-    fetch('/api/site-entry', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name: profile.name,
-        icon: profile.icon,
-        friendCode: profile.friendCode,
-        locale: profile.locale,
-      }),
-    }).catch(() => {});
+    // Log site entry to Discord (fire-and-forget) — skip for private profiles
+    if (!isPrivate) {
+      fetch('/api/site-entry', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: profile.name,
+          icon: profile.icon,
+          friendCode: profile.friendCode,
+          locale: profile.locale,
+        }),
+      }).catch(() => {});
+    }
 
     // Switch locale if different from current
     if (selectedLocale !== locale) {
@@ -283,6 +287,22 @@ export default function ProfileSetup() {
                   </div>
                 </div>
               </div>
+
+              <button
+                className={`${styles.privacyToggle} ${isPrivate ? styles.privacyToggleActive : ''}`}
+                onClick={() => setIsPrivate(!isPrivate)}
+                type="button"
+              >
+                <div className={styles.privacyIcon}>{isPrivate ? '🔒' : '🌐'}</div>
+                <div className={styles.privacyText}>
+                  <div className={styles.privacyLabel}>
+                    {t(isPrivate ? 'privateProfile' : 'publicProfile')}
+                  </div>
+                  <div className={styles.privacyDesc}>
+                    {t(isPrivate ? 'privateProfileDesc' : 'publicProfileDesc')}
+                  </div>
+                </div>
+              </button>
 
               <div className={styles.buttons}>
                 <button className={styles.btnBack} onClick={goBack}>

--- a/src/components/profile/SkinCustomizer.module.css
+++ b/src/components/profile/SkinCustomizer.module.css
@@ -262,6 +262,66 @@
   flex-shrink: 0;
 }
 
+/* Privacy Toggle */
+.privacySection {
+  padding: 0 28px 24px;
+}
+
+.privacyToggle {
+  width: 100%;
+  padding: 14px 18px;
+  background: var(--skin-surface, rgba(255, 255, 255, 0.03));
+  border: 2px solid var(--skin-border, rgba(255, 255, 255, 0.08));
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-align: left;
+  color: var(--skin-foreground, #ffffff);
+}
+
+.privacyToggle:hover {
+  background: var(--skin-accent-dim, rgba(255, 255, 255, 0.05));
+  border-color: var(--skin-border-hover, rgba(255, 255, 255, 0.15));
+}
+
+.privacyToggleActive {
+  border-color: var(--skin-accent, #007FFF);
+  background: var(--skin-accent-dim, rgba(0, 127, 255, 0.08));
+}
+
+.privacyIcon {
+  font-size: 1.3rem;
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.privacyText {
+  flex: 1;
+  min-width: 0;
+}
+
+.privacyLabel {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--skin-foreground, #ffffff);
+  letter-spacing: 0.03em;
+  margin-bottom: 2px;
+}
+
+.privacyDesc {
+  font-size: 0.65rem;
+  color: var(--skin-subtext, rgba(255, 255, 255, 0.35));
+  letter-spacing: 0.03em;
+  line-height: 1.4;
+}
+
 /* Responsive */
 @media (max-width: 640px) {
   .panel {
@@ -287,5 +347,9 @@
     flex-direction: column;
     gap: 8px;
     align-items: flex-start;
+  }
+
+  .privacySection {
+    padding: 0 20px 20px;
   }
 }

--- a/src/components/profile/SkinCustomizer.tsx
+++ b/src/components/profile/SkinCustomizer.tsx
@@ -8,6 +8,32 @@ import { getIconById } from '@/lib/profile/types';
 import type { Skin } from '@/lib/skin/types';
 import styles from './SkinCustomizer.module.css';
 
+function PrivacyToggle() {
+  const t = useTranslations('profile');
+  const { profile, updateProfile } = useProfile();
+  if (!profile) return null;
+
+  const isPrivate = profile.isPrivate;
+
+  return (
+    <button
+      className={`${styles.privacyToggle} ${isPrivate ? styles.privacyToggleActive : ''}`}
+      onClick={() => updateProfile({ isPrivate: !isPrivate })}
+      type="button"
+    >
+      <div className={styles.privacyIcon}>{isPrivate ? '🔒' : '🌐'}</div>
+      <div className={styles.privacyText}>
+        <div className={styles.privacyLabel}>
+          {t(isPrivate ? 'privateProfile' : 'publicProfile')}
+        </div>
+        <div className={styles.privacyDesc}>
+          {t(isPrivate ? 'privateProfileDesc' : 'publicProfileDesc')}
+        </div>
+      </div>
+    </button>
+  );
+}
+
 interface SkinCustomizerProps {
   onClose: () => void;
 }
@@ -125,6 +151,11 @@ export default function SkinCustomizer({ onClose }: SkinCustomizerProps) {
             />
             {currentSkin.name} — {currentSkin.nameJa}
           </div>
+        </div>
+
+        {/* Privacy setting */}
+        <div className={styles.privacySection}>
+          <PrivacyToggle />
         </div>
       </motion.div>
     </motion.div>

--- a/src/lib/profile/context.tsx
+++ b/src/lib/profile/context.tsx
@@ -7,6 +7,7 @@ import { getStoredProfile, setStoredProfile } from './storage';
 interface ProfileContextType {
   profile: UserProfile | null;
   setProfile: (profile: UserProfile) => void;
+  updateProfile: (updates: Partial<UserProfile>) => void;
   isProfileSetup: boolean;
   showProfileSetup: boolean;
   setShowProfileSetup: (show: boolean) => void;
@@ -36,9 +37,16 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
     setShowProfileSetup(false);
   };
 
+  const updateProfile = (updates: Partial<UserProfile>) => {
+    if (!profile) return;
+    const updated = { ...profile, ...updates };
+    setProfileState(updated);
+    setStoredProfile(updated);
+  };
+
   return (
     <ProfileContext.Provider
-      value={{ profile, setProfile, isProfileSetup, showProfileSetup, setShowProfileSetup }}
+      value={{ profile, setProfile, updateProfile, isProfileSetup, showProfileSetup, setShowProfileSetup }}
     >
       {children}
     </ProfileContext.Provider>

--- a/src/lib/profile/storage.ts
+++ b/src/lib/profile/storage.ts
@@ -13,7 +13,12 @@ export function getStoredProfile(): UserProfile | null {
   try {
     const raw = window.localStorage.getItem(PROFILE_STORAGE_KEY);
     if (!raw) return null;
-    return JSON.parse(raw) as UserProfile;
+    const parsed = JSON.parse(raw);
+    // Backward compatibility: default isPrivate to false for older profiles
+    if (typeof parsed.isPrivate !== 'boolean') {
+      parsed.isPrivate = false;
+    }
+    return parsed as UserProfile;
   } catch {
     return null;
   }

--- a/src/lib/profile/types.ts
+++ b/src/lib/profile/types.ts
@@ -3,6 +3,7 @@ export interface UserProfile {
   icon: string;
   friendCode: string;
   locale: 'ja' | 'en';
+  isPrivate: boolean;
   createdAt: number;
 }
 

--- a/src/types/multiplayer.ts
+++ b/src/types/multiplayer.ts
@@ -257,6 +257,7 @@ export interface SetProfileMessage {
   type: 'set_profile';
   name: string;
   icon: string;
+  isPrivate?: boolean;
 }
 
 export interface GetOnlineUsersMessage {


### PR DESCRIPTION
Allow users to set their profile as private during setup. Private profiles are hidden from the online players list and skip the Discord webhook notification on creation. The privacy toggle appears on the confirmation step of the profile setup wizard.

Changes:
- Add isPrivate field to UserProfile type with backward compat default
- Add privacy toggle button on profile setup confirmation step
- Add updateProfile method to profile context for runtime changes
- Send isPrivate flag via WebSocket set_profile message
- Filter private profiles from getOnlineUsers on multiplayer server
- Skip Discord site-entry webhook for private profiles
- Add i18n translations (en + ja) for privacy toggle labels

https://claude.ai/code/session_01LdUUw6d9tA7LEZBDGfCBbd