### PR TITLE
Debounce resize handlers to fix layout flickering during window resize

### DIFF
--- a/src/components/rhythmia/VanillaGame.tsx
+++ b/src/components/rhythmia/VanillaGame.tsx
@@ -923,7 +923,7 @@ export const Rhythmia: React.FC = () => {
     };
   }, [move, rotatePiece, hardDrop]);
 
-  // Update cell size on resize
+  // Update cell size on resize (debounced to prevent layout thrashing)
   useEffect(() => {
     const updateCellSize = () => {
       if (boardRef.current) {
@@ -935,8 +935,18 @@ export const Rhythmia: React.FC = () => {
     };
 
     updateCellSize();
-    window.addEventListener('resize', updateCellSize);
-    return () => window.removeEventListener('resize', updateCellSize);
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const debouncedUpdate = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(updateCellSize, 150);
+    };
+
+    window.addEventListener('resize', debouncedUpdate);
+    return () => {
+      if (timer) clearTimeout(timer);
+      window.removeEventListener('resize', debouncedUpdate);
+    };
   }, [gameStarted]);
 
   // Persist advancement stats and unlocks on component unmount (e.g., player leaves mid-game)

--- a/src/components/rhythmia/tetris/hooks/useDeviceType.ts
+++ b/src/components/rhythmia/tetris/hooks/useDeviceType.ts
@@ -51,16 +51,25 @@ export function useDeviceType(): DeviceInfo {
     );
 
     useEffect(() => {
+        let timer: ReturnType<typeof setTimeout> | null = null;
+
         const handleResize = () => {
-            setViewportWidth(window.innerWidth);
-            setViewportHeight(window.innerHeight);
+            if (timer) clearTimeout(timer);
+            timer = setTimeout(() => {
+                setViewportWidth(window.innerWidth);
+                setViewportHeight(window.innerHeight);
+            }, 150);
         };
 
-        handleResize();
+        // Set initial values synchronously (no debounce on mount)
+        setViewportWidth(window.innerWidth);
+        setViewportHeight(window.innerHeight);
+
         window.addEventListener('resize', handleResize);
         window.addEventListener('orientationchange', handleResize);
 
         return () => {
+            if (timer) clearTimeout(timer);
             window.removeEventListener('resize', handleResize);
             window.removeEventListener('orientationchange', handleResize);
         };

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -21,8 +21,18 @@ export function useIsMobile() {
     checkMobile();
 
     /* Re-check on resize in case of orientation change or window resize */
-    window.addEventListener('resize', checkMobile);
-    return () => window.removeEventListener('resize', checkMobile);
+    /* Debounced to prevent layout flickering during continuous resize */
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const debouncedCheck = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(checkMobile, 150);
+    };
+
+    window.addEventListener('resize', debouncedCheck);
+    return () => {
+      if (timer) clearTimeout(timer);
+      window.removeEventListener('resize', debouncedCheck);
+    };
   }, []);
 
   return isMobile;


### PR DESCRIPTION
Window resize events fire many times per second during a drag, causing the game layout to rapidly switch between breakpoints (mobile/tablet/ desktop) and recalculate cell sizes on every event. This adds 150ms debouncing to useDeviceType, useIsMobile, and the VanillaGame cell size measurement so layout only updates once resizing settles.

https://claude.ai/code/session_016ekBdHyGrwMjrk5EfpeT9H