### PR TITLE
feat: add feature customizer for single player and multiplayer modes

### DIFF
--- a/src/components/rhythmia/MultiplayerBattle.module.css
+++ b/src/components/rhythmia/MultiplayerBattle.module.css
@@ -333,6 +333,46 @@
   transform: translateY(-2px);
 }
 
+/* Settings Gear Button */
+.settingsGearBtn {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  z-index: 100;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.7);
+  cursor: pointer;
+  transition: all 0.2s;
+  backdrop-filter: blur(8px);
+}
+
+.settingsGearBtn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.25);
+  color: #ffffff;
+  transform: scale(1.05);
+}
+
+/* Feature Customizer Overlay */
+.featureOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .battleArena {

--- a/src/components/rhythmia/tetris/VanillaGame.module.css
+++ b/src/components/rhythmia/tetris/VanillaGame.module.css
@@ -2788,6 +2788,185 @@
 }
 
 /* ===================================================================
+   FEATURE CUSTOMIZER
+   =================================================================== */
+
+.featurePanel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  width: 320px;
+  max-width: 90vw;
+  padding: 28px 24px 20px;
+  background: rgba(10, 10, 20, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  backdrop-filter: blur(24px);
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
+}
+
+.featureTitle {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+}
+
+.featureSubtitle {
+  font-size: 0.65rem;
+  color: rgba(255, 255, 255, 0.3);
+  letter-spacing: 0.15em;
+  margin-bottom: 14px;
+}
+
+.featureList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  margin-bottom: 16px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.featureRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  background: rgba(255, 255, 255, 0.025);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  transition: all 0.2s;
+}
+
+.featureRow:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.featureLabelWrap {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.featureLabel {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.75);
+  letter-spacing: 0.05em;
+}
+
+.featureLabelJa {
+  font-size: 0.58rem;
+  color: rgba(255, 255, 255, 0.25);
+  letter-spacing: 0.08em;
+}
+
+/* Toggle switch */
+.featureToggle {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 11px;
+  background: rgba(255, 255, 255, 0.1);
+  cursor: pointer;
+  transition: background 0.25s;
+  flex-shrink: 0;
+}
+
+.featureToggle:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.featureToggleOn {
+  background: rgba(0, 127, 255, 0.5);
+}
+
+.featureToggleOn:hover {
+  background: rgba(0, 127, 255, 0.65);
+}
+
+.featureToggleThumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.5);
+  transition: transform 0.25s, background 0.25s;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+
+.featureToggleOn .featureToggleThumb {
+  transform: translateX(18px);
+  background: #ffffff;
+}
+
+.featureActions {
+  display: flex;
+  gap: 8px;
+  width: 100%;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.featureResetBtn,
+.featureBackBtn {
+  flex: 1;
+  padding: 9px 0;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-transform: uppercase;
+}
+
+.featureResetBtn {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.featureResetBtn:hover {
+  background: rgba(255, 80, 80, 0.1);
+  border-color: rgba(255, 80, 80, 0.3);
+  color: rgba(255, 120, 120, 0.9);
+}
+
+.featureBackBtn {
+  background: rgba(0, 127, 255, 0.1);
+  border: 1px solid rgba(0, 127, 255, 0.2);
+  color: rgba(100, 180, 255, 0.9);
+}
+
+.featureBackBtn:hover {
+  background: rgba(0, 127, 255, 0.2);
+  border-color: rgba(0, 127, 255, 0.4);
+  color: white;
+}
+
+@media (max-width: 480px) {
+  .featurePanel {
+    width: 280px;
+    padding: 20px 16px 16px;
+  }
+
+  .featureTitle { font-size: 0.85rem; }
+  .featureRow { padding: 8px 12px; }
+  .featureLabel { font-size: 0.7rem; }
+}
+
+/* ===================================================================
    INVENTORY UI — Minecraft Dungeons Style
    =================================================================== */
 .inventoryOverlay {

--- a/src/components/rhythmia/tetris/components/Board.tsx
+++ b/src/components/rhythmia/tetris/components/Board.tsx
@@ -5,7 +5,8 @@ import { ADVANCEMENTS } from '@/lib/advancements/definitions';
 import { loadAdvancementState } from '@/lib/advancements/storage';
 import Advancements from '@/components/rhythmia/Advancements';
 import { KeyBindSettings } from './KeyBindSettings';
-import type { Piece, Board as BoardType, Keybindings, KeybindAction } from '../types';
+import { FeatureCustomizer } from './FeatureCustomizer';
+import type { Piece, Board as BoardType, Keybindings, KeybindAction, FeatureSettings } from '../types';
 import styles from '../VanillaGame.module.css';
 
 interface BoardProps {
@@ -28,6 +29,8 @@ interface BoardProps {
     keybindings?: Keybindings;
     onKeybindChange?: (action: KeybindAction, key: string) => void;
     onKeybindingsUpdate?: (bindings: Keybindings) => void;
+    featureSettings?: FeatureSettings;
+    onFeatureSettingsUpdate?: (settings: FeatureSettings) => void;
 }
 
 /**
@@ -54,11 +57,14 @@ export function Board({
     keybindings,
     onKeybindChange,
     onKeybindingsUpdate,
+    featureSettings,
+    onFeatureSettingsUpdate,
 }: BoardProps) {
     const isFever = combo >= 10;
     const [showAdvancements, setShowAdvancements] = useState(false);
     const [showSettings, setShowSettings] = useState(false);
     const [showKeyBinds, setShowKeyBinds] = useState(false);
+    const [showFeatures, setShowFeatures] = useState(false);
     const [unlockedCount, setUnlockedCount] = useState(0);
     const [rebindingAction, setRebindingAction] = useState<KeybindAction | null>(null);
 
@@ -90,6 +96,7 @@ export function Board({
             setShowAdvancements(false);
             setShowSettings(false);
             setShowKeyBinds(false);
+            setShowFeatures(false);
             setRebindingAction(null);
         }
     }, [isPaused, gameOver]);
@@ -112,8 +119,9 @@ export function Board({
         if (currentPiece) {
             const shape = getShape(currentPiece.type, currentPiece.rotation);
 
+            const showGhost = featureSettings?.ghostPiece !== false;
             const ghostY = getGhostY(currentPiece, board);
-            if (ghostY !== currentPiece.y) {
+            if (showGhost && ghostY !== currentPiece.y) {
                 for (let y = 0; y < shape.length; y++) {
                     for (let x = 0; x < shape[y].length; x++) {
                         if (shape[y][x]) {
@@ -211,7 +219,7 @@ export function Board({
                 </div>
             )}
 
-            {/* Overlay for Paused — main menu, advancements, or key bindings sub-panel */}
+            {/* Overlay for Paused — main menu, advancements, key bindings, or features sub-panel */}
             {isPaused && !gameOver && (
                 <div className={styles.gameover} style={{ display: 'flex' }}>
                     {showKeyBinds && keybindings && onKeybindingsUpdate ? (
@@ -219,6 +227,13 @@ export function Board({
                             bindings={keybindings}
                             onUpdate={onKeybindingsUpdate}
                             onBack={() => setShowKeyBinds(false)}
+                        />
+                    ) : showFeatures && featureSettings && onFeatureSettingsUpdate ? (
+                        <FeatureCustomizer
+                            settings={featureSettings}
+                            onUpdate={onFeatureSettingsUpdate}
+                            onBack={() => setShowFeatures(false)}
+                            mode="singleplayer"
                         />
                     ) : !showAdvancements ? (
                         <>
@@ -240,6 +255,15 @@ export function Board({
                                         {unlockedCount}/{totalCount}
                                     </span>
                                 </button>
+                                {featureSettings && onFeatureSettingsUpdate && (
+                                    <button
+                                        className={styles.pauseMenuBtn}
+                                        onClick={() => setShowFeatures(true)}
+                                    >
+                                        <span className={styles.pauseMenuBtnIcon}>🎛</span>
+                                        Features
+                                    </button>
+                                )}
                                 {keybindings && onKeybindingsUpdate && (
                                     <button
                                         className={styles.pauseMenuBtn}

--- a/src/components/rhythmia/tetris/components/FeatureCustomizer.tsx
+++ b/src/components/rhythmia/tetris/components/FeatureCustomizer.tsx
@@ -1,0 +1,89 @@
+import React, { useState, useCallback } from 'react';
+import type { FeatureSettings } from '../types';
+import { DEFAULT_FEATURE_SETTINGS } from '../types';
+import styles from '../VanillaGame.module.css';
+
+type FeatureKey = keyof FeatureSettings;
+
+interface FeatureDef {
+    key: FeatureKey;
+    name: string;
+    nameJa: string;
+    description: string;
+    singlePlayer?: boolean;
+    multiplayer?: boolean;
+}
+
+const FEATURES: FeatureDef[] = [
+    { key: 'ghostPiece', name: 'Ghost Piece', nameJa: 'ゴースト', description: 'Show piece landing preview', singlePlayer: true, multiplayer: true },
+    { key: 'beatVfx', name: 'Beat VFX', nameJa: 'ビートエフェクト', description: 'Rhythm visual effects', singlePlayer: true, multiplayer: false },
+    { key: 'particles', name: 'Particles', nameJa: 'パーティクル', description: 'Terrain destruction particles', singlePlayer: true, multiplayer: false },
+    { key: 'items', name: 'Items & Crafting', nameJa: 'アイテム', description: 'Item drops and crafting system', singlePlayer: true, multiplayer: false },
+    { key: 'voxelBackground', name: '3D Background', nameJa: '3D背景', description: 'Voxel world background', singlePlayer: true, multiplayer: false },
+    { key: 'beatBar', name: 'Beat Bar', nameJa: 'ビートバー', description: 'Rhythm timing indicator', singlePlayer: true, multiplayer: false },
+    { key: 'sound', name: 'Sound', nameJa: 'サウンド', description: 'Sound effects', singlePlayer: true, multiplayer: true },
+    { key: 'garbageMeter', name: 'Garbage Meter', nameJa: 'ガベージメーター', description: 'Incoming garbage indicator', singlePlayer: false, multiplayer: true },
+];
+
+interface FeatureCustomizerProps {
+    settings: FeatureSettings;
+    onUpdate: (settings: FeatureSettings) => void;
+    onBack: () => void;
+    mode: 'singleplayer' | 'multiplayer';
+}
+
+export function FeatureCustomizer({ settings, onUpdate, onBack, mode }: FeatureCustomizerProps) {
+    const [current, setCurrent] = useState<FeatureSettings>({ ...settings });
+
+    const toggleFeature = useCallback((key: FeatureKey) => {
+        setCurrent(prev => {
+            const next = { ...prev, [key]: !prev[key] };
+            onUpdate(next);
+            return next;
+        });
+    }, [onUpdate]);
+
+    const resetDefaults = useCallback(() => {
+        const defaults = { ...DEFAULT_FEATURE_SETTINGS };
+        setCurrent(defaults);
+        onUpdate(defaults);
+    }, [onUpdate]);
+
+    const filteredFeatures = FEATURES.filter(f =>
+        mode === 'singleplayer' ? f.singlePlayer : f.multiplayer
+    );
+
+    return (
+        <div className={styles.featurePanel}>
+            <h3 className={styles.featureTitle}>FEATURES</h3>
+            <span className={styles.featureSubtitle}>カスタマイズ</span>
+
+            <div className={styles.featureList}>
+                {filteredFeatures.map(feature => (
+                    <div key={feature.key} className={styles.featureRow}>
+                        <div className={styles.featureLabelWrap}>
+                            <span className={styles.featureLabel}>{feature.name}</span>
+                            <span className={styles.featureLabelJa}>{feature.nameJa}</span>
+                        </div>
+                        <button
+                            className={`${styles.featureToggle} ${current[feature.key] ? styles.featureToggleOn : ''}`}
+                            onClick={() => toggleFeature(feature.key)}
+                            aria-label={`Toggle ${feature.name}`}
+                        >
+                            <span className={styles.featureToggleThumb} />
+                        </button>
+                    </div>
+                ))}
+            </div>
+
+            <div className={styles.featureActions}>
+                <button className={styles.featureResetBtn} onClick={resetDefaults}>
+                    Reset Defaults
+                </button>
+                <button className={styles.featureBackBtn} onClick={onBack}>
+                    Back
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/components/rhythmia/tetris/components/index.ts
+++ b/src/components/rhythmia/tetris/components/index.ts
@@ -25,3 +25,4 @@ export { WorldTransition, GamePhaseIndicator } from './WorldTransition';
 export { HealthManaHUD } from './HealthManaHUD';
 export { TutorialGuide, hasTutorialBeenSeen } from './TutorialGuide';
 export { KeyBindSettings } from './KeyBindSettings';
+export { FeatureCustomizer } from './FeatureCustomizer';

--- a/src/components/rhythmia/tetris/tetris.tsx
+++ b/src/components/rhythmia/tetris/tetris.tsx
@@ -540,9 +540,9 @@ export default function Rhythmia({ onQuit }: RhythmiaProps) {
     if (timing !== 'miss') {
       // On-beat — determine multiplier by timing quality
       switch (timing) {
-        case 'perfect': mult = 2;   break;
-        case 'great':   mult = 1.5; break;
-        case 'good':    mult = 1.2; break;
+        case 'perfect': mult = 2; break;
+        case 'great': mult = 1.5; break;
+        case 'good': mult = 1.2; break;
       }
       newCombo = prevCombo + 1;
       setCombo(newCombo);
@@ -588,8 +588,8 @@ export default function Rhythmia({ onQuit }: RhythmiaProps) {
     if (timing !== 'miss') {
       const judgmentConfig = {
         perfect: { text: 'PERFECT!', color: '#FFD700' },
-        great:   { text: 'GREAT!',   color: '#00E5FF' },
-        good:    { text: 'GOOD',     color: '#76FF03' },
+        great: { text: 'GREAT!', color: '#00E5FF' },
+        good: { text: 'GOOD', color: '#76FF03' },
       } as const;
 
       showJudgment(judgmentConfig[timing].text, judgmentConfig[timing].color, finalScore);
@@ -1276,8 +1276,10 @@ export default function Rhythmia({ onQuit }: RhythmiaProps) {
 
       {/* Floating item drops from terrain */}
       {featureSettings.items && (
-        <FloatingItems items={floatingItems} />
-        <FloatingTreasures treasures={floatingTreasures} />
+        <div>
+          <FloatingItems items={floatingItems} />
+          <FloatingTreasures treasures={floatingTreasures} />
+        </div>
       )}
 
       {/* World transition overlays (creation / collapse / reload) */}

--- a/src/components/rhythmia/tetris/types.ts
+++ b/src/components/rhythmia/tetris/types.ts
@@ -201,3 +201,26 @@ export type TerrainParticle = {
     life: number;
     maxLife: number;
 };
+
+// ===== Feature Customizer Settings =====
+export type FeatureSettings = {
+    ghostPiece: boolean;
+    beatVfx: boolean;
+    particles: boolean;
+    items: boolean;
+    voxelBackground: boolean;
+    beatBar: boolean;
+    sound: boolean;
+    garbageMeter: boolean;
+};
+
+export const DEFAULT_FEATURE_SETTINGS: FeatureSettings = {
+    ghostPiece: true,
+    beatVfx: true,
+    particles: true,
+    items: true,
+    voxelBackground: true,
+    beatBar: true,
+    sound: true,
+    garbageMeter: true,
+};


### PR DESCRIPTION
Adds a new FeatureCustomizer panel that lets players toggle game features on/off. In single player, accessible from the pause menu. In multiplayer, accessible via a settings gear button. Settings persist in localStorage.

Single player toggles: Ghost Piece, Beat VFX, Particles, Items & Crafting, 3D Background, Beat Bar, Sound.
Multiplayer toggles: Ghost Piece, Sound, Garbage Meter.

https://claude.ai/code/session_01W6qVCDsAHRaT8E1AnpmoBx