### PR TITLE
Add full-page slide navigation to Rhythmia lobby

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://azuretier.net/blog</loc><lastmod>2026-02-16T11:24:40.184Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/shader-demo</loc><lastmod>2026-02-16T11:24:40.185Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/sns-widgets</loc><lastmod>2026-02-16T11:24:40.185Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/sunphase</loc><lastmod>2026-02-16T11:24:40.185Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/blog</loc><lastmod>2026-02-17T02:10:29.096Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/shader-demo</loc><lastmod>2026-02-17T02:10:29.097Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sns-widgets</loc><lastmod>2026-02-17T02:10:29.097Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sunphase</loc><lastmod>2026-02-17T02:10:29.097Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/components/rhythmia/RhythmiaLobby.tsx
+++ b/src/components/rhythmia/RhythmiaLobby.tsx
@@ -20,6 +20,7 @@ import MultiplayerGame from '@/components/rhythmia/MultiplayerGame';
 import LocaleSwitcher from '@/components/LocaleSwitcher';
 import LoyaltyWidget from '@/components/loyalty/LoyaltyWidget';
 import { useRouter } from '@/i18n/navigation';
+import { useSlideScroll } from '@/hooks/useSlideScroll';
 
 type GameMode = 'lobby' | 'vanilla' | 'multiplayer';
 
@@ -41,6 +42,12 @@ export default function RhythmiaLobby() {
     const { profile, showProfileSetup } = useProfile();
 
     const isArenaLocked = unlockedCount < BATTLE_ARENA_REQUIRED_ADVANCEMENTS;
+
+    const TOTAL_SLIDES = 3;
+    const { currentSlide, goToSlide, containerRef, slideStyle } = useSlideScroll({
+        totalSlides: TOTAL_SLIDES,
+        enabled: gameMode === 'lobby' && !isLoading && !showProfileSetup && !showAdvancements && !showSkinCustomizer && !showOnlineUsers,
+    });
 
     useEffect(() => {
         setUnlockedCount(getUnlockedCount());
@@ -192,6 +199,8 @@ export default function RhythmiaLobby() {
         );
     }
 
+    const slidesEnabled = gameMode === 'lobby' && !isLoading && !showProfileSetup && !showAdvancements && !showSkinCustomizer && !showOnlineUsers;
+
     return (
         <div className={styles.page}>
             {/* Profile setup overlay */}
@@ -246,174 +255,205 @@ export default function RhythmiaLobby() {
                 )}
             </AnimatePresence>
 
-            <div className={styles.container}>
-                <motion.header
-                    className={styles.header}
-                    initial={{ opacity: 0, y: -20 }}
-                    animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? -20 : 0 }}
-                    transition={{ duration: 0.6, delay: 0.1 }}
-                >
-                    <div className={styles.logo}>azuretier<span className={styles.logoAccent}>.net</span></div>
-                    <div className={styles.statusBar}>
-                        <button
-                            className={styles.advButton}
-                            onClick={() => setShowAdvancements(true)}
-                        >
-                            {t('advancements.button', { count: unlockedCount, total: ADVANCEMENTS.length })}
-                        </button>
-                        <button
-                            className={onlineStyles.onlineButton}
-                            onClick={requestOnlineUsers}
-                        >
-                            <span className={styles.statusDot}></span>
-                            <span>{t('lobby.onlineCount', { count: onlineCount })}</span>
-                        </button>
-                        <div className={styles.statusItem}>
-                            <span>v{rhythmiaConfig.version}</span>
-                        </div>
-                        <button
-                            className={styles.advButton}
-                            onClick={() => router.push('/wiki')}
-                        >
-                            Wiki
-                        </button>
-                        <button
-                            className={styles.advButton}
-                            onClick={() => router.push('/updates')}
-                        >
-                            {t('nav.updates')}
-                        </button>
-                        <button
-                            className={styles.advButton}
-                            onClick={() => setShowSkinCustomizer(true)}
-                        >
-                            {t('skin.profileButton')}
-                        </button>
-                        <LocaleSwitcher />
-                    </div>
-                </motion.header>
-
-                <main className={styles.main}>
-                    <motion.div
-                        className={styles.heroText}
-                        initial={{ opacity: 0, y: 30 }}
-                        animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? 30 : 0 }}
-                        transition={{ duration: 0.7, delay: 0.2 }}
+            {/* Slide container */}
+            <div
+                className={styles.slideContainer}
+                ref={containerRef}
+                style={slideStyle}
+            >
+                {/* Slide 0: Landing — Header + Hero + Server Grid */}
+                <section className={`${styles.slideSection} ${styles.slideSectionLanding}`}>
+                    <motion.header
+                        className={styles.header}
+                        initial={{ opacity: 0, y: -20 }}
+                        animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? -20 : 0 }}
+                        transition={{ duration: 0.6, delay: 0.1 }}
                     >
-                        <h1>{t('lobby.selectServer')}</h1>
-                        <p>{t('lobby.chooseMode')}</p>
-                        <p className={styles.heroTagline}>{t('lobby.tagline')}</p>
-                    </motion.div>
+                        <div className={styles.logo}>azuretier<span className={styles.logoAccent}>.net</span></div>
+                        <div className={styles.statusBar}>
+                            <button
+                                className={styles.advButton}
+                                onClick={() => setShowAdvancements(true)}
+                            >
+                                {t('advancements.button', { count: unlockedCount, total: ADVANCEMENTS.length })}
+                            </button>
+                            <button
+                                className={onlineStyles.onlineButton}
+                                onClick={requestOnlineUsers}
+                            >
+                                <span className={styles.statusDot}></span>
+                                <span>{t('lobby.onlineCount', { count: onlineCount })}</span>
+                            </button>
+                            <div className={styles.statusItem}>
+                                <span>v{rhythmiaConfig.version}</span>
+                            </div>
+                            <button
+                                className={styles.advButton}
+                                onClick={() => router.push('/wiki')}
+                            >
+                                Wiki
+                            </button>
+                            <button
+                                className={styles.advButton}
+                                onClick={() => router.push('/updates')}
+                            >
+                                {t('nav.updates')}
+                            </button>
+                            <button
+                                className={styles.advButton}
+                                onClick={() => setShowSkinCustomizer(true)}
+                            >
+                                {t('skin.profileButton')}
+                            </button>
+                            <LocaleSwitcher />
+                        </div>
+                    </motion.header>
 
-                    <div className={styles.serverGrid}>
-                        {/* Rhythmia (Solo Mode) */}
+                    <main className={styles.main}>
                         <motion.div
-                            className={`${styles.serverCard} ${styles.vanilla}`}
-                            onClick={() => launchGame('vanilla')}
-                            initial={{ opacity: 0, y: 40 }}
-                            animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? 40 : 0 }}
-                            transition={{ duration: 0.6, delay: 0.3 }}
-                            whileHover={{ y: -8, transition: { duration: 0.25 } }}
+                            className={styles.heroText}
+                            initial={{ opacity: 0, y: 30 }}
+                            animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? 30 : 0 }}
+                            transition={{ duration: 0.7, delay: 0.2 }}
                         >
-                            <span className={styles.cardBadge}>{t('vanilla.badge')}</span>
-                            <h2 className={styles.cardTitle}>{t('vanilla.title')}</h2>
-                            <p className={styles.cardSubtitle}>{t('vanilla.subtitle')}</p>
-                            <p className={styles.cardDescription}>{t('vanilla.description')}</p>
-                            <button className={styles.playButton}>{t('lobby.play')}</button>
+                            <h1>{t('lobby.selectServer')}</h1>
+                            <p>{t('lobby.chooseMode')}</p>
+                            <p className={styles.heroTagline}>{t('lobby.tagline')}</p>
                         </motion.div>
 
-                        {/* Multiplayer Server (locked until 3 advancements) */}
-                        <motion.div
-                            className={`${styles.serverCard} ${styles.multiplayer} ${isArenaLocked ? styles.lockedCard : ''}`}
-                            onClick={() => launchGame('multiplayer')}
-                            initial={{ opacity: 0, y: 40 }}
-                            animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? 40 : 0 }}
-                            transition={{ duration: 0.6, delay: 0.45 }}
-                            whileHover={isArenaLocked ? {} : { y: -8, transition: { duration: 0.25 } }}
-                        >
-                            {isArenaLocked && (
-                                <div className={styles.lockOverlay}>
-                                    <svg className={styles.lockIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-                                        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-                                        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-                                    </svg>
-                                    <div className={styles.lockText}>
-                                        {t('advancements.lockMessage', {
-                                            current: unlockedCount,
-                                            required: BATTLE_ARENA_REQUIRED_ADVANCEMENTS,
-                                        })}
+                        <div className={styles.serverGrid}>
+                            {/* Rhythmia (Solo Mode) */}
+                            <motion.div
+                                className={`${styles.serverCard} ${styles.vanilla}`}
+                                onClick={() => launchGame('vanilla')}
+                                initial={{ opacity: 0, y: 40 }}
+                                animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? 40 : 0 }}
+                                transition={{ duration: 0.6, delay: 0.3 }}
+                                whileHover={{ y: -8, transition: { duration: 0.25 } }}
+                            >
+                                <span className={styles.cardBadge}>{t('vanilla.badge')}</span>
+                                <h2 className={styles.cardTitle}>{t('vanilla.title')}</h2>
+                                <p className={styles.cardSubtitle}>{t('vanilla.subtitle')}</p>
+                                <p className={styles.cardDescription}>{t('vanilla.description')}</p>
+                                <button className={styles.playButton}>{t('lobby.play')}</button>
+                            </motion.div>
+
+                            {/* Multiplayer Server (locked until 3 advancements) */}
+                            <motion.div
+                                className={`${styles.serverCard} ${styles.multiplayer} ${isArenaLocked ? styles.lockedCard : ''}`}
+                                onClick={() => launchGame('multiplayer')}
+                                initial={{ opacity: 0, y: 40 }}
+                                animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? 40 : 0 }}
+                                transition={{ duration: 0.6, delay: 0.45 }}
+                                whileHover={isArenaLocked ? {} : { y: -8, transition: { duration: 0.25 } }}
+                            >
+                                {isArenaLocked && (
+                                    <div className={styles.lockOverlay}>
+                                        <svg className={styles.lockIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                                            <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                                            <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                                        </svg>
+                                        <div className={styles.lockText}>
+                                            {t('advancements.lockMessage', {
+                                                current: unlockedCount,
+                                                required: BATTLE_ARENA_REQUIRED_ADVANCEMENTS,
+                                            })}
+                                        </div>
+                                    </div>
+                                )}
+                                <span className={`${styles.cardBadge} ${styles.new}`}>{t('multiplayer.badge')}</span>
+                                <h2 className={styles.cardTitle}>{t('multiplayer.title')}</h2>
+                                <p className={styles.cardSubtitle}>{t('multiplayer.subtitle')}</p>
+                                <p className={styles.cardDescription}>
+                                    {t('multiplayer.description')}
+                                </p>
+                                <div className={styles.cardFeatures}>
+                                    <span className={styles.featureTag}>{t('multiplayer.features.vs')}</span>
+                                    <span className={styles.featureTag}>{t('multiplayer.features.websocket')}</span>
+                                    <span className={styles.featureTag}>{t('multiplayer.features.ranked')}</span>
+                                </div>
+                                <div className={styles.cardStats}>
+                                    <div className={styles.stat}>
+                                        <div className={styles.statValue}>VS</div>
+                                        <div className={styles.statLabel}>{t('multiplayer.stats.mode')}</div>
+                                    </div>
+                                    <div className={styles.stat}>
+                                        <div className={styles.statValue}>1v1</div>
+                                        <div className={styles.statLabel}>{t('multiplayer.stats.battle')}</div>
+                                    </div>
+                                    <div className={styles.stat}>
+                                        <div className={styles.statValue}>LIVE</div>
+                                        <div className={styles.statLabel}>{t('multiplayer.stats.status')}</div>
                                     </div>
                                 </div>
-                            )}
-                            <span className={`${styles.cardBadge} ${styles.new}`}>{t('multiplayer.badge')}</span>
-                            <h2 className={styles.cardTitle}>{t('multiplayer.title')}</h2>
-                            <p className={styles.cardSubtitle}>{t('multiplayer.subtitle')}</p>
-                            <p className={styles.cardDescription}>
-                                {t('multiplayer.description')}
-                            </p>
-                            <div className={styles.cardFeatures}>
-                                <span className={styles.featureTag}>{t('multiplayer.features.vs')}</span>
-                                <span className={styles.featureTag}>{t('multiplayer.features.websocket')}</span>
-                                <span className={styles.featureTag}>{t('multiplayer.features.ranked')}</span>
-                            </div>
-                            <div className={styles.cardStats}>
-                                <div className={styles.stat}>
-                                    <div className={styles.statValue}>VS</div>
-                                    <div className={styles.statLabel}>{t('multiplayer.stats.mode')}</div>
-                                </div>
-                                <div className={styles.stat}>
-                                    <div className={styles.statValue}>1v1</div>
-                                    <div className={styles.statLabel}>{t('multiplayer.stats.battle')}</div>
-                                </div>
-                                <div className={styles.stat}>
-                                    <div className={styles.statValue}>LIVE</div>
-                                    <div className={styles.statLabel}>{t('multiplayer.stats.status')}</div>
-                                </div>
-                            </div>
-                            <button className={`${styles.playButton} ${isArenaLocked ? styles.lockedButton : ''}`} disabled={isArenaLocked}>
-                                {isArenaLocked ? t('advancements.locked') : t('lobby.battle')}
-                            </button>
-                        </motion.div>
+                                <button className={`${styles.playButton} ${isArenaLocked ? styles.lockedButton : ''}`} disabled={isArenaLocked}>
+                                    {isArenaLocked ? t('advancements.locked') : t('lobby.battle')}
+                                </button>
+                            </motion.div>
 
-                        {/* 9-Player Arena */}
-                        <motion.div
-                            className={`${styles.serverCard} ${styles.multiplayer}`}
-                            onClick={() => router.push('/arena')}
-                            initial={{ opacity: 0, y: 40 }}
-                            animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? 40 : 0 }}
-                            transition={{ duration: 0.6, delay: 0.6 }}
-                            whileHover={{ y: -8, transition: { duration: 0.25 } }}
-                        >
-                            <span className={`${styles.cardBadge} ${styles.new}`}>{t('arena.badge')}</span>
-                            <h2 className={styles.cardTitle}>{t('arena.title')}</h2>
-                            <p className={styles.cardSubtitle}>{t('arena.subtitle')}</p>
-                            <p className={styles.cardDescription}>
-                                {t('arena.description')}
-                            </p>
-                            <div className={styles.cardFeatures}>
-                                <span className={styles.featureTag}>{t('arena.features.players')}</span>
-                                <span className={styles.featureTag}>{t('arena.features.chaos')}</span>
-                                <span className={styles.featureTag}>{t('arena.features.sync')}</span>
-                            </div>
-                            <div className={styles.cardStats}>
-                                <div className={styles.stat}>
-                                    <div className={styles.statValue}>9</div>
-                                    <div className={styles.statLabel}>{t('arena.stats.players')}</div>
+                            {/* 9-Player Arena */}
+                            <motion.div
+                                className={`${styles.serverCard} ${styles.multiplayer}`}
+                                onClick={() => router.push('/arena')}
+                                initial={{ opacity: 0, y: 40 }}
+                                animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? 40 : 0 }}
+                                transition={{ duration: 0.6, delay: 0.6 }}
+                                whileHover={{ y: -8, transition: { duration: 0.25 } }}
+                            >
+                                <span className={`${styles.cardBadge} ${styles.new}`}>{t('arena.badge')}</span>
+                                <h2 className={styles.cardTitle}>{t('arena.title')}</h2>
+                                <p className={styles.cardSubtitle}>{t('arena.subtitle')}</p>
+                                <p className={styles.cardDescription}>
+                                    {t('arena.description')}
+                                </p>
+                                <div className={styles.cardFeatures}>
+                                    <span className={styles.featureTag}>{t('arena.features.players')}</span>
+                                    <span className={styles.featureTag}>{t('arena.features.chaos')}</span>
+                                    <span className={styles.featureTag}>{t('arena.features.sync')}</span>
                                 </div>
-                                <div className={styles.stat}>
-                                    <div className={styles.statValue}>120+</div>
-                                    <div className={styles.statLabel}>{t('arena.stats.bpm')}</div>
+                                <div className={styles.cardStats}>
+                                    <div className={styles.stat}>
+                                        <div className={styles.statValue}>9</div>
+                                        <div className={styles.statLabel}>{t('arena.stats.players')}</div>
+                                    </div>
+                                    <div className={styles.stat}>
+                                        <div className={styles.statValue}>120+</div>
+                                        <div className={styles.statLabel}>{t('arena.stats.bpm')}</div>
+                                    </div>
+                                    <div className={styles.stat}>
+                                        <div className={styles.statValue}>LIVE</div>
+                                        <div className={styles.statLabel}>{t('arena.stats.status')}</div>
+                                    </div>
                                 </div>
-                                <div className={styles.stat}>
-                                    <div className={styles.statValue}>LIVE</div>
-                                    <div className={styles.statLabel}>{t('arena.stats.status')}</div>
-                                </div>
-                            </div>
-                            <button className={styles.playButton}>{t('arena.quickMatch')}</button>
-                        </motion.div>
-                    </div>
+                                <button className={styles.playButton}>{t('arena.quickMatch')}</button>
+                            </motion.div>
+                        </div>
+                    </main>
 
-                    {/* For You Section */}
+                    {/* Scroll hint — only visible on first slide */}
+                    <AnimatePresence>
+                        {currentSlide === 0 && slidesEnabled && (
+                            <motion.div
+                                className={styles.scrollHint}
+                                initial={{ opacity: 0 }}
+                                animate={{ opacity: 1 }}
+                                exit={{ opacity: 0 }}
+                                transition={{ duration: 0.3 }}
+                            >
+                                <svg className={styles.scrollHintIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                                    <path d="M7 13l5 5 5-5" />
+                                    <path d="M7 6l5 5 5-5" />
+                                </svg>
+                            </motion.div>
+                        )}
+                    </AnimatePresence>
+                </section>
+
+                {/* Slide 1: For You */}
+                <section
+                    className={`${styles.slideSection} ${styles.slideSectionPlay}`}
+                    data-slide-scrollable
+                >
                     <motion.div
                         className={styles.forYouSection}
                         initial={{ opacity: 0, y: 30 }}
@@ -426,20 +466,33 @@ export default function RhythmiaLobby() {
                             totalAdvancements={ADVANCEMENTS.length}
                         />
                     </motion.div>
+                </section>
 
-                    {/* Loyalty widget — visible immediately on landing */}
+                {/* Slide 2: Loyalty + Footer */}
+                <section className={`${styles.slideSection} ${styles.slideSectionBottom}`}>
                     <LoyaltyWidget />
-                </main>
-
-                <motion.footer
-                    className={styles.footer}
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: isLoading ? 0 : 0.4 }}
-                    transition={{ duration: 0.6, delay: 0.6 }}
-                >
-                    {t('footer.copyright')}
-                </motion.footer>
+                    <motion.footer
+                        className={styles.footer}
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: isLoading ? 0 : 0.4 }}
+                        transition={{ duration: 0.6, delay: 0.6 }}
+                    >
+                        {t('footer.copyright')}
+                    </motion.footer>
+                </section>
             </div>
+
+            {/* Dot navigation */}
+            <nav className={`${styles.slideNav} ${!slidesEnabled ? styles.slideNavHidden : ''}`}>
+                {Array.from({ length: TOTAL_SLIDES }, (_, i) => (
+                    <button
+                        key={i}
+                        className={`${styles.slideDot} ${currentSlide === i ? styles.slideDotActive : ''}`}
+                        onClick={() => goToSlide(i)}
+                        aria-label={`Go to slide ${i + 1}`}
+                    />
+                ))}
+            </nav>
         </div>
     );
 }

--- a/src/components/rhythmia/rhythmia.module.css
+++ b/src/components/rhythmia/rhythmia.module.css
@@ -5,8 +5,7 @@
   min-height: 100vh;
   height: 100vh;
   max-width: 100%;
-  overflow-x: hidden;
-  overflow-y: auto;
+  overflow: hidden;
   color: var(--skin-foreground, #ffffff);
   position: relative;
   box-sizing: border-box;
@@ -72,6 +71,36 @@
   flex-direction: column;
   align-items: center;
   padding: 32px;
+  overflow-y: auto;
+}
+
+.slideSectionBottom {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 20px;
+  gap: 24px;
+}
+
+.scrollHintIcon {
+  width: 20px;
+  height: 20px;
+  opacity: 0.4;
+}
+
+.slideNavHidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .slideContainer {
+    transition-duration: 0ms;
+  }
+  .scrollHint {
+    animation: none;
+  }
 }
 
 .slideNav {

--- a/src/hooks/useSlideScroll.ts
+++ b/src/hooks/useSlideScroll.ts
@@ -1,0 +1,203 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+interface UseSlideScrollOptions {
+  totalSlides: number;
+  enabled: boolean;
+  debounceMs?: number;
+  deltaThreshold?: number;
+  touchThreshold?: number;
+}
+
+interface UseSlideScrollReturn {
+  currentSlide: number;
+  goToSlide: (index: number) => void;
+  containerRef: React.RefObject<HTMLDivElement>;
+  slideStyle: React.CSSProperties;
+}
+
+export function useSlideScroll({
+  totalSlides,
+  enabled,
+  debounceMs = 800,
+  deltaThreshold = 50,
+  touchThreshold = 50,
+}: UseSlideScrollOptions): UseSlideScrollReturn {
+  const [currentSlide, setCurrentSlide] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null!);
+  const isTransitioning = useRef(false);
+  const accumulatedDelta = useRef(0);
+  const deltaTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const touchStartY = useRef(0);
+
+  const goToSlide = useCallback(
+    (index: number) => {
+      const clamped = Math.max(0, Math.min(totalSlides - 1, index));
+      if (clamped === currentSlide) return;
+      if (isTransitioning.current) return;
+
+      isTransitioning.current = true;
+      setCurrentSlide(clamped);
+
+      setTimeout(() => {
+        isTransitioning.current = false;
+      }, debounceMs);
+    },
+    [currentSlide, totalSlides, debounceMs],
+  );
+
+  // Check if the wheel event target is inside an inner-scrollable area
+  // and whether that area is at its scroll boundary
+  const shouldChangeSlide = useCallback(
+    (target: HTMLElement, deltaY: number): boolean => {
+      const scrollable = target.closest('[data-slide-scrollable]') as HTMLElement | null;
+      if (!scrollable) return true;
+
+      const { scrollTop, scrollHeight, clientHeight } = scrollable;
+      const isAtTop = scrollTop <= 1;
+      const isAtBottom = scrollTop + clientHeight >= scrollHeight - 1;
+
+      if (deltaY > 0 && !isAtBottom) return false;
+      if (deltaY < 0 && !isAtTop) return false;
+      return true;
+    },
+    [],
+  );
+
+  // Wheel handler
+  useEffect(() => {
+    if (!enabled) return;
+    const container = containerRef.current?.parentElement;
+    if (!container) return;
+
+    const handleWheel = (e: WheelEvent) => {
+      const target = e.target as HTMLElement;
+      if (!shouldChangeSlide(target, e.deltaY)) return;
+
+      e.preventDefault();
+
+      if (isTransitioning.current) return;
+
+      accumulatedDelta.current += e.deltaY;
+      if (deltaTimer.current) clearTimeout(deltaTimer.current);
+      deltaTimer.current = setTimeout(() => {
+        accumulatedDelta.current = 0;
+      }, 100);
+
+      if (Math.abs(accumulatedDelta.current) < deltaThreshold) return;
+
+      const direction = accumulatedDelta.current > 0 ? 1 : -1;
+      accumulatedDelta.current = 0;
+
+      const next = currentSlide + direction;
+      if (next < 0 || next >= totalSlides) return;
+
+      isTransitioning.current = true;
+      setCurrentSlide(next);
+
+      setTimeout(() => {
+        isTransitioning.current = false;
+      }, debounceMs);
+    };
+
+    container.addEventListener('wheel', handleWheel, { passive: false });
+    return () => container.removeEventListener('wheel', handleWheel);
+  }, [enabled, currentSlide, totalSlides, debounceMs, deltaThreshold, shouldChangeSlide]);
+
+  // Touch handlers
+  useEffect(() => {
+    if (!enabled) return;
+    const container = containerRef.current?.parentElement;
+    if (!container) return;
+
+    const handleTouchStart = (e: TouchEvent) => {
+      touchStartY.current = e.touches[0].clientY;
+    };
+
+    const handleTouchEnd = (e: TouchEvent) => {
+      if (isTransitioning.current) return;
+
+      const deltaY = touchStartY.current - e.changedTouches[0].clientY;
+      if (Math.abs(deltaY) < touchThreshold) return;
+
+      // Check inner scroll boundaries for the touch target
+      const target = e.target as HTMLElement;
+      if (!shouldChangeSlide(target, deltaY)) return;
+
+      const direction = deltaY > 0 ? 1 : -1;
+      const next = currentSlide + direction;
+      if (next < 0 || next >= totalSlides) return;
+
+      isTransitioning.current = true;
+      setCurrentSlide(next);
+
+      setTimeout(() => {
+        isTransitioning.current = false;
+      }, debounceMs);
+    };
+
+    container.addEventListener('touchstart', handleTouchStart, { passive: true });
+    container.addEventListener('touchend', handleTouchEnd, { passive: true });
+    return () => {
+      container.removeEventListener('touchstart', handleTouchStart);
+      container.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, [enabled, currentSlide, totalSlides, debounceMs, touchThreshold, shouldChangeSlide]);
+
+  // Keyboard handler
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isTransitioning.current) return;
+
+      let direction = 0;
+      if (e.key === 'ArrowDown' || e.key === 'PageDown') {
+        direction = 1;
+      } else if (e.key === 'ArrowUp' || e.key === 'PageUp') {
+        direction = -1;
+      } else {
+        return;
+      }
+
+      e.preventDefault();
+      const next = currentSlide + direction;
+      if (next < 0 || next >= totalSlides) return;
+
+      isTransitioning.current = true;
+      setCurrentSlide(next);
+
+      setTimeout(() => {
+        isTransitioning.current = false;
+      }, debounceMs);
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [enabled, currentSlide, totalSlides, debounceMs]);
+
+  // Reset accumulated delta when disabled
+  useEffect(() => {
+    if (!enabled) {
+      accumulatedDelta.current = 0;
+      if (deltaTimer.current) {
+        clearTimeout(deltaTimer.current);
+        deltaTimer.current = null;
+      }
+    }
+  }, [enabled]);
+
+  // Cleanup timers on unmount
+  useEffect(() => {
+    return () => {
+      if (deltaTimer.current) clearTimeout(deltaTimer.current);
+    };
+  }, []);
+
+  const slideStyle: React.CSSProperties = {
+    transform: `translateY(-${currentSlide * 100}vh)`,
+  };
+
+  return { currentSlide, goToSlide, containerRef, slideStyle };
+}


### PR DESCRIPTION
## Summary
Implemented a full-page slide navigation system for the Rhythmia lobby, allowing users to scroll through distinct sections (landing, "For You", and loyalty/footer) using mouse wheel, touch gestures, or keyboard navigation.

## Key Changes
- **New `useSlideScroll` hook** (`src/hooks/useSlideScroll.ts`): Custom React hook that manages slide state and handles multiple input methods:
  - Wheel scrolling with delta accumulation and threshold detection
  - Touch gestures with configurable sensitivity
  - Keyboard navigation (arrow keys, Page Up/Down)
  - Smart boundary detection to allow inner-scrollable content to scroll before triggering slide changes
  - Debouncing and transition state management to prevent rapid slide changes

- **Restructured RhythmiaLobby layout**: Reorganized the main content into three distinct slide sections:
  - Slide 0: Landing page with header, hero text, and server selection cards
  - Slide 1: "For You" section with recommendations and advancements
  - Slide 2: Loyalty widget and footer

- **Added visual navigation elements**:
  - Dot navigation buttons at the bottom to jump to specific slides
  - Scroll hint indicator (animated arrows) visible only on the first slide
  - Navigation dots automatically hide when slides are disabled (during loading, profile setup, etc.)

- **CSS updates**: Modified `rhythmia.module.css` to support the slide container layout with proper overflow handling and responsive design considerations

## Implementation Details
- The hook respects accessibility preferences (`prefers-reduced-motion`)
- Slide navigation is intelligently disabled during modal overlays (profile setup, advancements, skin customizer, online users list)
- Inner-scrollable sections (marked with `data-slide-scrollable`) can scroll their own content before triggering slide transitions
- Full-viewport height sections (100vh) ensure smooth full-page transitions
- Touch and wheel events use passive listeners where appropriate for performance

https://claude.ai/code/session_01DdbqiftWJ2GnYRdpi82kHM