### PR TITLE
Simplify ProfileSetup to single-step language selection

### DIFF
--- a/src/components/profile/ProfileSetup.module.css
+++ b/src/components/profile/ProfileSetup.module.css
@@ -22,31 +22,6 @@
   align-items: center;
 }
 
-/* Step indicator */
-.steps {
-  display: flex;
-  gap: 8px;
-  margin-bottom: 32px;
-}
-
-.stepDot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.15);
-  transition: all 0.3s ease;
-}
-
-.stepDotActive {
-  background: #0ab9e6;
-  box-shadow: 0 0 8px rgba(10, 185, 230, 0.4);
-}
-
-.stepDotDone {
-  background: #0ab9e6;
-  opacity: 0.5;
-}
-
 /* Header */
 .title {
   font-size: 1.5rem;
@@ -63,117 +38,6 @@
   margin-bottom: 40px;
   text-align: center;
   letter-spacing: 0.05em;
-}
-
-/* Icon Selection Grid */
-.iconGrid {
-  display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 12px;
-  margin-bottom: 40px;
-  width: 100%;
-  max-width: 420px;
-}
-
-.iconOption {
-  width: 56px;
-  height: 56px;
-  border-radius: 50%;
-  border: 3px solid transparent;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.3rem;
-  font-weight: 700;
-  position: relative;
-  margin: 0 auto;
-}
-
-.iconOption:hover {
-  transform: scale(1.1);
-  border-color: rgba(255, 255, 255, 0.3);
-}
-
-.iconOptionSelected {
-  border-color: #0ab9e6;
-  box-shadow: 0 0 0 2px rgba(10, 185, 230, 0.3), 0 4px 16px rgba(10, 185, 230, 0.2);
-  transform: scale(1.1);
-}
-
-/* Name Input */
-.inputGroup {
-  width: 100%;
-  max-width: 400px;
-  margin-bottom: 32px;
-}
-
-.inputLabel {
-  display: block;
-  font-size: 0.7rem;
-  color: rgba(255, 255, 255, 0.4);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  margin-bottom: 8px;
-}
-
-.nameInput {
-  width: 100%;
-  padding: 14px 16px;
-  background: rgba(255, 255, 255, 0.06);
-  border: 2px solid rgba(255, 255, 255, 0.1);
-  border-radius: 8px;
-  color: #ffffff;
-  font-size: 1rem;
-  font-weight: 500;
-  outline: none;
-  transition: border-color 0.2s ease;
-  letter-spacing: 0.02em;
-  box-sizing: border-box;
-}
-
-.nameInput::placeholder {
-  color: rgba(255, 255, 255, 0.2);
-}
-
-.nameInput:focus {
-  border-color: #0ab9e6;
-}
-
-.charCount {
-  text-align: right;
-  font-size: 0.65rem;
-  color: rgba(255, 255, 255, 0.25);
-  margin-top: 6px;
-}
-
-/* Friend Code Display */
-.friendCodeSection {
-  width: 100%;
-  max-width: 400px;
-  margin-bottom: 40px;
-  text-align: center;
-}
-
-.friendCodeLabel {
-  font-size: 0.7rem;
-  color: rgba(255, 255, 255, 0.4);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  margin-bottom: 12px;
-}
-
-.friendCode {
-  font-size: 1.6rem;
-  font-weight: 700;
-  color: #ffffff;
-  letter-spacing: 0.08em;
-  font-variant-numeric: tabular-nums;
-  padding: 16px 24px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 12px;
 }
 
 /* Language Selection */
@@ -282,88 +146,12 @@
   letter-spacing: 0.08em;
 }
 
-/* Privacy Toggle */
-.privacyToggle {
-  width: 100%;
-  max-width: 400px;
-  padding: 14px 18px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 2px solid rgba(255, 255, 255, 0.08);
-  border-radius: 12px;
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  margin-bottom: 40px;
-  text-align: left;
-  color: #ffffff;
-}
-
-.privacyToggle:hover {
-  background: rgba(255, 255, 255, 0.06);
-  border-color: rgba(255, 255, 255, 0.15);
-}
-
-.privacyToggleActive {
-  border-color: #0ab9e6;
-  background: rgba(10, 185, 230, 0.08);
-}
-
-.privacyIcon {
-  font-size: 1.3rem;
-  flex-shrink: 0;
-  width: 36px;
-  height: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.privacyText {
-  flex: 1;
-  min-width: 0;
-}
-
-.privacyLabel {
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: #ffffff;
-  letter-spacing: 0.03em;
-  margin-bottom: 2px;
-}
-
-.privacyDesc {
-  font-size: 0.65rem;
-  color: rgba(255, 255, 255, 0.35);
-  letter-spacing: 0.03em;
-  line-height: 1.4;
-}
-
 /* Navigation Buttons */
 .buttons {
   display: flex;
   gap: 12px;
   width: 100%;
   max-width: 400px;
-}
-
-.btnBack {
-  padding: 14px 24px;
-  background: transparent;
-  border: 2px solid rgba(255, 255, 255, 0.12);
-  border-radius: 8px;
-  color: rgba(255, 255, 255, 0.5);
-  font-size: 0.8rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  letter-spacing: 0.08em;
-}
-
-.btnBack:hover {
-  border-color: rgba(255, 255, 255, 0.25);
-  color: rgba(255, 255, 255, 0.7);
 }
 
 .btnNext {
@@ -385,37 +173,14 @@
   transform: translateY(-1px);
 }
 
-.btnNext:disabled {
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.2);
-  cursor: not-allowed;
-  transform: none;
-}
-
 /* Responsive */
 @media (max-width: 640px) {
   .container {
     padding: 24px 20px;
   }
 
-  .iconGrid {
-    grid-template-columns: repeat(4, 1fr);
-    gap: 10px;
-  }
-
-  .iconOption {
-    width: 48px;
-    height: 48px;
-    font-size: 1.1rem;
-  }
-
   .title {
     font-size: 1.2rem;
-  }
-
-  .friendCode {
-    font-size: 1.2rem;
-    padding: 12px 16px;
   }
 
   .previewIcon {

--- a/src/components/profile/ProfileSetup.tsx
+++ b/src/components/profile/ProfileSetup.tsx
@@ -1,19 +1,17 @@
 'use client';
 
-import { useState, useMemo, useCallback } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { useState, useMemo } from 'react';
+import { motion } from 'framer-motion';
 import { useTranslations, useLocale } from 'next-intl';
 import { usePathname, useRouter } from '@/i18n/navigation';
-import { PROFILE_ICONS, getIconById } from '@/lib/profile/types';
-import { generateFriendCode } from '@/lib/profile/storage';
+import { getIconById } from '@/lib/profile/types';
+import { generateFriendCode, generateDefaultName } from '@/lib/profile/storage';
 import { useProfile } from '@/lib/profile/context';
 import type { UserProfile } from '@/lib/profile/types';
 import type { Locale } from '@/i18n/routing';
 import styles from './ProfileSetup.module.css';
 
-type Step = 'icon' | 'name' | 'language' | 'confirm';
-const STEPS: Step[] = ['icon', 'name', 'language', 'confirm'];
-const MAX_NAME_LENGTH = 10;
+const DEFAULT_ICON = 'icon_rhythm';
 
 export default function ProfileSetup() {
   const t = useTranslations('profile');
@@ -22,77 +20,41 @@ export default function ProfileSetup() {
   const pathname = usePathname();
   const { setProfile } = useProfile();
 
-  const [step, setStep] = useState<Step>('icon');
-  const [selectedIcon, setSelectedIcon] = useState<string>('icon_rhythm');
-  const [name, setName] = useState('');
   const [selectedLocale, setSelectedLocale] = useState<'ja' | 'en'>(locale === 'en' ? 'en' : 'ja');
-  const [isPrivate, setIsPrivate] = useState(false);
 
   const friendCode = useMemo(() => generateFriendCode(), []);
+  const defaultName = useMemo(() => generateDefaultName(), []);
 
-  const stepIndex = STEPS.indexOf(step);
-
-  const canProceed = useCallback(() => {
-    switch (step) {
-      case 'icon':
-        return !!selectedIcon;
-      case 'name':
-        return name.trim().length > 0;
-      case 'language':
-        return true;
-      case 'confirm':
-        return true;
-      default:
-        return false;
-    }
-  }, [step, selectedIcon, name]);
-
-  const goNext = () => {
-    const idx = STEPS.indexOf(step);
-    if (idx < STEPS.length - 1) {
-      setStep(STEPS[idx + 1]);
-    }
-  };
-
-  const goBack = () => {
-    const idx = STEPS.indexOf(step);
-    if (idx > 0) {
-      setStep(STEPS[idx - 1]);
-    }
-  };
+  const selectedIconData = getIconById(DEFAULT_ICON);
 
   const handleComplete = () => {
     const profile: UserProfile = {
-      name: name.trim(),
-      icon: selectedIcon,
+      name: defaultName,
+      icon: DEFAULT_ICON,
       friendCode,
       locale: selectedLocale,
-      isPrivate,
+      isPrivate: false,
       createdAt: Date.now(),
     };
     setProfile(profile);
 
-    // Log site entry to Discord (fire-and-forget) — skip for private profiles
-    if (!isPrivate) {
-      fetch('/api/site-entry', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: profile.name,
-          icon: profile.icon,
-          friendCode: profile.friendCode,
-          locale: profile.locale,
-        }),
-      }).catch(() => {});
-    }
+    // Log site entry to Discord (fire-and-forget)
+    fetch('/api/site-entry', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: profile.name,
+        icon: profile.icon,
+        friendCode: profile.friendCode,
+        locale: profile.locale,
+      }),
+    }).catch(() => {});
 
     // Switch locale if different from current
     if (selectedLocale !== locale) {
       router.replace(pathname, { locale: selectedLocale });
     }
   };
-
-  const selectedIconData = getIconById(selectedIcon);
 
   return (
     <motion.div
@@ -103,218 +65,61 @@ export default function ProfileSetup() {
       transition={{ duration: 0.3 }}
     >
       <div className={styles.container}>
-        {/* Step indicators */}
-        <div className={styles.steps}>
-          {STEPS.map((s, i) => (
-            <div
-              key={s}
-              className={`${styles.stepDot} ${
-                i === stepIndex ? styles.stepDotActive : i < stepIndex ? styles.stepDotDone : ''
-              }`}
-            />
-          ))}
-        </div>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.3 }}
+          style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%' }}
+        >
+          <div className={styles.title}>{t('langTitle')}</div>
+          <div className={styles.subtitle}>{t('langSubtitle')}</div>
 
-        <AnimatePresence mode="wait">
-          {/* Step 1: Icon Selection */}
-          {step === 'icon' && (
-            <motion.div
-              key="icon"
-              initial={{ opacity: 0, x: 40 }}
-              animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: -40 }}
-              transition={{ duration: 0.25 }}
-              style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%' }}
-            >
-              <div className={styles.title}>{t('iconTitle')}</div>
-              <div className={styles.subtitle}>{t('iconSubtitle')}</div>
-
-              <div className={styles.iconGrid}>
-                {PROFILE_ICONS.map((icon) => (
-                  <button
-                    key={icon.id}
-                    className={`${styles.iconOption} ${selectedIcon === icon.id ? styles.iconOptionSelected : ''}`}
-                    style={{ backgroundColor: icon.bgColor, color: icon.color }}
-                    onClick={() => setSelectedIcon(icon.id)}
-                    aria-label={icon.id}
-                  >
-                    {icon.emoji}
-                  </button>
-                ))}
-              </div>
-
-              <div className={styles.buttons}>
-                <button
-                  className={styles.btnNext}
-                  onClick={goNext}
-                  disabled={!canProceed()}
-                >
-                  {t('next')}
-                </button>
-              </div>
-            </motion.div>
-          )}
-
-          {/* Step 2: Name Input */}
-          {step === 'name' && (
-            <motion.div
-              key="name"
-              initial={{ opacity: 0, x: 40 }}
-              animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: -40 }}
-              transition={{ duration: 0.25 }}
-              style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%' }}
-            >
-              <div className={styles.title}>{t('nameTitle')}</div>
-              <div className={styles.subtitle}>{t('nameSubtitle')}</div>
-
-              <div className={styles.inputGroup}>
-                <label className={styles.inputLabel}>{t('nameLabel')}</label>
-                <input
-                  className={styles.nameInput}
-                  type="text"
-                  value={name}
-                  onChange={(e) => {
-                    if (e.target.value.length <= MAX_NAME_LENGTH) {
-                      setName(e.target.value);
-                    }
-                  }}
-                  placeholder={t('namePlaceholder')}
-                  maxLength={MAX_NAME_LENGTH}
-                  autoFocus
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && canProceed()) goNext();
-                  }}
-                />
-                <div className={styles.charCount}>
-                  {name.length}/{MAX_NAME_LENGTH}
-                </div>
-              </div>
-
-              <div className={styles.friendCodeSection}>
-                <div className={styles.friendCodeLabel}>{t('friendCodeLabel')}</div>
-                <div className={styles.friendCode}>{friendCode}</div>
-              </div>
-
-              <div className={styles.buttons}>
-                <button className={styles.btnBack} onClick={goBack}>
-                  {t('back')}
-                </button>
-                <button
-                  className={styles.btnNext}
-                  onClick={goNext}
-                  disabled={!canProceed()}
-                >
-                  {t('next')}
-                </button>
-              </div>
-            </motion.div>
-          )}
-
-          {/* Step 3: Language Selection */}
-          {step === 'language' && (
-            <motion.div
-              key="language"
-              initial={{ opacity: 0, x: 40 }}
-              animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: -40 }}
-              transition={{ duration: 0.25 }}
-              style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%' }}
-            >
-              <div className={styles.title}>{t('langTitle')}</div>
-              <div className={styles.subtitle}>{t('langSubtitle')}</div>
-
-              <div className={styles.langSection}>
-                <div className={styles.langOptions}>
-                  <button
-                    className={`${styles.langOption} ${selectedLocale === 'ja' ? styles.langOptionSelected : ''}`}
-                    onClick={() => setSelectedLocale('ja')}
-                  >
-                    <span className={styles.langName}>日本語</span>
-                    <span className={styles.langSub}>Japanese</span>
-                  </button>
-                  <button
-                    className={`${styles.langOption} ${selectedLocale === 'en' ? styles.langOptionSelected : ''}`}
-                    onClick={() => setSelectedLocale('en')}
-                  >
-                    <span className={styles.langName}>English</span>
-                    <span className={styles.langSub}>英語</span>
-                  </button>
-                </div>
-              </div>
-
-              <div className={styles.buttons}>
-                <button className={styles.btnBack} onClick={goBack}>
-                  {t('back')}
-                </button>
-                <button className={styles.btnNext} onClick={goNext}>
-                  {t('next')}
-                </button>
-              </div>
-            </motion.div>
-          )}
-
-          {/* Step 4: Confirm */}
-          {step === 'confirm' && (
-            <motion.div
-              key="confirm"
-              initial={{ opacity: 0, x: 40 }}
-              animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: -40 }}
-              transition={{ duration: 0.25 }}
-              style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%' }}
-            >
-              <div className={styles.title}>{t('confirmTitle')}</div>
-              <div className={styles.subtitle}>{t('confirmSubtitle')}</div>
-
-              <div className={styles.previewCard}>
-                {selectedIconData && (
-                  <div
-                    className={styles.previewIcon}
-                    style={{
-                      backgroundColor: selectedIconData.bgColor,
-                      color: selectedIconData.color,
-                    }}
-                  >
-                    {selectedIconData.emoji}
-                  </div>
-                )}
-                <div className={styles.previewInfo}>
-                  <div className={styles.previewName}>{name}</div>
-                  <div className={styles.previewCode}>{friendCode}</div>
-                  <div className={styles.previewLang}>
-                    {selectedLocale === 'ja' ? '日本語' : 'English'}
-                  </div>
-                </div>
-              </div>
-
+          <div className={styles.langSection}>
+            <div className={styles.langOptions}>
               <button
-                className={`${styles.privacyToggle} ${isPrivate ? styles.privacyToggleActive : ''}`}
-                onClick={() => setIsPrivate(!isPrivate)}
-                type="button"
+                className={`${styles.langOption} ${selectedLocale === 'ja' ? styles.langOptionSelected : ''}`}
+                onClick={() => setSelectedLocale('ja')}
               >
-                <div className={styles.privacyIcon}>{isPrivate ? '🔒' : '🌐'}</div>
-                <div className={styles.privacyText}>
-                  <div className={styles.privacyLabel}>
-                    {t(isPrivate ? 'privateProfile' : 'publicProfile')}
-                  </div>
-                  <div className={styles.privacyDesc}>
-                    {t(isPrivate ? 'privateProfileDesc' : 'publicProfileDesc')}
-                  </div>
-                </div>
+                <span className={styles.langName}>日本語</span>
+                <span className={styles.langSub}>Japanese</span>
               </button>
+              <button
+                className={`${styles.langOption} ${selectedLocale === 'en' ? styles.langOptionSelected : ''}`}
+                onClick={() => setSelectedLocale('en')}
+              >
+                <span className={styles.langName}>English</span>
+                <span className={styles.langSub}>英語</span>
+              </button>
+            </div>
+          </div>
 
-              <div className={styles.buttons}>
-                <button className={styles.btnBack} onClick={goBack}>
-                  {t('back')}
-                </button>
-                <button className={styles.btnNext} onClick={handleComplete}>
-                  OK
-                </button>
+          <div className={styles.previewCard}>
+            {selectedIconData && (
+              <div
+                className={styles.previewIcon}
+                style={{
+                  backgroundColor: selectedIconData.bgColor,
+                  color: selectedIconData.color,
+                }}
+              >
+                {selectedIconData.emoji}
               </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
+            )}
+            <div className={styles.previewInfo}>
+              <div className={styles.previewName}>{defaultName}</div>
+              <div className={styles.previewCode}>{friendCode}</div>
+              <div className={styles.previewLang}>
+                {selectedLocale === 'ja' ? '日本語' : 'English'}
+              </div>
+            </div>
+          </div>
+
+          <div className={styles.buttons}>
+            <button className={styles.btnNext} onClick={handleComplete}>
+              OK
+            </button>
+          </div>
+        </motion.div>
       </div>
     </motion.div>
   );

--- a/src/lib/profile/storage.ts
+++ b/src/lib/profile/storage.ts
@@ -8,6 +8,11 @@ export function generateFriendCode(): string {
   return `SW-${seg()}-${seg()}-${seg()}`;
 }
 
+export function generateDefaultName(): string {
+  const id = String(Math.floor(Math.random() * 10000)).padStart(4, '0');
+  return `Player${id}`;
+}
+
 export function getStoredProfile(): UserProfile | null {
   if (typeof window === 'undefined') return null;
   try {


### PR DESCRIPTION
## Summary
Refactored the ProfileSetup component to remove the multi-step wizard flow and replace it with a simplified single-step interface that only allows language selection. Profile creation now uses auto-generated defaults for name and icon instead of user input.

## Key Changes
- **Removed multi-step wizard**: Eliminated the 4-step flow (icon selection → name input → language → confirmation) and replaced with a single language selection screen
- **Auto-generated profile data**: 
  - Icon is now fixed to `icon_rhythm` (DEFAULT_ICON constant)
  - Name is auto-generated using new `generateDefaultName()` function that creates names like "Player0001"
- **Simplified state management**: Removed step tracking, icon selection state, name input state, and privacy toggle state
- **Removed unused imports**: Eliminated `AnimatePresence`, `useCallback`, `PROFILE_ICONS`, and `MAX_NAME_LENGTH`
- **Removed privacy feature**: Eliminated the private/public profile toggle; all profiles are now public and always log to Discord
- **Cleaned up CSS**: Removed styles for step indicators, icon grid, name input, friend code display, privacy toggle, and back button

## Implementation Details
- The `generateDefaultName()` function generates random 4-digit player IDs (e.g., "Player0042")
- Language selection remains the only user choice in the setup flow
- Profile preview still displays the generated name, friend code, and selected language
- The component maintains the same visual structure with motion animations but with significantly reduced complexity

https://claude.ai/code/session_01XCsNjwYLykrxU5rxvGKPLU