### PR TITLE
Add version selector screen and refactor icon management

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -6,9 +6,19 @@ import V1_0_0_UI from '@/components/home/v1.0.0/V1_0_0_UI';
 import V1_0_1_UI from '@/components/home/v1.0.1/V1_0_1_UI';
 import V1_0_2_UI from '@/components/home/v1.0.2/V1_0_2_UI';
 import FloatingVersionSwitcher from '@/components/version/FloatingVersionSwitcher';
+import VersionSelector from '@/components/version/VersionSelector';
+import type { UIVersion } from '@/lib/version/types';
 
 export default function HomePage() {
-    const { currentVersion } = useVersion();
+    const { currentVersion, isVersionSelected, setVersion } = useVersion();
+
+    const handleVersionSelect = (version: UIVersion) => {
+        setVersion(version);
+    };
+
+    if (!isVersionSelected) {
+        return <VersionSelector onSelect={handleVersionSelect} />;
+    }
 
     const renderPage = () => {
         switch (currentVersion) {

--- a/src/components/version/VersionSelector.tsx
+++ b/src/components/version/VersionSelector.tsx
@@ -2,24 +2,20 @@
 
 import { motion, AnimatePresence } from "framer-motion";
 import { UIVersion, VERSION_METADATA, UI_VERSIONS } from "@/lib/version/types";
-import { MessageCircle, Heart, Gamepad2 } from "lucide-react";
+import { MessageCircle, Heart, Gamepad2, Box } from "lucide-react";
 
 interface VersionSelectorProps {
   onSelect: (version: UIVersion) => void;
 }
 
-export default function VersionSelector({ onSelect }: VersionSelectorProps) {
-  const getIcon = (version: UIVersion) => {
-    switch (version) {
-      case "1.0.0":
-        return <MessageCircle className="w-12 h-12" />;
-      case "1.0.1":
-        return <Heart className="w-12 h-12" />;
-      case "1.0.2":
-        return <Gamepad2 className="w-12 h-12" />;
-    }
-  };
+const VERSION_ICONS: Record<UIVersion, React.ReactNode> = {
+  current: <Gamepad2 className="w-12 h-12" />,
+  "1.0.0": <MessageCircle className="w-12 h-12" />,
+  "1.0.1": <Heart className="w-12 h-12" />,
+  "1.0.2": <Box className="w-12 h-12" />,
+};
 
+export default function VersionSelector({ onSelect }: VersionSelectorProps) {
   return (
     <AnimatePresence>
       <motion.div
@@ -59,7 +55,7 @@ export default function VersionSelector({ onSelect }: VersionSelectorProps) {
               later.
             </motion.p>
 
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
               {UI_VERSIONS.map((version, index) => {
                 const metadata = VERSION_METADATA[version];
                 return (
@@ -83,7 +79,7 @@ export default function VersionSelector({ onSelect }: VersionSelectorProps) {
                         transition={{ duration: 0.5 }}
                         className="p-4 bg-gradient-to-br from-blue-500/20 to-purple-500/20 rounded-full text-blue-400 group-hover:text-blue-300 transition-colors"
                       >
-                        {getIcon(version)}
+                        {VERSION_ICONS[version]}
                       </motion.div>
 
                       {/* Title */}
@@ -93,7 +89,7 @@ export default function VersionSelector({ onSelect }: VersionSelectorProps) {
 
                       {/* Version */}
                       <span className="text-sm text-gray-500 font-mono">
-                        v{metadata.id}
+                        {version === "current" ? "latest" : `v${metadata.id}`}
                       </span>
 
                       {/* Description */}


### PR DESCRIPTION
## Summary
This PR enhances the version selection experience by introducing a dedicated version selector screen that displays before the main UI, and refactors the icon management system for better maintainability.

## Key Changes
- **Added version selector screen**: Users now see the `VersionSelector` component on initial page load if no version has been selected yet
- **Refactored icon management**: Converted the `getIcon()` function to a static `VERSION_ICONS` record for better performance and maintainability
- **Added "current" version support**: Introduced a new "current" version type with Gamepad2 icon, displayed as "latest" in the UI
- **Updated grid layout**: Changed version selector grid from `md:grid-cols-3` to `sm:grid-cols-2 lg:grid-cols-4` to accommodate the new "current" version option
- **Enhanced version label display**: Version labels now show "latest" for the current version and "v{id}" for historical versions
- **Integrated version context**: Updated `HomePage` to use `isVersionSelected` and `setVersion` from the version context hook

## Implementation Details
- The `VERSION_ICONS` record is now a module-level constant, eliminating the need for a switch statement on every render
- Added the `Box` icon import from lucide-react for the 1.0.2 version
- The version selector now acts as a gating component, preventing access to the main UI until a version is explicitly selected
- Version display logic now differentiates between "current" (latest) and versioned releases

https://claude.ai/code/session_01Mqf9eB7Q9gDzxM4Vfb6qfn