### PR TITLE
Add GitHub tag deployment switcher to version menu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,3 +92,13 @@ DISCORD_SITE_ENTRY_WEBHOOK_URL='https://discord.com/api/webhooks/your_webhook_id
 # Homepage Widget Configuration
 # Title for the third widget (Modded server card)
 NEXT_PUBLIC_THIRD_WIDGET_TITLE='SNS links widgets'
+
+# GitHub Tag Switcher — Vercel Deployment Lookup
+# Option 1: Vercel API (recommended for accurate deployment URL resolution)
+VERCEL_TOKEN=''
+VERCEL_PROJECT_ID=''
+# Option 2: Predictable URL fallback (if Vercel API token is not available)
+VERCEL_PROJECT_NAME='azuretier-net'
+VERCEL_TEAM_SLUG='azuretier'
+# Optional: GitHub token to raise API rate limit (60/hr unauthenticated → 5000/hr)
+GITHUB_TOKEN=''

--- a/src/app/api/github-tags/route.ts
+++ b/src/app/api/github-tags/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from 'next/server';
+import type { DeploymentTag, TagsApiResponse } from '@/types/deployment';
+
+interface GitHubTagResponse {
+  name: string;
+  commit: { sha: string; url: string };
+}
+
+interface VercelDeployment {
+  url: string;
+  meta?: { githubCommitSha?: string };
+}
+
+interface CachedData {
+  data: TagsApiResponse;
+  timestamp: number;
+}
+
+let cache: CachedData | null = null;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+export async function GET() {
+  if (cache && Date.now() - cache.timestamp < CACHE_TTL_MS) {
+    return NextResponse.json(cache.data, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600',
+      },
+    });
+  }
+
+  try {
+    const ghHeaders: Record<string, string> = {
+      Accept: 'application/vnd.github.v3+json',
+      'User-Agent': 'azuretier.net',
+    };
+
+    const githubToken = process.env.GITHUB_TOKEN;
+    if (githubToken) {
+      ghHeaders.Authorization = `Bearer ${githubToken}`;
+    }
+
+    const ghRes = await fetch(
+      'https://api.github.com/repos/Azuretier/azuretier.net/tags?per_page=20',
+      { headers: ghHeaders, next: { revalidate: 300 } }
+    );
+
+    if (!ghRes.ok) {
+      return NextResponse.json(
+        { tags: [], currentSha: null } satisfies TagsApiResponse,
+        { status: 200 }
+      );
+    }
+
+    const ghTags: GitHubTagResponse[] = await ghRes.json();
+    const currentSha = process.env.VERCEL_GIT_COMMIT_SHA || null;
+
+    // Resolve deployment URLs
+    let deploymentMap: Map<string, string> | null = null;
+    const vercelToken = process.env.VERCEL_TOKEN;
+    const vercelProjectId = process.env.VERCEL_PROJECT_ID;
+
+    if (vercelToken && vercelProjectId) {
+      try {
+        const vRes = await fetch(
+          `https://api.vercel.com/v6/deployments?projectId=${vercelProjectId}&limit=100`,
+          { headers: { Authorization: `Bearer ${vercelToken}` } }
+        );
+        if (vRes.ok) {
+          const vData: { deployments: VercelDeployment[] } = await vRes.json();
+          deploymentMap = new Map();
+          for (const d of vData.deployments) {
+            if (d.meta?.githubCommitSha && d.url) {
+              deploymentMap.set(d.meta.githubCommitSha, `https://${d.url}`);
+            }
+          }
+        }
+      } catch {
+        // Vercel API failed, fall through to predictable URL
+      }
+    }
+
+    const tags: DeploymentTag[] = ghTags.map((tag) => {
+      let deploymentUrl: string | null = null;
+
+      if (deploymentMap) {
+        deploymentUrl = deploymentMap.get(tag.commit.sha) || null;
+      } else {
+        const projectName =
+          process.env.VERCEL_PROJECT_NAME || 'azuretier-net';
+        const teamSlug = process.env.VERCEL_TEAM_SLUG || 'azuretier';
+        const sanitizedTag = tag.name
+          .replace(/[/.@]/g, '-')
+          .toLowerCase();
+        deploymentUrl = `https://${projectName}-git-${sanitizedTag}-${teamSlug}.vercel.app`;
+      }
+
+      return {
+        name: tag.name,
+        sha: tag.commit.sha,
+        deploymentUrl,
+        isCurrent: currentSha ? tag.commit.sha === currentSha : false,
+      };
+    });
+
+    const responseData: TagsApiResponse = { tags, currentSha };
+    cache = { data: responseData, timestamp: Date.now() };
+
+    return NextResponse.json(responseData, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600',
+      },
+    });
+  } catch (error) {
+    console.error('[GITHUB_TAGS] Error:', error);
+    return NextResponse.json(
+      { tags: [], currentSha: null } satisfies TagsApiResponse,
+      { status: 200 }
+    );
+  }
+}

--- a/src/components/version/FloatingVersionSwitcher.tsx
+++ b/src/components/version/FloatingVersionSwitcher.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Settings, X, Check, Gamepad2, MessageCircle, Heart, Palette } from 'lucide-react';
+import { Settings, X, Check, Gamepad2, MessageCircle, Heart, Palette, Tag } from 'lucide-react';
+import { useGitHubTags } from '@/hooks/useGitHubTags';
 import { useVersion } from '@/lib/version/context';
 import {
   VERSION_METADATA,
@@ -22,6 +23,7 @@ const VERSION_ICONS: Record<UIVersion, React.ReactNode> = {
 export default function FloatingVersionSwitcher() {
   const { currentVersion, setVersion, accentColor, setAccentColor } = useVersion();
   const [isOpen, setIsOpen] = useState(false);
+  const { tags, isLoading: tagsLoading, error: tagsError } = useGitHubTags();
 
   const handleVersionChange = (version: UIVersion) => {
     if (version === currentVersion) return;
@@ -173,12 +175,85 @@ export default function FloatingVersionSwitcher() {
                       })}
                     </div>
                   </section>
+
+                  {/* ── Deployments Section ── */}
+                  <section>
+                    <div className="flex items-center gap-2 mb-3">
+                      <Tag size={14} className="text-white/40" />
+                      <h4 className="text-xs font-semibold uppercase tracking-wider text-white/40">
+                        Deployments
+                      </h4>
+                    </div>
+                    {tagsLoading ? (
+                      <div className="space-y-2">
+                        {[1, 2, 3].map((i) => (
+                          <div
+                            key={i}
+                            className="h-14 rounded-xl bg-white/[0.03] animate-pulse"
+                          />
+                        ))}
+                      </div>
+                    ) : tagsError ? (
+                      <p className="text-xs text-white/30">
+                        Failed to load deployments
+                      </p>
+                    ) : tags.length === 0 ? (
+                      <p className="text-xs text-white/30">
+                        No tagged deployments available
+                      </p>
+                    ) : (
+                      <div className="space-y-2 max-h-48 overflow-y-auto pr-1">
+                        {tags.map((tag) => (
+                          <button
+                            key={tag.name}
+                            disabled={!tag.deploymentUrl || tag.isCurrent}
+                            onClick={() => {
+                              if (tag.deploymentUrl) {
+                                window.location.href = tag.deploymentUrl;
+                              }
+                            }}
+                            className={`w-full flex items-center gap-3 px-4 py-3 rounded-xl border text-left transition-all ${
+                              tag.isCurrent
+                                ? 'bg-white/10 border-white/20'
+                                : tag.deploymentUrl
+                                  ? 'bg-white/[0.03] border-transparent hover:bg-white/[0.06] hover:border-white/10'
+                                  : 'bg-white/[0.03] border-transparent opacity-40 cursor-not-allowed'
+                            }`}
+                          >
+                            <div
+                              className={`flex-shrink-0 w-9 h-9 rounded-lg flex items-center justify-center ${
+                                tag.isCurrent
+                                  ? 'bg-white/15 text-white'
+                                  : 'bg-white/5 text-white/40'
+                              }`}
+                            >
+                              <Tag size={20} />
+                            </div>
+                            <div className="flex-1 min-w-0">
+                              <span className="text-sm font-semibold text-white truncate block">
+                                {tag.name}
+                              </span>
+                              <p className="text-xs text-white/40 font-mono truncate">
+                                {tag.sha.slice(0, 7)}
+                              </p>
+                            </div>
+                            {tag.isCurrent && (
+                              <Check
+                                size={16}
+                                className="flex-shrink-0 text-emerald-400"
+                              />
+                            )}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </section>
                 </div>
 
                 {/* Footer */}
                 <div className="px-6 py-3 border-t border-white/5">
                   <p className="text-[11px] text-white/25 text-center">
-                    Settings are saved locally in your browser.
+                    Settings are saved locally. Deployments link to past versions.
                   </p>
                 </div>
               </div>

--- a/src/hooks/useGitHubTags.ts
+++ b/src/hooks/useGitHubTags.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import type { DeploymentTag, TagsApiResponse } from '@/types/deployment';
+
+interface UseGitHubTagsReturn {
+  tags: DeploymentTag[];
+  currentSha: string | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useGitHubTags(): UseGitHubTagsReturn {
+  const [tags, setTags] = useState<DeploymentTag[]>([]);
+  const [currentSha, setCurrentSha] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchTags() {
+      try {
+        const res = await fetch('/api/github-tags');
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data: TagsApiResponse = await res.json();
+        if (!cancelled) {
+          setTags(data.tags);
+          setCurrentSha(data.currentSha);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : 'Failed to fetch tags'
+          );
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    fetchTags();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { tags, currentSha, isLoading, error };
+}

--- a/src/types/deployment.ts
+++ b/src/types/deployment.ts
@@ -1,0 +1,11 @@
+export interface DeploymentTag {
+  name: string;
+  sha: string;
+  deploymentUrl: string | null;
+  isCurrent: boolean;
+}
+
+export interface TagsApiResponse {
+  tags: DeploymentTag[];
+  currentSha: string | null;
+}


### PR DESCRIPTION
## Summary
This PR adds a deployment switcher feature that allows users to navigate to previous tagged versions of the application deployed on Vercel. The switcher is integrated into the existing floating version menu and displays available GitHub tags with their corresponding deployment URLs.

## Key Changes

- **New API Route** (`src/app/api/github-tags/route.ts`): 
  - Fetches GitHub tags from the repository via GitHub API
  - Resolves deployment URLs by querying Vercel API for commit-to-deployment mappings
  - Falls back to predictable Vercel URL generation if API token unavailable
  - Implements 5-minute in-memory caching with HTTP cache headers for performance
  - Gracefully handles API failures with fallback responses

- **New Hook** (`src/hooks/useGitHubTags.ts`):
  - Client-side hook to fetch and manage GitHub tags data
  - Handles loading and error states
  - Includes cleanup to prevent state updates on unmounted components

- **Updated Version Switcher** (`src/components/version/FloatingVersionSwitcher.tsx`):
  - Integrated new "Deployments" section into the settings menu
  - Displays tags with commit SHA, deployment status, and clickable links
  - Shows loading skeleton, error state, and empty state appropriately
  - Highlights current deployment with checkmark indicator
  - Updated footer text to reflect new functionality

- **New Type Definitions** (`src/types/deployment.ts`):
  - `DeploymentTag`: Represents a tagged deployment with metadata
  - `TagsApiResponse`: API response structure

- **Environment Configuration** (`.env.example`):
  - Added documentation for Vercel API credentials (recommended approach)
  - Added fallback configuration for predictable URL generation
  - Added optional GitHub token for increased API rate limits

## Implementation Details

- The API route supports two deployment URL resolution strategies:
  1. **Vercel API lookup** (preferred): Accurate URLs from actual deployments
  2. **Predictable URL generation** (fallback): Constructs URLs from tag names when API unavailable
- Tag names are sanitized for URL compatibility (replacing `/`, `.`, `@` with `-`)
- The current deployment is identified via `VERCEL_GIT_COMMIT_SHA` environment variable
- Deployment buttons are disabled for the current version and when URLs cannot be resolved
- All API calls include proper error handling and graceful degradation

https://claude.ai/code/session_01RMkFgtAGjD6vNe1VVRZce1