### PR TITLE
Add power-up system, emotes, and targeting mechanics to Arena

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -602,7 +602,10 @@
         "peakChaos": "PEAK CHAOS",
         "tempoCollapses": "COLLAPSES",
         "lowestBpm": "LOW BPM",
-        "backToLobby": "Back to Lobby"
+        "backToLobby": "Back to Lobby",
+        "usePowerUp": "Power-Up",
+        "cycleTarget": "Target",
+        "emote": "Emote"
     },
     "footer": {
         "copyright": "azuretier.net © 2025"

--- a/messages/es.json
+++ b/messages/es.json
@@ -402,7 +402,10 @@
         "peakChaos": "CAOS MÁXIMO",
         "tempoCollapses": "COLAPSOS",
         "lowestBpm": "BPM MÍNIMO",
-        "backToLobby": "Volver al Lobby"
+        "backToLobby": "Volver al Lobby",
+        "usePowerUp": "Power-Up",
+        "cycleTarget": "Objetivo",
+        "emote": "Emote"
     },
     "footer": {
         "copyright": "azuretier.net © 2025"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -402,7 +402,10 @@
         "peakChaos": "CHAOS MAX",
         "tempoCollapses": "EFFONDREMENTS",
         "lowestBpm": "BPM MIN",
-        "backToLobby": "Retour au Lobby"
+        "backToLobby": "Retour au Lobby",
+        "usePowerUp": "Power-Up",
+        "cycleTarget": "Cible",
+        "emote": "Emote"
     },
     "footer": {
         "copyright": "azuretier.net © 2025"

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -602,7 +602,10 @@
         "peakChaos": "最大カオス",
         "tempoCollapses": "崩壊回数",
         "lowestBpm": "最低BPM",
-        "backToLobby": "ロビーに戻る"
+        "backToLobby": "ロビーに戻る",
+        "usePowerUp": "パワーアップ",
+        "cycleTarget": "ターゲット",
+        "emote": "エモート"
     },
     "footer": {
         "copyright": "azuretier.net © 2025"

--- a/messages/th.json
+++ b/messages/th.json
@@ -402,7 +402,10 @@
         "peakChaos": "โกลาหลสูงสุด",
         "tempoCollapses": "จังหวะพัง",
         "lowestBpm": "BPM ต่ำสุด",
-        "backToLobby": "กลับล็อบบี้"
+        "backToLobby": "กลับล็อบบี้",
+        "usePowerUp": "พาวเวอร์อัพ",
+        "cycleTarget": "เป้าหมาย",
+        "emote": "อิโมท"
     },
     "footer": {
         "copyright": "azuretier.net © 2025"

--- a/multiplayer-server.ts
+++ b/multiplayer-server.ts
@@ -15,6 +15,8 @@ import type {
   ArenaClientMessage,
   ArenaAction,
   ArenaBoardPayload,
+  EmoteType,
+  TargetMode,
 } from './src/types/arena';
 import {
   ARENA_MAX_PLAYERS,
@@ -296,7 +298,7 @@ function clearArenaTimer(playerId: string): void {
 }
 
 function isArenaMessage(type: string): boolean {
-  return type.startsWith('arena_') || type === 'create_arena' || type === 'join_arena' || type === 'queue_arena' || type === 'cancel_arena_queue';
+  return type.startsWith('arena_') || type === 'create_arena' || type === 'join_arena' || type === 'queue_arena' || type === 'cancel_arena_queue' || type === 'arena_use_powerup' || type === 'arena_emote' || type === 'arena_set_target';
 }
 
 function isMCBoardMessage(type: string): boolean {
@@ -1047,6 +1049,24 @@ function handleMessage(playerId: string, raw: string): void {
     case 'arena_relay': {
       const relayMsg = message as unknown as { payload: ArenaBoardPayload };
       arenaManager.handleRelay(playerId, relayMsg.payload);
+      break;
+    }
+
+    case 'arena_use_powerup': {
+      const pupMsg = message as unknown as { targetId?: string };
+      arenaManager.handleUsePowerUp(playerId, pupMsg.targetId);
+      break;
+    }
+
+    case 'arena_emote': {
+      const emoteMsg = message as unknown as { emote: EmoteType };
+      arenaManager.handleEmote(playerId, emoteMsg.emote);
+      break;
+    }
+
+    case 'arena_set_target': {
+      const targetMsg = message as unknown as { targetMode: TargetMode; targetId?: string };
+      arenaManager.handleSetTarget(playerId, targetMsg.targetMode, targetMsg.targetId);
       break;
     }
 

--- a/src/components/arena/ArenaGame.module.css
+++ b/src/components/arena/ArenaGame.module.css
@@ -881,3 +881,311 @@
   letter-spacing: 0.3em;
   text-shadow: 0 0 20px rgba(255, 51, 102, 0.3);
 }
+
+/* ===== Power-Up HUD ===== */
+.powerUpHud {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.powerUpSlot {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  cursor: default;
+  transition: all 0.3s;
+  min-width: 80px;
+  justify-content: center;
+}
+
+.powerUpSlot.hasPowerUp {
+  cursor: pointer;
+  border-color: rgba(0, 255, 204, 0.3);
+  background: rgba(0, 255, 204, 0.04);
+  animation: powerUpGlow 2s ease-in-out infinite;
+}
+
+.powerUpSlot.hasPowerUp:hover {
+  border-color: var(--arena-accent);
+  background: rgba(0, 255, 204, 0.08);
+  transform: scale(1.05);
+}
+
+@keyframes powerUpGlow {
+  0%, 100% { box-shadow: 0 0 0 rgba(0, 255, 204, 0); }
+  50% { box-shadow: 0 0 12px rgba(0, 255, 204, 0.15); }
+}
+
+.powerUpIcon {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.powerUpLabel {
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  color: var(--arena-accent);
+}
+
+.powerUpKey {
+  font-size: 0.5rem;
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.powerUpEmpty {
+  font-size: 0.6rem;
+  color: rgba(255, 255, 255, 0.15);
+  letter-spacing: 0.15em;
+}
+
+.activeEffects {
+  display: flex;
+  gap: 4px;
+}
+
+.activeEffect {
+  padding: 2px 8px;
+  border: 1px solid;
+  border-radius: 4px;
+  font-size: 0.5rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  animation: effectPulse 1s ease-in-out infinite;
+}
+
+@keyframes effectPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+/* ===== Event Feed ===== */
+.eventFeed {
+  position: fixed;
+  bottom: 60px;
+  left: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  z-index: 30;
+  pointer-events: none;
+  max-width: 280px;
+}
+
+.feedItem {
+  font-size: 0.6rem;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  padding: 3px 8px;
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 4px;
+  animation: feedSlideIn 0.3s ease-out;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@keyframes feedSlideIn {
+  from { opacity: 0; transform: translateX(-20px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+/* ===== Target Selector ===== */
+.targetSelector {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.targetLabel {
+  font-size: 0.5rem;
+  color: rgba(255, 255, 255, 0.3);
+  letter-spacing: 0.2em;
+}
+
+.targetModes {
+  display: flex;
+  gap: 3px;
+}
+
+.targetModeBtn {
+  padding: 3px 6px;
+  font-size: 0.5rem;
+  font-weight: 600;
+  font-family: inherit;
+  letter-spacing: 0.05em;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.4);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.targetModeBtn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.targetModeBtn.targetModeActive {
+  background: rgba(255, 51, 102, 0.1);
+  border-color: rgba(255, 51, 102, 0.3);
+  color: var(--arena-danger);
+}
+
+.targetPlayers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+  justify-content: center;
+  max-width: 80px;
+}
+
+.targetPlayerBtn {
+  padding: 2px 4px;
+  font-size: 0.45rem;
+  font-family: inherit;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 2px;
+  color: rgba(255, 255, 255, 0.3);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.targetPlayerBtn:hover {
+  background: rgba(255, 51, 102, 0.08);
+  border-color: rgba(255, 51, 102, 0.2);
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.targetPlayerBtn.targetPlayerActive {
+  background: rgba(255, 51, 102, 0.15);
+  border-color: var(--arena-danger);
+  color: var(--arena-danger);
+}
+
+/* Opponent targeted highlight */
+.opponentMini.targeted {
+  border-color: var(--arena-danger);
+  box-shadow: 0 0 8px rgba(255, 51, 102, 0.15);
+}
+
+.targetBadge {
+  font-size: 0.4rem;
+  padding: 1px 3px;
+  background: rgba(255, 51, 102, 0.15);
+  color: var(--arena-danger);
+  border-radius: 2px;
+  font-weight: 700;
+  margin-left: 3px;
+  letter-spacing: 0.05em;
+}
+
+.opponentBoardWrap {
+  position: relative;
+}
+
+/* ===== Emote System ===== */
+.emoteBar {
+  display: flex;
+  gap: 4px;
+  margin-top: 10px;
+}
+
+.emoteBtn {
+  padding: 4px 6px;
+  font-size: 0.55rem;
+  font-weight: 700;
+  font-family: inherit;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  color: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.emoteBtn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  transform: scale(1.1);
+}
+
+.emoteBubble {
+  position: absolute;
+  top: -14px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 2px 6px;
+  background: rgba(255, 255, 255, 0.9);
+  color: #000000;
+  border-radius: 4px;
+  font-size: 0.5rem;
+  font-weight: 700;
+  white-space: nowrap;
+  z-index: 20;
+  animation: emotePop 0.3s ease-out, emoteFade 3s ease-in forwards;
+  pointer-events: none;
+}
+
+@keyframes emotePop {
+  from { transform: translateX(-50%) scale(0.5); opacity: 0; }
+  to { transform: translateX(-50%) scale(1); opacity: 1; }
+}
+
+@keyframes emoteFade {
+  0%, 70% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+/* ===== Keyboard Hints ===== */
+.keyHints {
+  position: fixed;
+  bottom: 8px;
+  right: 12px;
+  display: flex;
+  gap: 12px;
+  font-size: 0.5rem;
+  color: rgba(255, 255, 255, 0.15);
+  letter-spacing: 0.05em;
+  z-index: 5;
+}
+
+/* ===== Responsive updates for new features ===== */
+@media (max-width: 640px) {
+  .powerUpHud {
+    gap: 4px;
+  }
+
+  .powerUpSlot {
+    min-width: 60px;
+    padding: 3px 6px;
+  }
+
+  .eventFeed {
+    max-width: 200px;
+    bottom: 40px;
+  }
+
+  .targetSelector {
+    margin-top: 8px;
+  }
+
+  .emoteBar {
+    margin-top: 6px;
+  }
+
+  .keyHints {
+    display: none;
+  }
+}

--- a/src/components/arena/ArenaGame.tsx
+++ b/src/components/arena/ArenaGame.tsx
@@ -421,6 +421,10 @@ export default function ArenaGame() {
   const holdPieceRef = useRef(holdPiece);
   holdPieceRef.current = holdPiece;
 
+  // Stable ref for activeEffects to check score_boost in handlePieceLock
+  const activeEffectsRef = useRef(activeEffects);
+  activeEffectsRef.current = activeEffects;
+
   const handlePieceLock = useCallback((piece: Piece, dropDistance = 0) => {
     lockStartTimeRef.current = null;
     lockMovesRef.current = 0;
@@ -465,7 +469,12 @@ export default function ArenaGame() {
 
     // Score calculation
     const base = dropDistance * 2 + [0, 100, 300, 500, 800][cleared] * levelRef.current;
-    const finalScore = base * mult * Math.max(1, comboRef.current);
+    // Apply 2x multiplier if score_boost power-up is active
+    const hasScoreBoost = activeEffectsRef.current.some(
+      e => e.type === 'score_boost' && e.expiresAt > Date.now()
+    );
+    const boostMultiplier = hasScoreBoost ? 2 : 1;
+    const finalScore = base * mult * Math.max(1, comboRef.current) * boostMultiplier;
     setScore(prev => prev + finalScore);
 
     setLines(prev => {

--- a/src/components/arena/ArenaGame.tsx
+++ b/src/components/arena/ArenaGame.tsx
@@ -3,8 +3,9 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useArenaSocket } from '@/hooks/useArenaSocket';
 import { useTranslations } from 'next-intl';
-import type { ArenaBoardPayload } from '@/types/arena';
-import { ARENA_MAX_PLAYERS } from '@/types/arena';
+import type { ArenaBoardPayload, ArenaFeedEvent, EmoteType, TargetMode } from '@/types/arena';
+import { ARENA_MAX_PLAYERS, POWERUP_DEFS, EMOTE_DEFS } from '@/types/arena';
+import type { PowerUpType } from '@/types/arena';
 
 // Tetris engine
 import { useGameState } from '@/components/rhythmia/tetris/hooks';
@@ -73,6 +74,147 @@ function PiecePreview({ pieceType }: { pieceType: string | null }) {
   );
 }
 
+// Event feed overlay
+function EventFeed({ events }: { events: ArenaFeedEvent[] }) {
+  if (events.length === 0) return null;
+  return (
+    <div className={styles.eventFeed}>
+      {events.map((ev) => (
+        <div
+          key={ev.id}
+          className={styles.feedItem}
+          style={{ color: ev.color }}
+        >
+          {ev.text}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Power-up indicator (shows held power-up + active effects)
+function PowerUpHUD({
+  heldPowerUp,
+  activeEffects,
+  onUse,
+}: {
+  heldPowerUp: PowerUpType | null;
+  activeEffects: { type: PowerUpType; expiresAt: number }[];
+  onUse: () => void;
+}) {
+  return (
+    <div className={styles.powerUpHud}>
+      <div
+        className={`${styles.powerUpSlot} ${heldPowerUp ? styles.hasPowerUp : ''}`}
+        onClick={heldPowerUp ? onUse : undefined}
+        title={heldPowerUp ? `Press E to use ${POWERUP_DEFS[heldPowerUp].label}` : 'No power-up'}
+      >
+        {heldPowerUp ? (
+          <>
+            <div
+              className={styles.powerUpIcon}
+              style={{ background: POWERUP_DEFS[heldPowerUp].color }}
+            />
+            <span className={styles.powerUpLabel}>{POWERUP_DEFS[heldPowerUp].label}</span>
+            <span className={styles.powerUpKey}>[E]</span>
+          </>
+        ) : (
+          <span className={styles.powerUpEmpty}>--</span>
+        )}
+      </div>
+      {activeEffects.length > 0 && (
+        <div className={styles.activeEffects}>
+          {activeEffects.map((eff, i) => (
+            <div
+              key={`${eff.type}-${i}`}
+              className={styles.activeEffect}
+              style={{ borderColor: POWERUP_DEFS[eff.type].color, color: POWERUP_DEFS[eff.type].color }}
+            >
+              {POWERUP_DEFS[eff.type].label}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Emote bubble overlay on mini board
+function EmoteBubble({ emote }: { emote: EmoteType }) {
+  return (
+    <div className={styles.emoteBubble}>
+      {EMOTE_DEFS[emote].emoji}
+    </div>
+  );
+}
+
+// Target mode selector
+function TargetSelector({
+  currentMode,
+  opponents,
+  manualTargetId,
+  onSelectMode,
+}: {
+  currentMode: TargetMode;
+  opponents: { id: string; name: string; alive: boolean }[];
+  manualTargetId: string | null;
+  onSelectMode: (mode: TargetMode, targetId?: string) => void;
+}) {
+  const modes: { mode: TargetMode; label: string }[] = [
+    { mode: 'random', label: 'RNG' },
+    { mode: 'ko_leader', label: 'KOs' },
+    { mode: 'nearest', label: 'NEAR' },
+  ];
+
+  return (
+    <div className={styles.targetSelector}>
+      <div className={styles.targetLabel}>TARGET</div>
+      <div className={styles.targetModes}>
+        {modes.map(({ mode, label }) => (
+          <button
+            key={mode}
+            className={`${styles.targetModeBtn} ${currentMode === mode ? styles.targetModeActive : ''}`}
+            onClick={() => onSelectMode(mode)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      <div className={styles.targetPlayers}>
+        {opponents.filter(o => o.alive).map(opp => (
+          <button
+            key={opp.id}
+            className={`${styles.targetPlayerBtn} ${currentMode === 'manual' && manualTargetId === opp.id ? styles.targetPlayerActive : ''}`}
+            onClick={() => onSelectMode('manual', opp.id)}
+            title={opp.name}
+          >
+            {opp.name.slice(0, 4)}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Emote bar
+function EmoteBar({ onSendEmote }: { onSendEmote: (emote: EmoteType) => void }) {
+  const emotes: EmoteType[] = ['gg', 'nice', 'rip', 'hype'];
+  return (
+    <div className={styles.emoteBar}>
+      {emotes.map((emote, i) => (
+        <button
+          key={emote}
+          className={styles.emoteBtn}
+          onClick={() => onSendEmote(emote)}
+          title={`Press ${i + 1}`}
+        >
+          {EMOTE_DEFS[emote].emoji}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 export default function ArenaGame() {
   const t = useTranslations('arena');
 
@@ -109,6 +251,15 @@ export default function ArenaGame() {
     sendAction,
     sendBoardRelay,
     leaveArena,
+    heldPowerUp,
+    activeEffects,
+    usePowerUp,
+    feedEvents,
+    emoteMap,
+    sendEmote,
+    targetMode,
+    manualTargetId,
+    setTargetMode,
   } = useArenaSocket();
 
   // ===== Tetris Game State =====
@@ -554,6 +705,37 @@ export default function ArenaGame() {
           e.preventDefault();
           hardDrop();
           break;
+        case 'e':
+        case 'E':
+          e.preventDefault();
+          usePowerUp();
+          break;
+        case '1':
+          e.preventDefault();
+          sendEmote('gg');
+          break;
+        case '2':
+          e.preventDefault();
+          sendEmote('nice');
+          break;
+        case '3':
+          e.preventDefault();
+          sendEmote('rip');
+          break;
+        case '4':
+          e.preventDefault();
+          sendEmote('hype');
+          break;
+        case 'Tab':
+          e.preventDefault();
+          // Cycle target mode
+          {
+            const modes: TargetMode[] = ['random', 'ko_leader', 'nearest'];
+            const currentIdx = modes.indexOf(targetMode);
+            const nextMode = modes[(currentIdx + 1) % modes.length];
+            setTargetMode(nextMode);
+          }
+          break;
       }
     };
 
@@ -578,7 +760,7 @@ export default function ArenaGame() {
       window.removeEventListener('keyup', handleKeyUp);
     };
   }, [phase, isPlaying, gameOver, moveHorizontal, movePiece, rotatePiece,
-    hardDrop, holdCurrentPiece, setScore, keyStatesRef]);
+    hardDrop, holdCurrentPiece, setScore, keyStatesRef, usePowerUp, sendEmote, targetMode, setTargetMode]);
 
   // ===== Game Over → Notify Arena Server =====
   useEffect(() => {
@@ -914,6 +1096,12 @@ export default function ArenaGame() {
               <span>LV <span className={styles.arenaStatValue}>{level}</span></span>
             </div>
 
+            <PowerUpHUD
+              heldPowerUp={heldPowerUp}
+              activeEffects={activeEffects}
+              onUse={() => usePowerUp()}
+            />
+
             <div className={styles.tempoDisplay}>
               <div className={`${styles.beatIndicator} ${onBeat ? styles.onBeat : ''}`} />
               <div className={styles.bpmValue}>{Math.round(bpm)}</div>
@@ -953,10 +1141,17 @@ export default function ArenaGame() {
                 )}
               </div>
 
-              {/* Next piece */}
+              {/* Next piece + controls */}
               <div className={styles.arenaSidePanel}>
                 <div className={styles.arenaSidePanelLabel}>NEXT</div>
                 <PiecePreview pieceType={nextPiece || null} />
+                <TargetSelector
+                  currentMode={targetMode}
+                  opponents={opponents.map(o => ({ id: o.id, name: o.name, alive: o.alive }))}
+                  manualTargetId={manualTargetId}
+                  onSelectMode={setTargetMode}
+                />
+                <EmoteBar onSendEmote={sendEmote} />
               </div>
             </div>
 
@@ -965,29 +1160,41 @@ export default function ArenaGame() {
               {opponents.map((opp) => {
                 const oppBoard = opponentBoards.get(opp.id);
                 const oppSync = syncMap[opp.id] ?? 1.0;
+                const oppEmote = emoteMap.get(opp.id);
+                const isTargeted = (targetMode === 'manual' && manualTargetId === opp.id);
 
                 return (
                   <div
                     key={opp.id}
-                    className={`${styles.opponentMini} ${!opp.alive ? styles.eliminated : ''}`}
+                    className={`${styles.opponentMini} ${!opp.alive ? styles.eliminated : ''} ${isTargeted ? styles.targeted : ''}`}
+                    onClick={() => opp.alive && setTargetMode('manual', opp.id)}
                   >
-                    <div className={styles.opponentName}>{opp.name}</div>
-                    {oppBoard?.board ? (
-                      <MiniBoardView board={oppBoard.board} />
-                    ) : (
-                      <div className={styles.opponentMiniBoard}>
-                        {Array.from({ length: 10 }).map((_, ri) => (
-                          <div key={ri} className={styles.miniRow}>
-                            {Array.from({ length: 10 }).map((__, ci) => (
-                              <div key={ci} className={styles.miniCell} />
-                            ))}
-                          </div>
-                        ))}
-                      </div>
-                    )}
+                    <div className={styles.opponentName}>
+                      {opp.name}
+                      {isTargeted && <span className={styles.targetBadge}>TGT</span>}
+                    </div>
+                    <div className={styles.opponentBoardWrap}>
+                      {oppEmote && oppEmote.expiresAt > Date.now() && (
+                        <EmoteBubble emote={oppEmote.emote} />
+                      )}
+                      {oppBoard?.board ? (
+                        <MiniBoardView board={oppBoard.board} />
+                      ) : (
+                        <div className={styles.opponentMiniBoard}>
+                          {Array.from({ length: 10 }).map((_, ri) => (
+                            <div key={ri} className={styles.miniRow}>
+                              {Array.from({ length: 10 }).map((__, ci) => (
+                                <div key={ci} className={styles.miniCell} />
+                              ))}
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
                     <div className={styles.opponentStats}>
                       <span>{oppBoard?.score ?? 0}</span>
                       <span>{oppBoard?.lines ?? 0}L</span>
+                      <span>{opp.kills}KO</span>
                     </div>
                     <div className={styles.opponentSync}>
                       <div
@@ -1001,6 +1208,9 @@ export default function ArenaGame() {
             </div>
           </div>
 
+          {/* Event Feed */}
+          <EventFeed events={feedEvents} />
+
           {/* Overlays */}
           {showCollapse && <div className={styles.tempoCollapseOverlay} />}
           {showElimBanner && lastElimination && (
@@ -1008,6 +1218,13 @@ export default function ArenaGame() {
               {lastElimination.playerName} {t('eliminated')} #{lastElimination.placement}
             </div>
           )}
+
+          {/* Keyboard hints */}
+          <div className={styles.keyHints}>
+            <span>[E] {t('usePowerUp')}</span>
+            <span>[Tab] {t('cycleTarget')}</span>
+            <span>[1-4] {t('emote')}</span>
+          </div>
         </div>
       )}
 
@@ -1039,6 +1256,7 @@ export default function ArenaGame() {
                 <div className={styles.rankingName}>{r.playerName}</div>
                 <div className={styles.rankingStat}>{r.score} pts</div>
                 <div className={styles.rankingStat}>{r.kills} KO</div>
+                <div className={styles.rankingStat}>{r.powerUpsUsed} PWR</div>
                 <div className={styles.rankingStat}>{Math.round(r.avgSync * 100)}%</div>
               </div>
             ))}

--- a/src/hooks/useArenaSocket.ts
+++ b/src/hooks/useArenaSocket.ts
@@ -414,6 +414,22 @@ export function useArenaSocket() {
     };
   }, []);
 
+  // Clean up expired active effects periodically
+  useEffect(() => {
+    const effectCleanupTimer = setInterval(() => {
+      setActiveEffects(prev => {
+        const now = Date.now();
+        const filtered = prev.filter(e => e.expiresAt > now);
+        // Only update state if something was actually removed
+        return filtered.length === prev.length ? prev : filtered;
+      });
+    }, 500);
+
+    return () => {
+      clearInterval(effectCleanupTimer);
+    };
+  }, []);
+
   // ===== Actions =====
 
   const queueForArena = useCallback((playerName: string) => {

--- a/src/hooks/useArenaSocket.ts
+++ b/src/hooks/useArenaSocket.ts
@@ -8,6 +8,10 @@ import type {
   ArenaRanking,
   ArenaSessionStats,
   ArenaBoardPayload,
+  ArenaFeedEvent,
+  PowerUpType,
+  EmoteType,
+  TargetMode,
 } from '@/types/arena';
 
 type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
@@ -91,6 +95,22 @@ export function useArenaSocket() {
   // Opponent boards (relayed)
   const opponentBoardsRef = useRef<Map<string, ArenaBoardPayload>>(new Map());
   const [opponentBoards, setOpponentBoards] = useState<Map<string, ArenaBoardPayload>>(new Map());
+
+  // Power-up state
+  const [heldPowerUp, setHeldPowerUp] = useState<PowerUpType | null>(null);
+  const [activeEffects, setActiveEffects] = useState<{ type: PowerUpType; expiresAt: number }[]>([]);
+  const [lastPowerUpUsed, setLastPowerUpUsed] = useState<{ playerId: string; playerName: string; powerUp: PowerUpType; targetName?: string } | null>(null);
+
+  // Event feed
+  const [feedEvents, setFeedEvents] = useState<ArenaFeedEvent[]>([]);
+
+  // Emotes
+  const [lastEmote, setLastEmote] = useState<{ playerId: string; playerName: string; emote: EmoteType } | null>(null);
+  const [emoteMap, setEmoteMap] = useState<Map<string, { emote: EmoteType; expiresAt: number }>>(new Map());
+
+  // Target state
+  const [targetMode, setTargetModeState] = useState<TargetMode>('random');
+  const [manualTargetId, setManualTargetIdState] = useState<string | null>(null);
 
   // ===== WebSocket Connection =====
   const connectWebSocketRef = useRef<() => void>(() => {});
@@ -263,6 +283,54 @@ export function useArenaSocket() {
         setLastTempoCollapse(msg as TempoCollapseEvent);
         break;
       }
+
+      case 'arena_powerup_spawned': {
+        setHeldPowerUp(msg.powerUp as PowerUpType);
+        break;
+      }
+
+      case 'arena_powerup_used': {
+        setLastPowerUpUsed({
+          playerId: msg.playerId,
+          playerName: msg.playerName,
+          powerUp: msg.powerUp as PowerUpType,
+          targetName: msg.targetName,
+        });
+        // If it was us who used it, clear held power-up
+        if (msg.playerId === playerIdRef.current) {
+          setHeldPowerUp(null);
+          // Apply self-effects
+          if (msg.powerUp === 'shield' || msg.powerUp === 'score_boost') {
+            setActiveEffects(prev => [...prev, { type: msg.powerUp as PowerUpType, expiresAt: Date.now() + (msg.powerUp === 'shield' ? 5000 : 6000) }]);
+          }
+        }
+        // If we are the target of freeze
+        if (msg.powerUp === 'freeze_target' && msg.targetId === playerIdRef.current) {
+          setActiveEffects(prev => [...prev, { type: 'freeze_target' as PowerUpType, expiresAt: Date.now() + 3000 }]);
+        }
+        break;
+      }
+
+      case 'arena_emote_sent': {
+        const emoteData = { playerId: msg.playerId, playerName: msg.playerName, emote: msg.emote as EmoteType };
+        setLastEmote(emoteData);
+        setEmoteMap(prev => {
+          const next = new Map(prev);
+          next.set(msg.playerId, { emote: msg.emote as EmoteType, expiresAt: Date.now() + 3000 });
+          return next;
+        });
+        break;
+      }
+
+      case 'arena_event_feed': {
+        const feedEvent = msg.event as ArenaFeedEvent;
+        setFeedEvents(prev => {
+          const next = [...prev, feedEvent];
+          // Keep only last 8 events
+          return next.length > 8 ? next.slice(-8) : next;
+        });
+        break;
+      }
     }
   }, [send]);
 
@@ -382,6 +450,26 @@ export function useArenaSocket() {
     send({ type: 'arena_relay', payload });
   }, [send]);
 
+  const usePowerUp = useCallback((targetId?: string) => {
+    send({ type: 'arena_use_powerup', targetId });
+  }, [send]);
+
+  const sendEmote = useCallback((emote: EmoteType) => {
+    send({ type: 'arena_emote', emote });
+    // Also show our own emote locally
+    setEmoteMap(prev => {
+      const next = new Map(prev);
+      next.set(playerIdRef.current, { emote, expiresAt: Date.now() + 3000 });
+      return next;
+    });
+  }, [send]);
+
+  const setTargetMode = useCallback((mode: TargetMode, targetId?: string) => {
+    setTargetModeState(mode);
+    setManualTargetIdState(targetId || null);
+    send({ type: 'arena_set_target', targetMode: mode, targetId });
+  }, [send]);
+
   const leaveArena = useCallback(() => {
     send({ type: 'arena_leave' });
     reconnectTokenRef.current = '';
@@ -391,6 +479,12 @@ export function useArenaSocket() {
     setError(null);
     opponentBoardsRef.current.clear();
     setOpponentBoards(new Map());
+    setHeldPowerUp(null);
+    setActiveEffects([]);
+    setFeedEvents([]);
+    setEmoteMap(new Map());
+    setTargetModeState('random');
+    setManualTargetIdState(null);
   }, [send]);
 
   return {
@@ -438,5 +532,24 @@ export function useArenaSocket() {
     sendAction,
     sendBoardRelay,
     leaveArena,
+
+    // Power-ups
+    heldPowerUp,
+    activeEffects,
+    lastPowerUpUsed,
+    usePowerUp,
+
+    // Event feed
+    feedEvents,
+
+    // Emotes
+    lastEmote,
+    emoteMap,
+    sendEmote,
+
+    // Targeting
+    targetMode,
+    manualTargetId,
+    setTargetMode,
   };
 }

--- a/src/types/multiplayer.ts
+++ b/src/types/multiplayer.ts
@@ -104,7 +104,10 @@ export interface ArenaGenericMessage {
     | 'arena_start'
     | 'arena_action'
     | 'arena_relay'
-    | 'arena_leave';
+    | 'arena_leave'
+    | 'arena_use_powerup'
+    | 'arena_emote'
+    | 'arena_set_target';
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive power-up system, emote communication, and player targeting mechanics to the Arena game mode. Players can now collect and use power-ups during matches, send quick emotes to opponents, and choose how garbage lines are distributed to other players.

## Key Changes

### Power-Up System
- Added 6 power-up types with distinct mechanics:
  - **Shield**: Blocks incoming garbage for 5 seconds
  - **Garbage Bomb**: Sends 4 garbage lines to a targeted player
  - **Score Boost**: 2x score multiplier for 6 seconds
  - **Freeze Target**: Slows target's gravity for 3 seconds
  - **Heal**: Removes up to 3 garbage rows (client-side)
  - **Chaos Surge**: Instantly adds 15 chaos to the room
- Power-ups spawn on line clears (25% chance) and Tetris clears (60% chance)
- Players can hold one power-up at a time and activate it with the E key
- Active effects are tracked with expiration times and displayed in the HUD

### Targeting System
- Added 4 targeting modes for garbage distribution:
  - **Random**: Sends garbage to a random alive opponent
  - **KO Leader**: Targets the player with the most eliminations
  - **Nearest**: Targets the player with the closest score
  - **Manual**: Allows clicking opponent boards to select a specific target
- Target mode can be cycled with Tab key or selected via UI buttons
- Manual targets are highlighted with a "TGT" badge on opponent boards

### Emote System
- Added 4 quick emotes: GG, Nice!, RIP, and !!!
- Emotes can be sent with number keys (1-4) or UI buttons
- Emote bubbles appear above opponent boards for 3 seconds
- Emotes are broadcast to all players in the room

### Event Feed
- New event feed overlay displays game events (power-up spawns, usage, shields blocking, etc.)
- Events are color-coded based on type and fade out after display
- Shows up to 8 most recent events

### UI Components
- **PowerUpHUD**: Displays held power-up with glow animation and active effects
- **TargetSelector**: Mode buttons and opponent quick-select buttons
- **EmoteBar**: Quick emote buttons with keyboard hints
- **EventFeed**: Scrolling event log with color-coded messages
- **EmoteBubble**: Floating emote display on opponent boards

### Server-Side Implementation
- `ArenaRoomManager` now tracks power-up spawning and usage
- Garbage targeting logic resolves target based on player's target mode
- Shield effects block garbage delivery with event notification
- Power-up usage is broadcast to all players with details
- Active effects are cleaned up each tick based on expiration time
- Power-ups used is tracked in session statistics

### Styling
- Added 300+ lines of CSS for new UI components
- Responsive design adjustments for mobile (max-width: 640px)
- Animations for power-up glow, effect pulse, emote pop, and event feed slide-in
- Color-coded visual feedback for different power-up types

### Type Definitions
- New types: `PowerUpType`, `EmoteType`, `TargetMode`, `ActiveEffect`, `ArenaFeedEvent`
- New message types for power-up usage, emotes, and targeting
- Updated `ArenaPlayer` interface with power-up and targeting fields
- Updated `ArenaRoom` interface with power-up tracking

### Localization
- Added translations for new UI labels in English, Spanish, French, Japanese, and Thai

## Notable Implementation Details
- Power-ups are weighted for spawn probability (bomb and shield are most common)
- Shield effects prevent garbage delivery entirely with visual feedback
- Emotes and events have automatic expiration to prevent UI clutter
- Target resolution happens server-side to prevent cheating
- Active effects are filtered each game tick to remove expired ones
- Manual targeting is validated against alive/connected status

https://claude.ai/code/session_01K9KrfKrbVLYvcpwMxaAa6F