### PR TITLE
Move back button from game header to pause menu

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -160,13 +160,7 @@ export default function RhythmiaPage() {
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.3 }}
             >
-                <div className={styles.gameHeader}>
-                    <span className={styles.gameTitle}>{t('vanilla.gameTitle')}</span>
-                    <button className={styles.backButton} onClick={closeGame}>
-                        {t('lobby.back')}
-                    </button>
-                </div>
-                <VanillaGame />
+                <VanillaGame onQuit={closeGame} />
             </motion.div>
         );
     }
@@ -180,13 +174,7 @@ export default function RhythmiaPage() {
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.3 }}
             >
-                <div className={styles.gameHeader}>
-                    <span className={styles.gameTitle}>{t('multiplayer.gameTitle')}</span>
-                    <button className={styles.backButton} onClick={closeGame}>
-                        {t('lobby.back')}
-                    </button>
-                </div>
-                <MultiplayerGame />
+                <MultiplayerGame onQuit={closeGame} />
             </motion.div>
         );
     }

--- a/src/components/rhythmia/MultiplayerGame.tsx
+++ b/src/components/rhythmia/MultiplayerGame.tsx
@@ -18,7 +18,11 @@ type GameMode = 'lobby' | 'name-entry' | 'room-browser' | 'waiting-room' | 'coun
 const MAX_RECONNECT_ATTEMPTS = 5;
 const PING_TIMEOUT = 60000; // Consider connection dead if no ping from server in 60s
 
-export default function MultiplayerGame() {
+interface MultiplayerGameProps {
+  onQuit?: () => void;
+}
+
+export default function MultiplayerGame({ onQuit }: MultiplayerGameProps) {
   // Connection
   const wsRef = useRef<WebSocket | null>(null);
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('disconnected');
@@ -450,6 +454,11 @@ export default function MultiplayerGame() {
               <p className={styles.modeDesc}>Summon monsters to destroy your opponent&apos;s base</p>
             </div>
           </div>
+          {onQuit && (
+            <button className={styles.backBtn} onClick={onQuit}>
+              ← Back to Title
+            </button>
+          )}
         </div>
       )}
 

--- a/src/components/rhythmia/tetris/VanillaGame.module.css
+++ b/src/components/rhythmia/tetris/VanillaGame.module.css
@@ -816,6 +816,19 @@
   color: rgba(0, 0, 0, 0.4);
 }
 
+.pauseMenuQuitBtn {
+  margin-top: 8px;
+  background: rgba(255, 60, 60, 0.1);
+  border-color: rgba(255, 60, 60, 0.25);
+  color: rgba(255, 100, 100, 0.9);
+}
+
+.pauseMenuQuitBtn:hover {
+  background: rgba(255, 60, 60, 0.2);
+  border-color: rgba(255, 60, 60, 0.5);
+  color: #ff6464;
+}
+
 /* Responsive: pause menu on smaller screens */
 @media (max-width: 480px) {
   .pauseMenuButtons {

--- a/src/components/rhythmia/tetris/components/Board.tsx
+++ b/src/components/rhythmia/tetris/components/Board.tsx
@@ -18,6 +18,7 @@ interface BoardProps {
     score: number;
     onRestart: () => void;
     onResume?: () => void;
+    onQuit?: () => void;
     colorTheme?: ColorTheme;
     onThemeChange?: (theme: ColorTheme) => void;
     worldIdx?: number;
@@ -43,6 +44,7 @@ export function Board({
     score,
     onRestart,
     onResume,
+    onQuit,
     colorTheme = 'stage',
     onThemeChange,
     worldIdx = 0,
@@ -191,9 +193,19 @@ export function Board({
                 <div className={styles.gameover} style={{ display: 'flex' }}>
                     <h2>GAME OVER</h2>
                     <div className={styles.finalScore}>{score.toLocaleString()} pts</div>
-                    <button className={styles.restartBtn} onClick={onRestart}>
-                        もう一度
-                    </button>
+                    <div className={styles.pauseMenuButtons}>
+                        <button className={styles.pauseMenuBtn} onClick={onRestart}>
+                            もう一度
+                        </button>
+                        {onQuit && (
+                            <button
+                                className={`${styles.pauseMenuBtn} ${styles.pauseMenuQuitBtn}`}
+                                onClick={onQuit}
+                            >
+                                Back to Title
+                            </button>
+                        )}
+                    </div>
                 </div>
             )}
 
@@ -233,6 +245,15 @@ export function Board({
                                     >
                                         <span className={styles.pauseMenuBtnIcon}>⌨</span>
                                         Key Bindings
+                                    </button>
+                                )}
+                                {onQuit && (
+                                    <button
+                                        className={`${styles.pauseMenuBtn} ${styles.pauseMenuQuitBtn}`}
+                                        onClick={onQuit}
+                                    >
+                                        <span className={styles.pauseMenuBtnIcon}>🚪</span>
+                                        Save and Quit to Title
                                     </button>
                                 )}
                             </div>

--- a/src/components/rhythmia/tetris/tetris.tsx
+++ b/src/components/rhythmia/tetris/tetris.tsx
@@ -60,11 +60,15 @@ import {
   KeyBindSettings,
 } from './components';
 
+interface RhythmiaProps {
+  onQuit?: () => void;
+}
+
 /**
  * Rhythmia - A rhythm-based Tetris game with full game loop:
  * World Creation → Dig → Item Drop → Craft → Firepower → Collapse → Reload → Next World
  */
-export default function Rhythmia() {
+export default function Rhythmia({ onQuit }: RhythmiaProps) {
   // Device type detection for responsive layouts
   const deviceInfo = useDeviceType();
   const { type: deviceType, isLandscape } = deviceInfo;
@@ -1216,6 +1220,7 @@ export default function Rhythmia() {
                 score={score}
                 onRestart={() => startGame(gameMode)}
                 onResume={() => { setIsPaused(false); setShowInventory(false); setShowShop(false); }}
+                onQuit={onQuit}
                 colorTheme={colorTheme}
                 onThemeChange={setColorTheme}
                 worldIdx={worldIdx}


### PR DESCRIPTION
Remove the always-visible back button header bar from vanilla and multiplayer game containers. Instead, add "Save and Quit to Title" option to the Minecraft-style pause menu (Escape/P key) and a "Back to Title" button on the game over screen. For multiplayer, add a "Back to Title" button on the lobby screen.

https://claude.ai/code/session_0171igHq9MZc6TNGZ9PvMv7A