### PR TITLE
Redesign ForYouTab with horizontal widget layout and Minecraft textures

### DIFF
--- a/src/components/rhythmia/ForYouTab.module.css
+++ b/src/components/rhythmia/ForYouTab.module.css
@@ -1,4 +1,4 @@
-/* For You Tab */
+/* For You Tab — Minecraft Dungeons Widget Style */
 .forYouContainer {
     width: 100%;
     max-width: 900px;
@@ -26,88 +26,186 @@
     font-weight: 300;
 }
 
-/* Card Grid */
-.cardGrid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 16px;
+/* Vertical Widget List */
+.widgetList {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
     width: 100%;
 }
 
-/* Card */
-.card {
-    position: relative;
+/* Single Horizontal Widget */
+.widget {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    width: 100%;
+    padding: 12px 16px;
     background: rgba(255, 255, 255, 0.025);
-    border: 1px solid rgba(255, 255, 255, 0.07);
-    border-radius: 10px;
-    padding: 20px;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    border: 2px solid rgba(255, 255, 255, 0.08);
+    border-radius: 4px;
+    cursor: pointer;
+    text-decoration: none;
+    color: inherit;
+    transition:
+        transform 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+        border-color 0.2s ease,
+        background 0.25s ease,
+        box-shadow 0.25s ease;
+    position: relative;
     overflow: hidden;
 }
 
-.card::before {
+.widget::before {
     content: '';
     position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 2px;
+    inset: 0;
     opacity: 0;
-    transition: opacity 0.3s;
+    transition: opacity 0.25s ease;
+    pointer-events: none;
 }
 
-.card:hover {
-    border-color: rgba(255, 255, 255, 0.15);
-    background: rgba(255, 255, 255, 0.04);
+.widget:hover {
+    transform: scale(1.015);
+    border-color: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.05);
+    box-shadow:
+        0 0 16px rgba(0, 127, 255, 0.08),
+        inset 0 0 20px rgba(255, 255, 255, 0.015);
 }
 
-.card:hover::before {
+.widget:hover::before {
     opacity: 1;
 }
 
-/* Card type accent lines */
-.card.tutorial::before {
-    background: linear-gradient(90deg, rgba(100, 180, 255, 0.6), transparent);
+.widget:active {
+    transform: scale(0.995);
 }
 
-.card.video::before {
-    background: linear-gradient(90deg, rgba(255, 80, 80, 0.6), transparent);
+/* Type-specific accent glow on hover */
+.widget.tutorial::before {
+    background: linear-gradient(90deg, rgba(100, 180, 255, 0.06) 0%, transparent 60%);
 }
 
-.card.tip::before {
-    background: linear-gradient(90deg, rgba(255, 200, 60, 0.6), transparent);
+.widget.video::before {
+    background: linear-gradient(90deg, rgba(255, 80, 80, 0.06) 0%, transparent 60%);
 }
 
-/* Card Header */
-.cardHeader {
+.widget.tip::before {
+    background: linear-gradient(90deg, rgba(255, 200, 60, 0.06) 0%, transparent 60%);
+}
+
+/* Pixel-art Thumbnail */
+.thumbnailFrame {
+    flex-shrink: 0;
+    width: 52px;
+    height: 52px;
+    position: relative;
+    border: 3px solid rgba(255, 255, 255, 0.15);
+    border-radius: 2px;
+    background: rgba(0, 0, 0, 0.4);
+    box-shadow:
+        0 0 8px rgba(0, 0, 0, 0.5),
+        inset 0 0 6px rgba(0, 0, 0, 0.3);
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: border-color 0.2s ease, box-shadow 0.25s ease;
+}
+
+.widget:hover .thumbnailFrame {
+    border-color: rgba(255, 255, 255, 0.3);
+}
+
+.widget.tutorial:hover .thumbnailFrame {
+    box-shadow:
+        0 0 10px rgba(100, 180, 255, 0.25),
+        inset 0 0 6px rgba(100, 180, 255, 0.1);
+}
+
+.widget.video:hover .thumbnailFrame {
+    box-shadow:
+        0 0 10px rgba(255, 80, 80, 0.25),
+        inset 0 0 6px rgba(255, 80, 80, 0.1);
+}
+
+.widget.tip:hover .thumbnailFrame {
+    box-shadow:
+        0 0 10px rgba(255, 200, 60, 0.25),
+        inset 0 0 6px rgba(255, 200, 60, 0.1);
+}
+
+.thumbnailImg {
+    width: 36px;
+    height: 36px;
+    image-rendering: pixelated;
+    object-fit: cover;
+    opacity: 0.85;
+    transition: opacity 0.2s ease;
+}
+
+.widget:hover .thumbnailImg {
+    opacity: 1;
+}
+
+/* Fallback icon (when no image) */
+.thumbnailIcon {
+    font-size: 1.4rem;
+    line-height: 1;
+    opacity: 0.7;
+    transition: opacity 0.2s ease;
+}
+
+.widget:hover .thumbnailIcon {
+    opacity: 1;
+}
+
+/* Widget Content Area */
+.widgetContent {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.widgetTopRow {
     display: flex;
     align-items: center;
     gap: 8px;
-    margin-bottom: 12px;
-}
-
-.typeIcon {
-    font-size: 0.85rem;
-    line-height: 1;
 }
 
 .typeLabel {
-    font-size: 0.6rem;
+    font-size: 0.55rem;
     font-weight: 600;
     letter-spacing: 0.15em;
     text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.4);
+    color: rgba(255, 255, 255, 0.35);
+    flex-shrink: 0;
+}
+
+.widget.tutorial .typeLabel {
+    color: rgba(100, 180, 255, 0.6);
+}
+
+.widget.video .typeLabel {
+    color: rgba(255, 80, 80, 0.6);
+}
+
+.widget.tip .typeLabel {
+    color: rgba(255, 200, 60, 0.6);
 }
 
 .diffBadge {
-    margin-left: auto;
-    padding: 2px 8px;
-    font-size: 0.55rem;
+    padding: 1px 6px;
+    font-size: 0.5rem;
     font-weight: 500;
-    letter-spacing: 0.08em;
-    border-radius: 3px;
+    letter-spacing: 0.06em;
+    border-radius: 2px;
     border: 1px solid rgba(255, 255, 255, 0.1);
     color: rgba(255, 255, 255, 0.4);
+    flex-shrink: 0;
 }
 
 .diff_beginner {
@@ -125,53 +223,39 @@
     color: rgba(255, 80, 80, 0.7);
 }
 
-/* Card Content */
-.cardTitle {
-    font-size: 0.9rem;
+.widgetTitle {
+    font-size: 0.85rem;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.9);
-    margin-bottom: 8px;
-    line-height: 1.4;
+    line-height: 1.3;
     letter-spacing: 0.02em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
-.cardDescription {
-    font-size: 0.75rem;
-    color: rgba(255, 255, 255, 0.35);
-    line-height: 1.6;
+.widgetDescription {
+    font-size: 0.72rem;
+    color: rgba(255, 255, 255, 0.32);
+    line-height: 1.4;
     font-weight: 300;
-    margin-bottom: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
-/* Tags */
-.tagList {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 5px;
-    margin-bottom: 8px;
+/* Arrow indicator on right side */
+.widgetArrow {
+    flex-shrink: 0;
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.15);
+    transition: color 0.2s ease, transform 0.2s ease;
+    margin-left: 8px;
 }
 
-.tag {
-    padding: 2px 8px;
-    font-size: 0.6rem;
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    border-radius: 3px;
-    color: rgba(255, 255, 255, 0.35);
-    letter-spacing: 0.04em;
-}
-
-/* YouTube Link */
-.cardLink {
-    font-size: 0.65rem;
-    color: rgba(255, 80, 80, 0.7);
-    letter-spacing: 0.05em;
-    font-weight: 500;
-    transition: color 0.25s;
-}
-
-.card:hover .cardLink {
-    color: rgba(255, 80, 80, 1);
+.widget:hover .widgetArrow {
+    color: rgba(255, 255, 255, 0.5);
+    transform: translateX(3px);
 }
 
 /* Refresh */
@@ -269,14 +353,27 @@
 }
 
 /* Responsive */
-@media (max-width: 768px) {
-    .cardGrid {
-        grid-template-columns: 1fr;
+@media (max-width: 600px) {
+    .widget {
+        gap: 12px;
+        padding: 10px 12px;
     }
-}
 
-@media (min-width: 769px) and (max-width: 1024px) {
-    .cardGrid {
-        grid-template-columns: repeat(2, 1fr);
+    .thumbnailFrame {
+        width: 44px;
+        height: 44px;
+    }
+
+    .thumbnailImg {
+        width: 28px;
+        height: 28px;
+    }
+
+    .widgetTitle {
+        font-size: 0.78rem;
+    }
+
+    .widgetDescription {
+        font-size: 0.66rem;
     }
 }

--- a/src/components/rhythmia/ForYouTab.tsx
+++ b/src/components/rhythmia/ForYouTab.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslations } from 'next-intl';
+import Image from 'next/image';
 import styles from './ForYouTab.module.css';
 
 interface ContentCard {
@@ -21,16 +22,23 @@ interface ForYouTabProps {
     totalAdvancements: number;
 }
 
-const TYPE_ICONS: Record<string, string> = {
-    tutorial: '📖',
-    video: '▶',
-    tip: '💡',
+/** Map content types to pixel-art block textures from the public/textures directory */
+const TYPE_THUMBNAILS: Record<string, string> = {
+    tutorial: '/textures/blocks/obsidian.png',
+    video: '/textures/blocks/brick.png',
+    tip: '/textures/blocks/grass_top.png',
 };
 
 const DIFFICULTY_LABELS: Record<string, Record<string, string>> = {
     en: { beginner: 'Beginner', intermediate: 'Intermediate', advanced: 'Advanced' },
     ja: { beginner: '初級', intermediate: '中級', advanced: '上級' },
 };
+
+function getWikiUrl(card: ContentCard, locale: string): string {
+    if (card.url) return card.url;
+    const prefix = locale === 'ja' ? '' : '/en';
+    return `${prefix}/wiki`;
+}
 
 export default function ForYouTab({ locale, unlockedAdvancements, totalAdvancements }: ForYouTabProps) {
     const [cards, setCards] = useState<ContentCard[]>([]);
@@ -94,47 +102,59 @@ export default function ForYouTab({ locale, unlockedAdvancements, totalAdvanceme
                 <p className={styles.sectionSubtitle}>{t('subtitle')}</p>
             </div>
 
-            <div className={styles.cardGrid}>
+            <div className={styles.widgetList}>
                 <AnimatePresence mode="wait">
-                    {cards.map((card, index) => (
-                        <motion.div
-                            key={card.id}
-                            className={`${styles.card} ${styles[card.type]}`}
-                            initial={{ opacity: 0, y: 20 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            exit={{ opacity: 0, y: -10 }}
-                            transition={{ duration: 0.35, delay: index * 0.06 }}
-                            whileHover={{ y: -4, transition: { duration: 0.2 } }}
-                            onClick={() => card.url && window.open(card.url, '_blank', 'noopener,noreferrer')}
-                            style={{ cursor: card.url ? 'pointer' : 'default' }}
-                        >
-                            <div className={styles.cardHeader}>
-                                <span className={styles.typeIcon}>{TYPE_ICONS[card.type] || '📌'}</span>
-                                <span className={styles.typeLabel}>{t(`types.${card.type}`)}</span>
-                                {card.difficulty && (
-                                    <span className={`${styles.diffBadge} ${styles[`diff_${card.difficulty}`]}`}>
-                                        {diffLabels[card.difficulty]}
-                                    </span>
-                                )}
-                            </div>
-                            <h3 className={styles.cardTitle}>{card.title}</h3>
-                            <p className={styles.cardDescription}>{card.description}</p>
-                            {card.tags && card.tags.length > 0 && (
-                                <div className={styles.tagList}>
-                                    {card.tags.map((tag) => (
-                                        <span key={tag} className={styles.tag}>
-                                            {tag}
-                                        </span>
-                                    ))}
+                    {cards.map((card, index) => {
+                        const href = getWikiUrl(card, locale);
+                        const thumbnail = TYPE_THUMBNAILS[card.type];
+
+                        return (
+                            <motion.a
+                                key={card.id}
+                                href={href}
+                                target={card.url ? '_blank' : undefined}
+                                rel={card.url ? 'noopener noreferrer' : undefined}
+                                className={`${styles.widget} ${styles[card.type]}`}
+                                initial={{ opacity: 0, x: -16 }}
+                                animate={{ opacity: 1, x: 0 }}
+                                exit={{ opacity: 0, x: 16 }}
+                                transition={{ duration: 0.3, delay: index * 0.05 }}
+                            >
+                                {/* Pixel-art thumbnail */}
+                                <div className={styles.thumbnailFrame}>
+                                    {thumbnail ? (
+                                        <Image
+                                            src={thumbnail}
+                                            alt=""
+                                            width={36}
+                                            height={36}
+                                            className={styles.thumbnailImg}
+                                            unoptimized
+                                        />
+                                    ) : (
+                                        <span className={styles.thumbnailIcon}>📌</span>
+                                    )}
                                 </div>
-                            )}
-                            {card.url && (
-                                <div className={styles.cardLink}>
-                                    {t('watchOnYouTube')} →
+
+                                {/* Content */}
+                                <div className={styles.widgetContent}>
+                                    <div className={styles.widgetTopRow}>
+                                        <span className={styles.typeLabel}>{t(`types.${card.type}`)}</span>
+                                        {card.difficulty && (
+                                            <span className={`${styles.diffBadge} ${styles[`diff_${card.difficulty}`]}`}>
+                                                {diffLabels[card.difficulty]}
+                                            </span>
+                                        )}
+                                    </div>
+                                    <h3 className={styles.widgetTitle}>{card.title}</h3>
+                                    <p className={styles.widgetDescription}>{card.description}</p>
                                 </div>
-                            )}
-                        </motion.div>
-                    ))}
+
+                                {/* Arrow */}
+                                <span className={styles.widgetArrow}>→</span>
+                            </motion.a>
+                        );
+                    })}
                 </AnimatePresence>
             </div>
 


### PR DESCRIPTION
## Summary
Redesigned the "For You" tab from a 3-column card grid layout to a vertical list of horizontal widgets, styled with Minecraft Dungeons aesthetics and pixel-art block textures.

## Key Changes

- **Layout Transformation**: Changed from CSS Grid (3 columns) to flexbox vertical list with horizontal widget items
  - Each widget now displays as a compact horizontal row with thumbnail, content, and navigation arrow
  - Improved mobile responsiveness with adjusted breakpoints (600px instead of 768px)

- **Visual Redesign**:
  - Added pixel-art thumbnail frames (52×52px) displaying Minecraft block textures
  - Replaced emoji icons with actual texture images from `/textures/blocks/` directory
  - Enhanced hover effects: scale animation, colored glow shadows, and arrow translation
  - Refined color scheme with type-specific accent colors (blue for tutorials, red for videos, yellow for tips)

- **Component Structure**:
  - Converted from `<motion.div>` cards to semantic `<motion.a>` links for better accessibility
  - Reorganized content hierarchy: thumbnail → type label + difficulty badge → title → description → arrow
  - Added `getWikiUrl()` helper function to handle URL routing with locale support
  - Integrated Next.js `Image` component for optimized texture rendering with `pixelated` image-rendering

- **Styling Refinements**:
  - Reduced padding and gaps for more compact widget appearance
  - Added text truncation (ellipsis) for title and description to prevent overflow
  - Improved transition timing and easing for smoother interactions
  - Type-specific gradient accents now use lower opacity (0.06) for subtler effect
  - Removed tag list and YouTube-specific link styling in favor of unified arrow indicator

- **Responsive Design**:
  - Mobile adjustments: smaller thumbnails (44×44px), reduced font sizes, tighter spacing
  - Maintained visual hierarchy across all screen sizes

https://claude.ai/code/session_01SVbxGYTk9P7pVTA7yHcxqP