### PR TITLE
Fix game-over state handling to prevent stage transitions on death

### DIFF
--- a/src/components/rhythmia/tetris/components/WorldTransition.tsx
+++ b/src/components/rhythmia/tetris/components/WorldTransition.tsx
@@ -8,6 +8,7 @@ interface WorldTransitionProps {
     worldIdx: number;
     stageNumber: number;
     terrainPhase?: TerrainPhase;
+    gameOver?: boolean;
 }
 
 /**
@@ -17,7 +18,7 @@ interface WorldTransitionProps {
  * - CHECKPOINT: Ground generating for TD phase
  * - TRANSITION: Reload/rebuild visual between stages
  */
-export function WorldTransition({ phase, worldIdx, stageNumber, terrainPhase = 'dig' }: WorldTransitionProps) {
+export function WorldTransition({ phase, worldIdx, stageNumber, terrainPhase = 'dig', gameOver = false }: WorldTransitionProps) {
     const [visible, setVisible] = useState(false);
     const [text, setText] = useState('');
     const [subText, setSubText] = useState('');
@@ -63,7 +64,14 @@ export function WorldTransition({ phase, worldIdx, stageNumber, terrainPhase = '
         }
     }, [phase, worldIdx, stageNumber, terrainPhase, isLastInWorld]);
 
-    if (!visible) return null;
+    // Immediately hide transition overlay when player dies
+    useEffect(() => {
+        if (gameOver) {
+            setVisible(false);
+        }
+    }, [gameOver]);
+
+    if (!visible || gameOver) return null;
 
     return (
         <div className={`${styles.worldTransition} ${styles[`wt_${phase.toLowerCase()}`]}`}>

--- a/src/components/rhythmia/tetris/hooks/useGameState.ts
+++ b/src/components/rhythmia/tetris/hooks/useGameState.ts
@@ -841,6 +841,9 @@ export function useGameState() {
         gamePhaseRef.current = 'COLLAPSE';
 
         setTimeout(() => {
+            // Abort transition if player died during collapse
+            if (gameOverRef.current) return;
+
             setGamePhase('CHECKPOINT');
             gamePhaseRef.current = 'CHECKPOINT';
 
@@ -859,6 +862,9 @@ export function useGameState() {
             tdBeatsRemainingRef.current = TD_WAVE_BEATS;
 
             setTimeout(() => {
+                // Abort transition if player died during checkpoint
+                if (gameOverRef.current) return;
+
                 setGamePhase('PLAYING');
                 gamePhaseRef.current = 'PLAYING';
             }, 1500);
@@ -880,10 +886,16 @@ export function useGameState() {
         bulletsRef.current = [];
 
         setTimeout(() => {
+            // Abort transition if player died during collapse
+            if (gameOverRef.current) return;
+
             setGamePhase('TRANSITION');
             gamePhaseRef.current = 'TRANSITION';
 
             setTimeout(() => {
+                // Abort transition if player died during transition
+                if (gameOverRef.current) return;
+
                 // Advance to next stage
                 const nextStage = stageNumberRef.current + 1;
                 startNewStage(nextStage);
@@ -900,6 +912,9 @@ export function useGameState() {
                 gamePhaseRef.current = 'WORLD_CREATION';
 
                 setTimeout(() => {
+                    // Abort transition if player died during world creation
+                    if (gameOverRef.current) return;
+
                     setGamePhase('PLAYING');
                     gamePhaseRef.current = 'PLAYING';
                 }, 1500);

--- a/src/components/rhythmia/tetris/tetris.tsx
+++ b/src/components/rhythmia/tetris/tetris.tsx
@@ -904,17 +904,18 @@ export default function Rhythmia({ onQuit }: RhythmiaProps) {
         // Apply damage when enemies reach the tower
         if (reached > 0) {
           const damage = reached * ENEMY_REACH_DAMAGE;
-          setTowerHealthRef.current(prev => {
-            const newHealth = Math.max(0, prev - damage);
-            if (newHealth <= 0) {
-              setGameOverRef.current(true);
-            }
-            return newHealth;
-          });
+          const newHealth = Math.max(0, towerHealthRef.current - damage);
+          towerHealthRef.current = newHealth;
+          setTowerHealthRef.current(newHealth);
+          if (newHealth <= 0) {
+            setGameOverRef.current(true);
+            gameOverRef.current = true;
+          }
         }
 
         // Check wave complete: no more spawning and all enemies dead
-        if (tdBeatsRemainingRef.current <= 0 && gamePhaseRef.current === 'PLAYING') {
+        // Skip if player just died (tower destroyed) to prevent stage transition on death
+        if (!gameOverRef.current && tdBeatsRemainingRef.current <= 0 && gamePhaseRef.current === 'PLAYING') {
           const aliveCount = enemiesRef.current.filter(e => e.alive).length;
           if (aliveCount === 0) {
             completeWaveRef.current();
@@ -1221,6 +1222,7 @@ export default function Rhythmia({ onQuit }: RhythmiaProps) {
         worldIdx={worldIdx}
         stageNumber={stageNumber}
         terrainPhase={terrainPhase}
+        gameOver={gameOver}
       />
 
       {/* Tutorial Guide — shown on first vanilla play */}


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where the game could transition to the next stage or display transition overlays even after the player's tower was destroyed. The changes ensure that once the player dies, all pending state transitions are aborted and UI overlays are immediately hidden.

## Key Changes

- **Tower health state management**: Refactored tower damage application to directly update the ref before calling setState, ensuring immediate state consistency
- **Game-over checks in state transitions**: Added `gameOverRef.current` checks in all delayed state transition callbacks (`completeWaveRef`, `completeStageRef`) to prevent phase changes after death
- **Wave completion guard**: Added a check to prevent wave completion logic from triggering when the game is already over
- **WorldTransition overlay cleanup**: 
  - Added `gameOver` prop to `WorldTransition` component
  - Immediately hide the transition overlay when player dies
  - Return null to prevent rendering when game is over
- **Ref synchronization**: Set both `gameOverRef.current` and call `setGameOverRef` when tower health reaches zero to maintain consistency across the codebase

## Implementation Details

The fix addresses a race condition where setTimeout callbacks scheduled during gameplay could execute after the player died, causing unintended state transitions. By checking `gameOverRef.current` at the start of each delayed callback, we ensure that death immediately halts all pending transitions while the UI gracefully hides any active overlays.

https://claude.ai/code/session_01ArivhKDuMQ1h7XyuxS6mzt