### PR TITLE
Add combo break VFX and judgment display mode toggle

### DIFF
--- a/src/components/rhythmia/tetris/VanillaGame.module.css
+++ b/src/components/rhythmia/tetris/VanillaGame.module.css
@@ -296,27 +296,26 @@
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
-/* On-beat zone: left edge (phase 0–15%, just after beat fires) */
+/* Timing zone: GOOD (outer ring, phase 0–20% left and 80–100% right) */
 .beatTargetLeft {
   position: absolute;
   left: 0;
   top: 0;
   bottom: 0;
-  width: 15%;
-  background: rgba(255, 215, 0, 0.08);
-  border-right: 1px solid rgba(255, 215, 0, 0.2);
+  width: 20%;
+  background: linear-gradient(to right, rgba(118, 255, 3, 0.06), rgba(118, 255, 3, 0.03));
+  border-right: 1px solid rgba(118, 255, 3, 0.12);
   border-radius: 8px 0 0 8px;
 }
 
-/* On-beat zone: right edge (phase 75–100%, approaching next beat) */
 .beatTargetRight {
   position: absolute;
   right: 0;
   top: 0;
   bottom: 0;
-  width: 25%;
-  background: rgba(255, 215, 0, 0.08);
-  border-left: 1px solid rgba(255, 215, 0, 0.2);
+  width: 20%;
+  background: linear-gradient(to left, rgba(118, 255, 3, 0.06), rgba(118, 255, 3, 0.03));
+  border-left: 1px solid rgba(118, 255, 3, 0.12);
   border-radius: 0 8px 8px 0;
 }
 
@@ -331,12 +330,27 @@
   z-index: 2;
   transform: translateX(-50%);
   left: calc(var(--beat-phase, 0) * 100%);
+  transition: background 0.05s, box-shadow 0.05s, width 0.05s;
 }
 
-/* On-beat glow — driven by data-onbeat attribute set in rAF loop */
-.beatBar[data-onbeat] .beatCursor {
+/* GOOD timing glow */
+.beatBar[data-onbeat="good"] .beatCursor {
+  background: #76FF03;
+  box-shadow: 0 0 6px rgba(118, 255, 3, 0.5), 0 0 12px rgba(118, 255, 3, 0.2);
+  width: 5px;
+}
+
+/* GREAT timing glow */
+.beatBar[data-onbeat="great"] .beatCursor {
+  background: #00E5FF;
+  box-shadow: 0 0 8px rgba(0, 229, 255, 0.6), 0 0 16px rgba(0, 229, 255, 0.3);
+  width: 5px;
+}
+
+/* PERFECT timing glow */
+.beatBar[data-onbeat="perfect"] .beatCursor {
   background: #FFD700;
-  box-shadow: 0 0 8px rgba(255, 215, 0, 0.6), 0 0 16px rgba(255, 215, 0, 0.3);
+  box-shadow: 0 0 10px rgba(255, 215, 0, 0.7), 0 0 20px rgba(255, 215, 0, 0.4);
   width: 6px;
 }
 
@@ -362,6 +376,29 @@
   0% { opacity: 0; transform: translate(-50%, -50%) scale(0.5); }
   30% { opacity: 1; transform: translate(-50%, -50%) scale(1.2); }
   100% { opacity: 0; transform: translate(-50%, -60%) scale(1); }
+}
+
+/* Judgment display mode toggle */
+.judgmentModeToggle {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  z-index: 90;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.judgmentModeToggle:hover {
+  background: rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.9);
 }
 
 /* Mobile Touch Controls */

--- a/src/components/rhythmia/tetris/components/GameUI.tsx
+++ b/src/components/rhythmia/tetris/components/GameUI.tsx
@@ -226,23 +226,52 @@ export function ThemeNav({ colorTheme, onThemeChange }: ThemeNavProps) {
     );
 }
 
+export type JudgmentDisplayMode = 'text' | 'score';
+
 interface JudgmentDisplayProps {
     text: string;
     color: string;
     show: boolean;
+    score?: number;
+    displayMode?: JudgmentDisplayMode;
 }
 
 /**
- * Judgment text display (PERFECT!, etc.)
+ * Judgment text display — switchable between timing text (PERFECT!, GREAT!, etc.)
+ * and earned score (+1600, etc.)
  */
-export function JudgmentDisplay({ text, color, show }: JudgmentDisplayProps) {
+export function JudgmentDisplay({ text, color, show, score = 0, displayMode = 'text' }: JudgmentDisplayProps) {
+    const displayText = displayMode === 'score' && score > 0
+        ? `+${score.toLocaleString()}`
+        : text;
+
     return (
         <div
             className={`${styles.judgment} ${show ? styles.show : ''}`}
             style={{ color, textShadow: `0 0 30px ${color}` }}
         >
-            {text}
+            {displayText}
         </div>
+    );
+}
+
+interface JudgmentModeToggleProps {
+    mode: JudgmentDisplayMode;
+    onToggle: () => void;
+}
+
+/**
+ * Toggle button for switching between score and text judgment display
+ */
+export function JudgmentModeToggle({ mode, onToggle }: JudgmentModeToggleProps) {
+    return (
+        <button
+            className={styles.judgmentModeToggle}
+            onClick={onToggle}
+            title={mode === 'text' ? 'Switch to score display' : 'Switch to text display'}
+        >
+            {mode === 'text' ? 'ABC' : '123'}
+        </button>
     );
 }
 

--- a/src/components/rhythmia/tetris/components/index.ts
+++ b/src/components/rhythmia/tetris/components/index.ts
@@ -12,8 +12,10 @@ export {
     StatsPanel,
     ThemeNav,
     JudgmentDisplay,
+    JudgmentModeToggle,
     TouchControls,
 } from './GameUI';
+export type { JudgmentDisplayMode } from './GameUI';
 export { RhythmVFX } from './RhythmVFX';
 export { FloatingItems } from './FloatingItems';
 export { FloatingTreasures } from './FloatingTreasures';

--- a/src/components/rhythmia/tetris/hooks/useGameState.ts
+++ b/src/components/rhythmia/tetris/hooks/useGameState.ts
@@ -113,6 +113,7 @@ export function useGameState() {
     const [beatPhase, setBeatPhase] = useState(0);
     const [judgmentText, setJudgmentText] = useState('');
     const [judgmentColor, setJudgmentColor] = useState('');
+    const [judgmentScore, setJudgmentScore] = useState(0);
     const [showJudgmentAnim, setShowJudgmentAnim] = useState(false);
     const [boardBeat, setBoardBeat] = useState(false);
     const [boardShake, setBoardShake] = useState(false);
@@ -268,10 +269,11 @@ export function useGameState() {
         return newPiece;
     }, [getNextFromBag]);
 
-    // Show judgment text with animation
-    const showJudgment = useCallback((text: string, color: string) => {
+    // Show judgment text with animation — optionally includes score earned
+    const showJudgment = useCallback((text: string, color: string, earnedScore?: number) => {
         setJudgmentText(text);
         setJudgmentColor(color);
+        setJudgmentScore(earnedScore ?? 0);
         setShowJudgmentAnim(false);
         requestAnimationFrame(() => {
             setShowJudgmentAnim(true);
@@ -1036,6 +1038,7 @@ export function useGameState() {
         beatPhase,
         judgmentText,
         judgmentColor,
+        judgmentScore,
         showJudgmentAnim,
         boardBeat,
         boardShake,

--- a/src/components/rhythmia/tetris/hooks/useRhythmVFX.ts
+++ b/src/components/rhythmia/tetris/hooks/useRhythmVFX.ts
@@ -81,6 +81,34 @@ interface AscendingParticle extends BaseParticle {
     pulseSpeed: number;
 }
 
+interface ComboBreakShard {
+    x: number;
+    y: number;
+    vx: number;
+    vy: number;
+    rotation: number;
+    rotationSpeed: number;
+    width: number;
+    height: number;
+    life: number;
+    maxLife: number;
+    color: string;
+    alpha: number;
+    trail: { x: number; y: number; alpha: number }[];
+}
+
+interface ComboBreakRing {
+    x: number;
+    y: number;
+    radius: number;
+    maxRadius: number;
+    life: number;
+    maxLife: number;
+    color: string;
+    lineWidth: number;
+    dashed: boolean;
+}
+
 // All active effects managed by the VFX system
 interface VFXState {
     beatRings: BeatRing[];
@@ -91,6 +119,8 @@ interface VFXState {
     speedLines: SpeedLine[];
     ascendingParticles: AscendingParticle[];
     genericParticles: BaseParticle[];
+    comboBreakShards: ComboBreakShard[];
+    comboBreakRings: ComboBreakRing[];
     isFever: boolean;
     feverHue: number;
     combo: number;
@@ -119,6 +149,8 @@ export function useRhythmVFX() {
         speedLines: [],
         ascendingParticles: [],
         genericParticles: [],
+        comboBreakShards: [],
+        comboBreakRings: [],
         isFever: false,
         feverHue: 0,
         combo: 0,
@@ -344,6 +376,80 @@ export function useRhythmVFX() {
         }
     }, []);
 
+    const spawnComboBreakEffect = useCallback((lostCombo: number) => {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        const geo = boardGeoRef.current;
+        const state = stateRef.current;
+        const cx = geo.left + geo.width / 2;
+        const cy = geo.top + geo.height / 2;
+
+        // Scale intensity based on combo lost — bigger combo = more dramatic
+        const intensity = Math.min(1, lostCombo / 20);
+        const shardCount = Math.min(40, 10 + lostCombo * 2);
+
+        // Glass-shard particles exploding outward from center
+        for (let i = 0; i < shardCount; i++) {
+            const angle = (Math.PI * 2 * i) / shardCount + (Math.random() - 0.5) * 0.4;
+            const speed = 3 + Math.random() * 8 + intensity * 5;
+            const hue = Math.random() > 0.5
+                ? 0 + Math.random() * 30      // Red-orange
+                : 280 + Math.random() * 40;    // Purple-magenta
+
+            state.comboBreakShards.push({
+                x: cx + (Math.random() - 0.5) * 40,
+                y: cy + (Math.random() - 0.5) * 40,
+                vx: Math.cos(angle) * speed,
+                vy: Math.sin(angle) * speed - 2,
+                rotation: Math.random() * Math.PI * 2,
+                rotationSpeed: (Math.random() - 0.5) * 15,
+                width: 3 + Math.random() * 8 + intensity * 4,
+                height: 1 + Math.random() * 3,
+                life: 1,
+                maxLife: 1,
+                color: `hsl(${hue}, 100%, ${50 + Math.random() * 30}%)`,
+                alpha: 0.8 + Math.random() * 0.2,
+                trail: [],
+            });
+        }
+
+        // Expanding shockwave rings
+        const ringCount = 1 + Math.floor(intensity * 2);
+        for (let i = 0; i < ringCount; i++) {
+            state.comboBreakRings.push({
+                x: cx,
+                y: cy,
+                radius: 0,
+                maxRadius: Math.max(geo.width, geo.height) * (0.5 + intensity * 0.4) + i * 30,
+                life: 1,
+                maxLife: 1,
+                color: i === 0 ? '#FF4444' : `hsl(${320 + i * 20}, 80%, 60%)`,
+                lineWidth: 3 - i * 0.5,
+                dashed: i > 0,
+            });
+        }
+
+        // Additional scattered ember particles for high combos
+        if (lostCombo >= 5) {
+            const emberCount = Math.min(25, lostCombo);
+            for (let i = 0; i < emberCount; i++) {
+                const angle = Math.random() * Math.PI * 2;
+                const dist = 20 + Math.random() * 60;
+                state.genericParticles.push({
+                    x: cx + Math.cos(angle) * dist,
+                    y: cy + Math.sin(angle) * dist,
+                    vx: (Math.random() - 0.5) * 3,
+                    vy: -1 - Math.random() * 3,
+                    life: 1,
+                    maxLife: 1,
+                    color: `hsl(${Math.random() * 40}, 100%, ${60 + Math.random() * 30}%)`,
+                    alpha: 0.7,
+                    size: 1.5 + Math.random() * 2.5,
+                });
+            }
+        }
+    }, []);
+
     // ===== Main VFX Event Handler =====
 
     const emit = useCallback((event: VFXEvent) => {
@@ -386,6 +492,10 @@ export function useRhythmVFX() {
                 }
                 break;
 
+            case 'comboBreak':
+                spawnComboBreakEffect(event.lostCombo);
+                break;
+
             case 'feverStart':
                 state.isFever = true;
                 spawnSpeedLines(event.combo);
@@ -395,7 +505,7 @@ export function useRhythmVFX() {
                 state.isFever = false;
                 break;
         }
-    }, [spawnBeatRing, spawnEqualizerBars, spawnGlitchParticles, spawnRotationTrail, spawnHardDropParticles, spawnSpeedLines, spawnAscendingParticles]);
+    }, [spawnBeatRing, spawnEqualizerBars, spawnGlitchParticles, spawnRotationTrail, spawnHardDropParticles, spawnSpeedLines, spawnAscendingParticles, spawnComboBreakEffect]);
 
     // ===== Canvas Render Loop =====
 
@@ -651,6 +761,88 @@ export function useRhythmVFX() {
             ctx.beginPath();
             ctx.arc(p.x, p.y, p.size * p.life, 0, Math.PI * 2);
             ctx.fill();
+            ctx.restore();
+        }
+
+        // --- Combo Break Shards ---
+        for (let i = state.comboBreakShards.length - 1; i >= 0; i--) {
+            const shard = state.comboBreakShards[i];
+            shard.life -= dt * 1.8;
+            shard.x += shard.vx;
+            shard.y += shard.vy;
+            shard.vy += 8 * dt; // gravity
+            shard.vx *= 0.98; // air resistance
+            shard.rotation += shard.rotationSpeed * dt;
+
+            // Update trail
+            shard.trail.push({ x: shard.x, y: shard.y, alpha: shard.life * 0.3 });
+            if (shard.trail.length > 6) shard.trail.shift();
+
+            if (shard.life <= 0) {
+                state.comboBreakShards.splice(i, 1);
+                continue;
+            }
+
+            // Draw trail
+            for (let t = 0; t < shard.trail.length; t++) {
+                const tp = shard.trail[t];
+                ctx.save();
+                ctx.globalAlpha = tp.alpha * (t / shard.trail.length) * 0.5;
+                ctx.fillStyle = shard.color;
+                ctx.beginPath();
+                ctx.arc(tp.x, tp.y, shard.width * 0.3 * shard.life, 0, Math.PI * 2);
+                ctx.fill();
+                ctx.restore();
+            }
+
+            // Draw shard
+            ctx.save();
+            ctx.translate(shard.x, shard.y);
+            ctx.rotate(shard.rotation);
+            ctx.globalAlpha = shard.life * shard.alpha;
+            ctx.fillStyle = shard.color;
+            ctx.shadowColor = shard.color;
+            ctx.shadowBlur = 8 * shard.life;
+
+            // Diamond/shard shape
+            ctx.beginPath();
+            const w = shard.width * shard.life;
+            const h = shard.height * shard.life;
+            ctx.moveTo(0, -h);
+            ctx.lineTo(w * 0.5, 0);
+            ctx.lineTo(0, h);
+            ctx.lineTo(-w * 0.5, 0);
+            ctx.closePath();
+            ctx.fill();
+
+            ctx.restore();
+        }
+
+        // --- Combo Break Rings ---
+        for (let i = state.comboBreakRings.length - 1; i >= 0; i--) {
+            const ring = state.comboBreakRings[i];
+            ring.life -= dt * 2.0;
+            ring.radius += (ring.maxRadius - ring.radius) * dt * 5;
+
+            if (ring.life <= 0) {
+                state.comboBreakRings.splice(i, 1);
+                continue;
+            }
+
+            ctx.save();
+            ctx.globalAlpha = ring.life * 0.6;
+            ctx.strokeStyle = ring.color;
+            ctx.lineWidth = ring.lineWidth * ring.life;
+            ctx.shadowColor = ring.color;
+            ctx.shadowBlur = 12 * ring.life;
+
+            if (ring.dashed) {
+                ctx.setLineDash([8, 6]);
+            }
+
+            ctx.beginPath();
+            ctx.arc(ring.x, ring.y, ring.radius, 0, Math.PI * 2);
+            ctx.stroke();
             ctx.restore();
         }
 

--- a/src/components/rhythmia/tetris/tetris.tsx
+++ b/src/components/rhythmia/tetris/tetris.tsx
@@ -43,6 +43,7 @@ import {
   BeatBar,
   StatsPanel,
   JudgmentDisplay,
+  JudgmentModeToggle,
   TouchControls,
   RhythmVFX,
   FloatingItems,
@@ -60,6 +61,7 @@ import {
   hasTutorialBeenSeen,
   KeyBindSettings,
 } from './components';
+import type { JudgmentDisplayMode } from './components';
 
 interface RhythmiaProps {
   onQuit?: () => void;
@@ -127,6 +129,25 @@ export default function Rhythmia({ onQuit }: RhythmiaProps) {
 
   const [pauseStateBeforeOverlay, setPauseStateBeforeOverlay] = useState(false);
 
+  // Judgment display mode: 'text' (PERFECT!, GREAT!, etc.) or 'score' (+1600, etc.)
+  const [judgmentDisplayMode, setJudgmentDisplayMode] = useState<JudgmentDisplayMode>(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        const stored = localStorage.getItem('rhythmia_judgment_mode');
+        if (stored === 'score' || stored === 'text') return stored;
+      } catch { /* ignore */ }
+    }
+    return 'text';
+  });
+
+  const toggleJudgmentMode = useCallback(() => {
+    setJudgmentDisplayMode(prev => {
+      const next = prev === 'text' ? 'score' : 'text';
+      try { localStorage.setItem('rhythmia_judgment_mode', next); } catch { /* ignore */ }
+      return next;
+    });
+  }, []);
+
   const handleKeybindChange = useCallback((action: KeybindAction, key: string) => {
     setKeybindings(prev => {
       const next = { ...prev, [action]: key };
@@ -178,6 +199,7 @@ export default function Rhythmia({ onQuit }: RhythmiaProps) {
     beatPhase,
     judgmentText,
     judgmentColor,
+    judgmentScore,
     showJudgmentAnim,
     boardBeat,
     boardShake,
@@ -473,41 +495,48 @@ export default function Rhythmia({ onQuit }: RhythmiaProps) {
 
     const mode = gameModeRef.current;
 
-    // Beat judgment
+    // Beat judgment — four timing windows based on distance from beat
     const currentBeatPhase = beatPhaseRef.current;
-    const onBeat = currentBeatPhase > 0.75 || currentBeatPhase < 0.15;
+    // Distance from beat center (0.0 = exactly on beat, 0.5 = furthest away)
+    const distFromBeat = currentBeatPhase <= 0.5 ? currentBeatPhase : 1 - currentBeatPhase;
     let mult = 1;
+    let timing: 'perfect' | 'great' | 'good' | 'miss';
+
+    if (distFromBeat < 0.06) {
+      timing = 'perfect';  // ~12% of beat window (tightest)
+    } else if (distFromBeat < 0.12) {
+      timing = 'great';    // ~12% more
+    } else if (distFromBeat < 0.20) {
+      timing = 'good';     // ~16% more
+    } else {
+      timing = 'miss';     // everything else
+    }
 
     // Track pieces placed for advancements
     gamePiecesPlacedRef.current++;
 
-    if (onBeat) {
-      mult = 2;
-      const newCombo = comboRef.current + 1;
+    // Determine combo for this placement (before updating state)
+    const prevCombo = comboRef.current;
+    let newCombo = 0;
+    const onBeat = timing !== 'miss';
+
+    if (timing !== 'miss') {
+      // On-beat — determine multiplier by timing quality
+      switch (timing) {
+        case 'perfect': mult = 2;   break;
+        case 'great':   mult = 1.5; break;
+        case 'good':    mult = 1.2; break;
+      }
+      newCombo = prevCombo + 1;
       setCombo(newCombo);
-      showJudgment('PERFECT!', '#FFD700');
-      playTone(1047, 0.2, 'triangle');
-
-      // Track advancement stats
-      gamePerfectBeatsRef.current++;
-      if (newCombo > gameBestComboRef.current) {
-        gameBestComboRef.current = newCombo;
-      }
-
-      // VFX: combo change event
-      vfxRef.current.emit({ type: 'comboChange', combo: newCombo, onBeat: true });
-
-      // VFX: fever mode trigger at combo 10+
-      if (newCombo >= 10 && comboRef.current < 10) {
-        vfxRef.current.emit({ type: 'feverStart', combo: newCombo });
-      }
     } else {
       // VFX: combo broken — end fever if active
-      if (comboRef.current >= 10) {
+      if (prevCombo >= 10) {
         vfxRef.current.emit({ type: 'feverEnd' });
       }
-      if (comboRef.current > 0) {
-        showJudgment('MISS', '#FF4444');
+      if (prevCombo > 0) {
+        // Emit combo break particle effect — intensity scales with lost combo
+        vfxRef.current.emit({ type: 'comboBreak', lostCombo: prevCombo });
       }
       setCombo(0);
       vfxRef.current.emit({ type: 'comboChange', combo: 0, onBeat: false });
@@ -534,8 +563,46 @@ export default function Rhythmia({ onQuit }: RhythmiaProps) {
 
     // Calculate score with rhythm multiplier
     const baseScore = dropDistance * 2 + [0, 100, 300, 500, 800][clearedLines] * levelRef.current;
-    const finalScore = baseScore * mult * Math.max(1, comboRef.current);
+    const comboMult = Math.max(1, timing !== 'miss' ? newCombo : 1);
+    const finalScore = baseScore * mult * comboMult;
     updateScore(scoreRef.current + finalScore);
+
+    // Show judgment with earned score — called after score calc so score display mode works
+    if (timing !== 'miss') {
+      const judgmentConfig = {
+        perfect: { text: 'PERFECT!', color: '#FFD700' },
+        great:   { text: 'GREAT!',   color: '#00E5FF' },
+        good:    { text: 'GOOD',     color: '#76FF03' },
+      } as const;
+
+      showJudgment(judgmentConfig[timing].text, judgmentConfig[timing].color, finalScore);
+
+      if (timing === 'perfect') {
+        playTone(1047, 0.2, 'triangle');
+      } else if (timing === 'great') {
+        playTone(880, 0.15, 'triangle');
+      } else {
+        playTone(660, 0.1, 'triangle');
+      }
+
+      // Track advancement stats
+      if (timing === 'perfect') {
+        gamePerfectBeatsRef.current++;
+      }
+      if (newCombo > gameBestComboRef.current) {
+        gameBestComboRef.current = newCombo;
+      }
+
+      // VFX: combo change event
+      vfxRef.current.emit({ type: 'comboChange', combo: newCombo, onBeat: true });
+
+      // VFX: fever mode trigger at combo 10+
+      if (newCombo >= 10 && prevCombo < 10) {
+        vfxRef.current.emit({ type: 'feverStart', combo: newCombo });
+      }
+    } else if (prevCombo > 0) {
+      showJudgment('MISS', '#FF4444', 0);
+    }
 
     if (clearedLines > 0) {
       // Track tetris clears (4 lines at once) for advancements
@@ -884,8 +951,14 @@ export default function Rhythmia({ onQuit }: RhythmiaProps) {
         // Direct DOM update — bypasses React for smooth cross-browser animation
         if (beatBarRef.current) {
           beatBarRef.current.style.setProperty('--beat-phase', String(phase));
-          if (phase > 0.75 || phase < 0.15) {
-            beatBarRef.current.setAttribute('data-onbeat', '');
+          // Distance from beat center for timing zone display
+          const dist = phase <= 0.5 ? phase : 1 - phase;
+          if (dist < 0.06) {
+            beatBarRef.current.setAttribute('data-onbeat', 'perfect');
+          } else if (dist < 0.12) {
+            beatBarRef.current.setAttribute('data-onbeat', 'great');
+          } else if (dist < 0.20) {
+            beatBarRef.current.setAttribute('data-onbeat', 'good');
           } else {
             beatBarRef.current.removeAttribute('data-onbeat');
           }
@@ -1344,7 +1417,14 @@ export default function Rhythmia({ onQuit }: RhythmiaProps) {
         text={judgmentText}
         color={judgmentColor}
         show={showJudgmentAnim}
+        score={judgmentScore}
+        displayMode={judgmentDisplayMode}
       />
+
+      {/* Judgment mode toggle (text vs score) — only shown during gameplay */}
+      {isPlaying && !gameOver && (
+        <JudgmentModeToggle mode={judgmentDisplayMode} onToggle={toggleJudgmentMode} />
+      )}
 
       {/* Advancement Toast */}
       {toastIds.length > 0 && (

--- a/src/components/rhythmia/tetris/types.ts
+++ b/src/components/rhythmia/tetris/types.ts
@@ -59,6 +59,7 @@ export type VFXEvent =
     | { type: 'rotation'; pieceType: string; boardX: number; boardY: number; fromRotation: number; toRotation: number }
     | { type: 'hardDrop'; pieceType: string; boardX: number; boardY: number; dropDistance: number }
     | { type: 'comboChange'; combo: number; onBeat: boolean }
+    | { type: 'comboBreak'; lostCombo: number }
     | { type: 'feverStart'; combo: number }
     | { type: 'feverEnd' };
 


### PR DESCRIPTION
## Summary
Enhanced the rhythm game's visual feedback system by adding a dramatic combo break particle effect and introducing a toggleable judgment display mode that switches between timing text (PERFECT!, GREAT!, etc.) and earned score display (+1600, etc.).

## Key Changes

### Combo Break Visual Effects
- Added `ComboBreakShard` and `ComboBreakRing` interfaces to represent glass-shard particles and expanding shockwave rings
- Implemented `spawnComboBreakEffect()` that triggers when a combo is lost, with intensity scaling based on the combo count lost
- Effect includes:
  - Glass-shard particles exploding outward with rotation, gravity, and trail effects
  - Expanding concentric rings with color variation
  - Scattered ember particles for high combos (5+)
- Added rendering logic for both shard trails and ring animations in the canvas render loop
- Integrated `comboBreak` VFX event type into the event handler

### Judgment Display Mode Toggle
- Added `JudgmentDisplayMode` type ('text' | 'score') with localStorage persistence
- Created `JudgmentModeToggle` component with ABC/123 button indicator
- Modified `JudgmentDisplay` to conditionally show either timing text or formatted score based on mode
- Toggle button appears during active gameplay in the top-right corner

### Timing Window Refinement
- Replaced binary on-beat detection with four-tier timing system:
  - **PERFECT**: ±6% of beat window (tightest, 2x multiplier)
  - **GREAT**: ±12% of beat window (1.5x multiplier)
  - **GOOD**: ±20% of beat window (1.2x multiplier)
  - **MISS**: Outside timing window (combo break)
- Updated beat bar visual zones and cursor glow colors to reflect timing tiers
- Beat cursor now displays different colors/glows for each timing quality

### Score Calculation & Display
- Modified `showJudgment()` to accept and display earned score
- Score calculation now properly applies timing multiplier before combo multiplier
- Different audio tones play for each timing quality (perfect > great > good)

### UI/CSS Updates
- Updated beat target zones from 15%/25% to symmetric 20% GOOD zones
- Added gradient backgrounds and refined border colors for timing zones
- Enhanced beat cursor styling with timing-specific glows and transitions
- Added `judgmentModeToggle` button styling with hover effects

## Implementation Details
- Combo break effect intensity scales with lost combo count (up to 40 shards for 20+ combo)
- Shards use diamond shapes with rotation and physics (gravity, air resistance)
- Trails are rendered as semi-transparent circles following shard paths
- Rings expand smoothly with dashed styling for secondary rings
- All timing calculations use distance from beat center for symmetry
- Score display respects the user's preferred judgment mode preference

https://claude.ai/code/session_019xsqcC98NEswsmEnrBcixw