### PR TITLE
Add tutorial search functionality to ForYouTab

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1155,6 +1155,8 @@
     "columnTutorials": "TUTORIALS",
     "searchTutorials": "Search tutorials...",
     "noTutorialResults": "No tutorials found",
+    "moreBelow": "+{count} more below",
+    "endOfList": "End of list",
     "types": {
       "tutorial": "TUTORIAL",
       "video": "VIDEO",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1153,6 +1153,8 @@
     "tutorialsSubtitle": "Learn techniques and strategies",
     "columnForYou": "RECOMMENDED",
     "columnTutorials": "TUTORIALS",
+    "searchTutorials": "Search tutorials...",
+    "noTutorialResults": "No tutorials found",
     "types": {
       "tutorial": "TUTORIAL",
       "video": "VIDEO",

--- a/messages/es.json
+++ b/messages/es.json
@@ -34,6 +34,8 @@
     "watchOnYouTube": "Ver en YouTube",
     "searchTutorials": "Buscar tutoriales...",
     "noTutorialResults": "No se encontraron tutoriales",
+    "moreBelow": "+{count} más abajo",
+    "endOfList": "Fin de la lista",
     "types": {
       "tutorial": "TUTORIAL",
       "video": "VIDEO",

--- a/messages/es.json
+++ b/messages/es.json
@@ -32,6 +32,8 @@
     "retry": "REINTENTAR",
     "refresh": "ACTUALIZAR",
     "watchOnYouTube": "Ver en YouTube",
+    "searchTutorials": "Buscar tutoriales...",
+    "noTutorialResults": "No se encontraron tutoriales",
     "types": {
       "tutorial": "TUTORIAL",
       "video": "VIDEO",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -84,6 +84,8 @@
     "retry": "RÉESSAYER",
     "refresh": "ACTUALISER",
     "watchOnYouTube": "Regarder sur YouTube",
+    "searchTutorials": "Rechercher des tutoriels...",
+    "noTutorialResults": "Aucun tutoriel trouvé",
     "types": {
       "tutorial": "TUTORIEL",
       "video": "VIDÉO",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -86,6 +86,8 @@
     "watchOnYouTube": "Regarder sur YouTube",
     "searchTutorials": "Rechercher des tutoriels...",
     "noTutorialResults": "Aucun tutoriel trouvé",
+    "moreBelow": "+{count} ci-dessous",
+    "endOfList": "Fin de la liste",
     "types": {
       "tutorial": "TUTORIEL",
       "video": "VIDÉO",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -134,6 +134,8 @@
         "columnTutorials": "チュートリアル",
         "searchTutorials": "チュートリアルを検索...",
         "noTutorialResults": "チュートリアルが見つかりません",
+        "moreBelow": "あと{count}件",
+        "endOfList": "リストの末尾",
         "types": {
             "tutorial": "チュートリアル",
             "video": "動画",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -132,6 +132,8 @@
         "tutorialsSubtitle": "テクニックと戦略を学ぼう",
         "columnForYou": "おすすめ",
         "columnTutorials": "チュートリアル",
+        "searchTutorials": "チュートリアルを検索...",
+        "noTutorialResults": "チュートリアルが見つかりません",
         "types": {
             "tutorial": "チュートリアル",
             "video": "動画",

--- a/messages/th.json
+++ b/messages/th.json
@@ -1015,6 +1015,8 @@
     "watchOnYouTube": "ดูบน YouTube",
     "searchTutorials": "ค้นหาบทเรียน...",
     "noTutorialResults": "ไม่พบบทเรียน",
+    "moreBelow": "อีก {count} รายการด้านล่าง",
+    "endOfList": "สิ้นสุดรายการ",
     "types": {
       "tutorial": "บทเรียน",
       "video": "วิดีโอ",

--- a/messages/th.json
+++ b/messages/th.json
@@ -1013,6 +1013,8 @@
     "retry": "ลองใหม่",
     "refresh": "รีเฟรช",
     "watchOnYouTube": "ดูบน YouTube",
+    "searchTutorials": "ค้นหาบทเรียน...",
+    "noTutorialResults": "ไม่พบบทเรียน",
     "types": {
       "tutorial": "บทเรียน",
       "video": "วิดีโอ",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://azuretier.net/blog</loc><lastmod>2026-02-18T07:02:28.498Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/shader-demo</loc><lastmod>2026-02-18T07:02:28.498Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/sns-widgets</loc><lastmod>2026-02-18T07:02:28.498Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://azuretier.net/sunphase</loc><lastmod>2026-02-18T07:02:28.498Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/blog</loc><lastmod>2026-02-19T10:10:02.189Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/shader-demo</loc><lastmod>2026-02-19T10:10:02.190Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sns-widgets</loc><lastmod>2026-02-19T10:10:02.190Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://azuretier.net/sunphase</loc><lastmod>2026-02-19T10:10:02.190Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/components/rhythmia/ForYouTab.module.css
+++ b/src/components/rhythmia/ForYouTab.module.css
@@ -310,9 +310,10 @@
     border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
-/* Scrollable viewport for tutorials to match recommended height */
+/* Scrollable viewport for tutorials — show ~2 cards with peek of 3rd */
 .tutorialViewport {
     overflow-y: auto;
+    max-height: 200px;
     scrollbar-width: thin;
     scrollbar-color: rgba(255, 255, 255, 0.08) transparent;
 }
@@ -332,6 +333,64 @@
 
 .tutorialViewport::-webkit-scrollbar-thumb:hover {
     background: rgba(255, 255, 255, 0.15);
+}
+
+/* Tutorial Search */
+.searchContainer {
+    position: relative;
+    margin-bottom: 10px;
+}
+
+.searchInput {
+    width: 100%;
+    padding: 8px 32px 8px 12px;
+    font-size: 0.7rem;
+    font-weight: 400;
+    letter-spacing: 0.05em;
+    color: rgba(255, 255, 255, 0.8);
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 4px;
+    outline: none;
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.searchInput::placeholder {
+    color: rgba(255, 255, 255, 0.2);
+    letter-spacing: 0.08em;
+}
+
+.searchInput:focus {
+    border-color: rgba(100, 180, 255, 0.3);
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.searchClear {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    color: rgba(255, 255, 255, 0.25);
+    font-size: 0.9rem;
+    cursor: pointer;
+    padding: 2px 4px;
+    line-height: 1;
+    transition: color 0.2s ease;
+}
+
+.searchClear:hover {
+    color: rgba(255, 255, 255, 0.6);
+}
+
+/* No Results */
+.noResults {
+    text-align: center;
+    padding: 20px 12px;
+    font-size: 0.7rem;
+    color: rgba(255, 255, 255, 0.25);
+    letter-spacing: 0.1em;
 }
 
 /* Tag Badge */

--- a/src/components/rhythmia/ForYouTab.module.css
+++ b/src/components/rhythmia/ForYouTab.module.css
@@ -310,10 +310,10 @@
     border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
-/* Scrollable viewport for tutorials — show ~2 cards, snap one-by-one */
+/* Scrollable viewport for tutorials — show ~3 cards, snap one-by-one */
 .tutorialViewport {
     overflow-y: auto;
-    max-height: 200px;
+    max-height: 290px;
     scroll-snap-type: y mandatory;
     scroll-behavior: smooth;
     scrollbar-width: thin;

--- a/src/components/rhythmia/ForYouTab.module.css
+++ b/src/components/rhythmia/ForYouTab.module.css
@@ -310,12 +310,18 @@
     border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
 
-/* Scrollable viewport for tutorials — show ~2 cards with peek of 3rd */
+/* Scrollable viewport for tutorials — show ~2 cards, snap one-by-one */
 .tutorialViewport {
     overflow-y: auto;
     max-height: 200px;
+    scroll-snap-type: y mandatory;
+    scroll-behavior: smooth;
     scrollbar-width: thin;
     scrollbar-color: rgba(255, 255, 255, 0.08) transparent;
+}
+
+.tutorialViewport .widget {
+    scroll-snap-align: start;
 }
 
 .tutorialViewport::-webkit-scrollbar {
@@ -391,6 +397,57 @@
     font-size: 0.7rem;
     color: rgba(255, 255, 255, 0.25);
     letter-spacing: 0.1em;
+}
+
+/* Scroll Indicator */
+.scrollIndicator {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 8px;
+    padding: 6px 4px;
+    border-top: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.scrollCount {
+    font-size: 0.55rem;
+    font-weight: 500;
+    letter-spacing: 0.12em;
+    color: rgba(255, 255, 255, 0.25);
+}
+
+.scrollNav {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.scrollBtn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 3px;
+    background: rgba(255, 255, 255, 0.02);
+    color: rgba(255, 255, 255, 0.3);
+    font-size: 0.6rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    padding: 0;
+    line-height: 1;
+}
+
+.scrollBtn:hover:not(:disabled) {
+    border-color: rgba(100, 180, 255, 0.3);
+    color: rgba(255, 255, 255, 0.7);
+    background: rgba(100, 180, 255, 0.06);
+}
+
+.scrollBtn:disabled {
+    opacity: 0.3;
+    cursor: default;
 }
 
 /* Tag Badge */

--- a/src/components/rhythmia/ForYouTab.tsx
+++ b/src/components/rhythmia/ForYouTab.tsx
@@ -149,7 +149,7 @@ export default function ForYouTab({ locale, unlockedAdvancements, totalAdvanceme
         });
 
     const CARD_HEIGHT = 90; // ~80px card + 10px gap
-    const VISIBLE_COUNT = 2;
+    const VISIBLE_COUNT = 3;
 
     // Track scroll position to compute which card is at the top
     useEffect(() => {

--- a/src/components/rhythmia/ForYouTab.tsx
+++ b/src/components/rhythmia/ForYouTab.tsx
@@ -177,6 +177,7 @@ export default function ForYouTab({ locale, unlockedAdvancements, totalAdvanceme
         const nextIndex = direction === 'down'
             ? Math.min(scrollIndex + 1, filteredTutorials.length - VISIBLE_COUNT)
             : Math.max(scrollIndex - 1, 0);
+        setScrollIndex(nextIndex);
         el.scrollTo({ top: nextIndex * CARD_HEIGHT, behavior: 'smooth' });
     }, [scrollIndex, filteredTutorials.length]);
 


### PR DESCRIPTION
## Summary
Replaced the dynamic viewport height synchronization logic with a search feature for tutorials. The right column now includes a searchable input that filters tutorials by title and tags, with a fixed viewport height instead of dynamic sizing.

## Key Changes
- **Removed dynamic height measurement**: Eliminated `useRef` and viewport height state that synchronized the tutorials column with the recommended content column
- **Added tutorial search**: Implemented a new `tutorialSearch` state with real-time filtering by tutorial title and tags
- **Added search UI**: Created a search input with a clear button in the tutorials column header
- **Fixed viewport height**: Set `tutorialViewport` to a fixed `max-height: 200px` to display approximately 2 cards with a peek of the 3rd
- **Added empty state**: Display "No tutorials found" message when search yields no results
- **Updated translations**: Added `searchTutorials` and `noTutorialResults` strings across all supported languages (en, es, fr, ja, th)

## Implementation Details
- The `filteredTutorials` computed value filters `SORTED_TUTORIALS` by checking if the tutorial title or any tag matches the search query (case-insensitive)
- Search input uses debounce-free immediate filtering for responsive UX
- Clear button only appears when search text is present
- Maintained existing animation and styling for tutorial cards
- Removed unused imports (`useRef`) to clean up dependencies

https://claude.ai/code/session_01ReFyhs5e1YhH4RoewCDkUb