### PR TITLE
Add version 1.0.2 UI and refactor version switching logic

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://azuretier.net/blog</loc><lastmod>2026-02-12T19:27:57.195Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/shader-demo</loc><lastmod>2026-02-12T19:27:57.195Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/sns-widgets</loc><lastmod>2026-02-12T19:27:57.195Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/sunphase</loc><lastmod>2026-02-12T19:27:57.195Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/blog</loc><lastmod>2026-02-14T09:04:08.412Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/shader-demo</loc><lastmod>2026-02-14T09:04:08.413Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sns-widgets</loc><lastmod>2026-02-14T09:04:08.413Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sunphase</loc><lastmod>2026-02-14T09:04:08.413Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -4,6 +4,7 @@ import { useVersion } from '@/lib/version/context';
 import RhythmiaLobby from '@/components/rhythmia/RhythmiaLobby';
 import V1_0_0_UI from '@/components/home/v1.0.0/V1_0_0_UI';
 import V1_0_1_UI from '@/components/home/v1.0.1/V1_0_1_UI';
+import V1_0_2_UI from '@/components/home/v1.0.2/V1_0_2_UI';
 import FloatingVersionSwitcher from '@/components/version/FloatingVersionSwitcher';
 
 export default function HomePage() {
@@ -15,6 +16,8 @@ export default function HomePage() {
                 return <V1_0_0_UI />;
             case '1.0.1':
                 return <V1_0_1_UI />;
+            case '1.0.2':
+                return <V1_0_2_UI />;
             case 'current':
             default:
                 return <RhythmiaLobby />;

--- a/src/components/version/FloatingVersionSwitcher.tsx
+++ b/src/components/version/FloatingVersionSwitcher.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Settings, X, Check, Gamepad2, MessageCircle, Heart, Palette } from 'lucide-react';
+import { Settings, X, Check, Gamepad2, MessageCircle, Heart, Palette, Blocks } from 'lucide-react';
 import { useVersion } from '@/lib/version/context';
 import {
   VERSION_METADATA,
@@ -17,6 +17,7 @@ const VERSION_ICONS: Record<UIVersion, React.ReactNode> = {
   current: <Gamepad2 size={20} />,
   '1.0.0': <MessageCircle size={20} />,
   '1.0.1': <Heart size={20} />,
+  '1.0.2': <Blocks size={20} />,
 };
 
 export default function FloatingVersionSwitcher() {
@@ -27,16 +28,6 @@ export default function FloatingVersionSwitcher() {
     if (version === currentVersion) return;
     setVersion(version);
     setIsOpen(false);
-    
-    // Navigate to the appropriate page
-    // Use window.location.href for full reload to ensure clean state
-    if (version === '1.0.0') {
-      window.location.href = '/';
-    } else if (version === '1.0.1') {
-      window.location.href = '/current';
-    } else if (version === '1.0.2') {
-      window.location.href = '/';
-    }
   };
 
   const handleAccentChange = (color: AccentColor) => {

--- a/src/components/version/VersionSelector.tsx
+++ b/src/components/version/VersionSelector.tsx
@@ -2,7 +2,7 @@
 
 import { motion, AnimatePresence } from "framer-motion";
 import { UIVersion, VERSION_METADATA, UI_VERSIONS } from "@/lib/version/types";
-import { MessageCircle, Heart, Gamepad2 } from "lucide-react";
+import { MessageCircle, Heart, Blocks } from "lucide-react";
 
 interface VersionSelectorProps {
   onSelect: (version: UIVersion) => void;
@@ -16,7 +16,7 @@ export default function VersionSelector({ onSelect }: VersionSelectorProps) {
       case "1.0.1":
         return <Heart className="w-12 h-12" />;
       case "1.0.2":
-        return <Gamepad2 className="w-12 h-12" />;
+        return <Blocks className="w-12 h-12" />;
     }
   };
 
@@ -60,7 +60,7 @@ export default function VersionSelector({ onSelect }: VersionSelectorProps) {
             </motion.p>
 
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-              {UI_VERSIONS.map((version, index) => {
+              {UI_VERSIONS.filter(v => v !== 'current').map((version, index) => {
                 const metadata = VERSION_METADATA[version];
                 return (
                   <motion.button

--- a/src/lib/version/types.ts
+++ b/src/lib/version/types.ts
@@ -2,7 +2,7 @@
  * UI Version type definitions
  */
 
-export const UI_VERSIONS = ['1.0.0', '1.0.1', '1.0.2'] as const;
+export const UI_VERSIONS = ['current', '1.0.0', '1.0.1', '1.0.2'] as const;
 export type UIVersion = typeof UI_VERSIONS[number];
 
 // Alias for backward compatibility


### PR DESCRIPTION
## Summary
This PR adds support for version 1.0.2 UI and refactors the version switching mechanism by removing automatic page navigation logic from the FloatingVersionSwitcher component.

## Key Changes
- **Added v1.0.2 UI support**: Imported and integrated `V1_0_2_UI` component in the home page with proper version routing
- **Updated version icons**: Added `Blocks` icon for v1.0.2 in both `FloatingVersionSwitcher` and `VersionSelector` components
- **Refactored version switching**: Removed automatic `window.location.href` navigation from `FloatingVersionSwitcher.handleVersionChange()`, allowing version state to be managed purely through context
- **Updated version types**: Added `'current'` to the `UI_VERSIONS` array for explicit version tracking
- **Fixed VersionSelector display**: Filtered out `'current'` version from the version selection grid to show only historical versions (1.0.0, 1.0.1, 1.0.2)
- **Updated sitemap**: Regenerated with current timestamps (transitive change)

## Implementation Details
The removal of navigation logic from the version switcher suggests a shift toward client-side version management via React context rather than full page reloads. This allows for smoother transitions between UI versions and better state preservation. The `'current'` version is now explicitly included in the version type system but filtered from user-facing selection UI.

https://claude.ai/code/session_017pw7mWyUrK7rD7h2QTMcJz