### PR TITLE
wwwFix layout flickering by consolidating animations and removing stagge…

### DIFF
--- a/src/components/rhythmia/RhythmiaLobby.tsx
+++ b/src/components/rhythmia/RhythmiaLobby.tsx
@@ -171,328 +171,310 @@ export default function RhythmiaLobby() {
         connectMultiplayerWs();
     };
 
-    if (gameMode === 'vanilla') {
-        return (
-            <motion.div
-                className={styles.gameContainer + ' ' + styles.active}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.3 }}
-            >
-                <VanillaGame onQuit={closeGame} />
-            </motion.div>
-        );
-    }
-
-    if (gameMode === 'multiplayer') {
-        return (
-            <motion.div
-                className={styles.gameContainer + ' ' + styles.active}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.3 }}
-            >
-                <MultiplayerGame onQuit={closeGame} />
-            </motion.div>
-        );
-    }
-
     const slidesEnabled = gameMode === 'lobby' && !isLoading && !showProfileSetup && !showAdvancements && !showSkinCustomizer && !showOnlineUsers;
 
     return (
         <div className={styles.page}>
-            {/* Profile setup overlay */}
-            <AnimatePresence>
-                {showProfileSetup && <ProfileSetup />}
-            </AnimatePresence>
-
-            {/* Loading overlay */}
-            <AnimatePresence>
-                {isLoading && !showProfileSetup && (
+            {/* Game mode views */}
+            <AnimatePresence mode="wait">
+                {gameMode === 'vanilla' && (
                     <motion.div
-                        className={styles.loadingOverlay}
-                        initial={{ opacity: 1 }}
-                        exit={{ opacity: 0 }}
-                        transition={{ duration: 0.4 }}
-                    >
-                        <div className={styles.loader}></div>
-                        <div className={styles.loadingText}>{t('lobby.loading')}</div>
-                    </motion.div>
-                )}
-            </AnimatePresence>
-
-            {/* Online users panel */}
-            <AnimatePresence>
-                {showOnlineUsers && (
-                    <OnlineUsers
-                        users={onlineUsers}
-                        onClose={() => setShowOnlineUsers(false)}
-                    />
-                )}
-            </AnimatePresence>
-
-            {/* Advancements panel */}
-            <AnimatePresence>
-                {showAdvancements && (
-                    <motion.div
-                        className={styles.advOverlay}
+                        key="vanilla"
+                        className={styles.gameContainer + ' ' + styles.active}
                         initial={{ opacity: 0 }}
                         animate={{ opacity: 1 }}
                         exit={{ opacity: 0 }}
-                        transition={{ duration: 0.25 }}
+                        transition={{ duration: 0.3 }}
                     >
-                        <Advancements onClose={() => setShowAdvancements(false)} />
+                        <VanillaGame onQuit={closeGame} />
                     </motion.div>
                 )}
-            </AnimatePresence>
 
-            {/* Skin customizer panel */}
-            <AnimatePresence>
-                {showSkinCustomizer && (
-                    <SkinCustomizer onClose={() => setShowSkinCustomizer(false)} />
-                )}
-            </AnimatePresence>
-
-            {/* Slide container */}
-            <div
-                className={styles.slideContainer}
-                ref={containerRef}
-                style={slideStyle}
-            >
-                {/* Slide 0: Landing — Header + Hero + Server Grid */}
-                <section className={`${styles.slideSection} ${styles.slideSectionLanding}`}>
-                    <motion.header
-                        className={styles.header}
-                        initial={{ opacity: 0, y: -20 }}
-                        animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? -20 : 0 }}
-                        transition={{ duration: 0.6, delay: 0.1 }}
-                    >
-                        <div className={styles.logo}>azuretier<span className={styles.logoAccent}>.net</span></div>
-                        <div className={styles.statusBar}>
-                            <button
-                                className={styles.advButton}
-                                onClick={() => setShowAdvancements(true)}
-                            >
-                                {t('advancements.button', { count: unlockedCount, total: ADVANCEMENTS.length })}
-                            </button>
-                            <button
-                                className={onlineStyles.onlineButton}
-                                onClick={requestOnlineUsers}
-                            >
-                                <span className={styles.statusDot}></span>
-                                <span>{t('lobby.onlineCount', { count: onlineCount })}</span>
-                            </button>
-                            <div className={styles.statusItem}>
-                                <span>v{rhythmiaConfig.version}</span>
-                            </div>
-                            <button
-                                className={styles.advButton}
-                                onClick={() => router.push('/wiki')}
-                            >
-                                Wiki
-                            </button>
-                            <button
-                                className={styles.advButton}
-                                onClick={() => router.push('/updates')}
-                            >
-                                {t('nav.updates')}
-                            </button>
-                            <button
-                                className={styles.advButton}
-                                onClick={() => setShowSkinCustomizer(true)}
-                            >
-                                {t('skin.profileButton')}
-                            </button>
-                            <LocaleSwitcher />
-                        </div>
-                    </motion.header>
-
-                    <main className={styles.main}>
-                        <motion.div
-                            className={styles.heroText}
-                            initial={{ opacity: 0, y: 30 }}
-                            animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? 30 : 0 }}
-                            transition={{ duration: 0.7, delay: 0.2 }}
-                        >
-                            <h1>{t('lobby.selectServer')}</h1>
-                            <p>{t('lobby.chooseMode')}</p>
-                            <p className={styles.heroTagline}>{t('lobby.tagline')}</p>
-                        </motion.div>
-
-                        <div className={styles.serverGrid}>
-                            {/* Rhythmia (Solo Mode) */}
-                            <motion.div
-                                className={`${styles.serverCard} ${styles.vanilla}`}
-                                onClick={() => launchGame('vanilla')}
-                                initial={{ opacity: 0, y: 40 }}
-                                animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? 40 : 0 }}
-                                transition={{ duration: 0.6, delay: 0.3 }}
-                                whileHover={{ y: -8, transition: { duration: 0.25 } }}
-                            >
-                                <span className={styles.cardBadge}>{t('vanilla.badge')}</span>
-                                <h2 className={styles.cardTitle}>{t('vanilla.title')}</h2>
-                                <p className={styles.cardSubtitle}>{t('vanilla.subtitle')}</p>
-                                <p className={styles.cardDescription}>{t('vanilla.description')}</p>
-                                <button className={styles.playButton}>{t('lobby.play')}</button>
-                            </motion.div>
-
-                            {/* Multiplayer Server (locked until 3 advancements) */}
-                            <motion.div
-                                className={`${styles.serverCard} ${styles.multiplayer} ${isArenaLocked ? styles.lockedCard : ''}`}
-                                onClick={() => launchGame('multiplayer')}
-                                initial={{ opacity: 0, y: 40 }}
-                                animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? 40 : 0 }}
-                                transition={{ duration: 0.6, delay: 0.45 }}
-                                whileHover={isArenaLocked ? {} : { y: -8, transition: { duration: 0.25 } }}
-                            >
-                                {isArenaLocked && (
-                                    <div className={styles.lockOverlay}>
-                                        <svg className={styles.lockIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-                                            <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-                                            <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-                                        </svg>
-                                        <div className={styles.lockText}>
-                                            {t('advancements.lockMessage', {
-                                                current: unlockedCount,
-                                                required: BATTLE_ARENA_REQUIRED_ADVANCEMENTS,
-                                            })}
-                                        </div>
-                                    </div>
-                                )}
-                                <span className={`${styles.cardBadge} ${styles.new}`}>{t('multiplayer.badge')}</span>
-                                <h2 className={styles.cardTitle}>{t('multiplayer.title')}</h2>
-                                <p className={styles.cardSubtitle}>{t('multiplayer.subtitle')}</p>
-                                <p className={styles.cardDescription}>
-                                    {t('multiplayer.description')}
-                                </p>
-                                <div className={styles.cardFeatures}>
-                                    <span className={styles.featureTag}>{t('multiplayer.features.vs')}</span>
-                                    <span className={styles.featureTag}>{t('multiplayer.features.websocket')}</span>
-                                    <span className={styles.featureTag}>{t('multiplayer.features.ranked')}</span>
-                                </div>
-                                <div className={styles.cardStats}>
-                                    <div className={styles.stat}>
-                                        <div className={styles.statValue}>VS</div>
-                                        <div className={styles.statLabel}>{t('multiplayer.stats.mode')}</div>
-                                    </div>
-                                    <div className={styles.stat}>
-                                        <div className={styles.statValue}>1v1</div>
-                                        <div className={styles.statLabel}>{t('multiplayer.stats.battle')}</div>
-                                    </div>
-                                    <div className={styles.stat}>
-                                        <div className={styles.statValue}>LIVE</div>
-                                        <div className={styles.statLabel}>{t('multiplayer.stats.status')}</div>
-                                    </div>
-                                </div>
-                                <button className={`${styles.playButton} ${isArenaLocked ? styles.lockedButton : ''}`} disabled={isArenaLocked}>
-                                    {isArenaLocked ? t('advancements.locked') : t('lobby.battle')}
-                                </button>
-                            </motion.div>
-
-                            {/* 9-Player Arena */}
-                            <motion.div
-                                className={`${styles.serverCard} ${styles.multiplayer}`}
-                                onClick={() => router.push('/arena')}
-                                initial={{ opacity: 0, y: 40 }}
-                                animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? 40 : 0 }}
-                                transition={{ duration: 0.6, delay: 0.6 }}
-                                whileHover={{ y: -8, transition: { duration: 0.25 } }}
-                            >
-                                <span className={`${styles.cardBadge} ${styles.new}`}>{t('arena.badge')}</span>
-                                <h2 className={styles.cardTitle}>{t('arena.title')}</h2>
-                                <p className={styles.cardSubtitle}>{t('arena.subtitle')}</p>
-                                <p className={styles.cardDescription}>
-                                    {t('arena.description')}
-                                </p>
-                                <div className={styles.cardFeatures}>
-                                    <span className={styles.featureTag}>{t('arena.features.players')}</span>
-                                    <span className={styles.featureTag}>{t('arena.features.chaos')}</span>
-                                    <span className={styles.featureTag}>{t('arena.features.sync')}</span>
-                                </div>
-                                <div className={styles.cardStats}>
-                                    <div className={styles.stat}>
-                                        <div className={styles.statValue}>9</div>
-                                        <div className={styles.statLabel}>{t('arena.stats.players')}</div>
-                                    </div>
-                                    <div className={styles.stat}>
-                                        <div className={styles.statValue}>120+</div>
-                                        <div className={styles.statLabel}>{t('arena.stats.bpm')}</div>
-                                    </div>
-                                    <div className={styles.stat}>
-                                        <div className={styles.statValue}>LIVE</div>
-                                        <div className={styles.statLabel}>{t('arena.stats.status')}</div>
-                                    </div>
-                                </div>
-                                <button className={styles.playButton}>{t('arena.quickMatch')}</button>
-                            </motion.div>
-                        </div>
-                    </main>
-
-                    {/* Scroll hint — only visible on first slide */}
-                    <AnimatePresence>
-                        {currentSlide === 0 && slidesEnabled && (
-                            <motion.div
-                                className={styles.scrollHint}
-                                initial={{ opacity: 0 }}
-                                animate={{ opacity: 1 }}
-                                exit={{ opacity: 0 }}
-                                transition={{ duration: 0.3 }}
-                            >
-                                <svg className={styles.scrollHintIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                                    <path d="M7 13l5 5 5-5" />
-                                    <path d="M7 6l5 5 5-5" />
-                                </svg>
-                            </motion.div>
-                        )}
-                    </AnimatePresence>
-                </section>
-
-                {/* Slide 1: For You */}
-                <section
-                    className={`${styles.slideSection} ${styles.slideSectionPlay}`}
-                    data-slide-scrollable
-                >
+                {gameMode === 'multiplayer' && (
                     <motion.div
-                        className={styles.forYouSection}
-                        initial={{ opacity: 0, y: 30 }}
-                        animate={{ opacity: isLoading ? 0 : 1, y: isLoading ? 30 : 0 }}
-                        transition={{ duration: 0.6, delay: 0.7 }}
-                    >
-                        <ForYouTab
-                            locale={locale}
-                            unlockedAdvancements={unlockedCount}
-                            totalAdvancements={ADVANCEMENTS.length}
-                        />
-                    </motion.div>
-                </section>
-
-                {/* Slide 2: Loyalty + Footer */}
-                <section className={`${styles.slideSection} ${styles.slideSectionBottom}`}>
-                    <LoyaltyWidget />
-                    <motion.footer
-                        className={styles.footer}
+                        key="multiplayer"
+                        className={styles.gameContainer + ' ' + styles.active}
                         initial={{ opacity: 0 }}
-                        animate={{ opacity: isLoading ? 0 : 0.4 }}
-                        transition={{ duration: 0.6, delay: 0.6 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 0.3 }}
                     >
-                        {t('footer.copyright')}
-                    </motion.footer>
-                </section>
-            </div>
+                        <MultiplayerGame onQuit={closeGame} />
+                    </motion.div>
+                )}
 
-            {/* Dot navigation */}
-            <nav className={`${styles.slideNav} ${!slidesEnabled ? styles.slideNavHidden : ''}`}>
-                {Array.from({ length: TOTAL_SLIDES }, (_, i) => (
-                    <button
-                        key={i}
-                        className={`${styles.slideDot} ${currentSlide === i ? styles.slideDotActive : ''}`}
-                        onClick={() => goToSlide(i)}
-                        aria-label={`Go to slide ${i + 1}`}
-                    />
-                ))}
-            </nav>
+                {gameMode === 'lobby' && (
+                    <motion.div
+                        key="lobby"
+                        className={styles.lobbyContent}
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 0.3 }}
+                    >
+                        {/* Overlays — single AnimatePresence for coordinated transitions */}
+                        <AnimatePresence mode="wait">
+                            {showProfileSetup && <ProfileSetup key="profile" />}
+                            {!showProfileSetup && isLoading && (
+                                <motion.div
+                                    key="loading"
+                                    className={styles.loadingOverlay}
+                                    initial={{ opacity: 1 }}
+                                    exit={{ opacity: 0 }}
+                                    transition={{ duration: 0.4 }}
+                                >
+                                    <div className={styles.loader}></div>
+                                    <div className={styles.loadingText}>{t('lobby.loading')}</div>
+                                </motion.div>
+                            )}
+                        </AnimatePresence>
+
+                        {/* Panel overlays — separate group so they don't conflict with loading */}
+                        <AnimatePresence>
+                            {showOnlineUsers && (
+                                <OnlineUsers
+                                    key="online"
+                                    users={onlineUsers}
+                                    onClose={() => setShowOnlineUsers(false)}
+                                />
+                            )}
+                            {showAdvancements && (
+                                <motion.div
+                                    key="adv"
+                                    className={styles.advOverlay}
+                                    initial={{ opacity: 0 }}
+                                    animate={{ opacity: 1 }}
+                                    exit={{ opacity: 0 }}
+                                    transition={{ duration: 0.25 }}
+                                >
+                                    <Advancements onClose={() => setShowAdvancements(false)} />
+                                </motion.div>
+                            )}
+                            {showSkinCustomizer && (
+                                <SkinCustomizer key="skin" onClose={() => setShowSkinCustomizer(false)} />
+                            )}
+                        </AnimatePresence>
+
+                        {/* Slide container */}
+                        <div
+                            className={styles.slideContainer}
+                            ref={containerRef}
+                            style={slideStyle}
+                        >
+                            {/* Slide 0: Landing — Header + Hero + Server Grid */}
+                            <section className={`${styles.slideSection} ${styles.slideSectionLanding}`}>
+                                <header
+                                    className={`${styles.header} ${isLoading ? styles.hiddenContent : styles.visibleContent}`}
+                                >
+                                    <div className={styles.logo}>azuretier<span className={styles.logoAccent}>.net</span></div>
+                                    <div className={styles.statusBar}>
+                                        <button
+                                            className={styles.advButton}
+                                            onClick={() => setShowAdvancements(true)}
+                                        >
+                                            {t('advancements.button', { count: unlockedCount, total: ADVANCEMENTS.length })}
+                                        </button>
+                                        <button
+                                            className={onlineStyles.onlineButton}
+                                            onClick={requestOnlineUsers}
+                                        >
+                                            <span className={styles.statusDot}></span>
+                                            <span>{t('lobby.onlineCount', { count: onlineCount })}</span>
+                                        </button>
+                                        <div className={styles.statusItem}>
+                                            <span>v{rhythmiaConfig.version}</span>
+                                        </div>
+                                        <button
+                                            className={styles.advButton}
+                                            onClick={() => router.push('/wiki')}
+                                        >
+                                            Wiki
+                                        </button>
+                                        <button
+                                            className={styles.advButton}
+                                            onClick={() => router.push('/updates')}
+                                        >
+                                            {t('nav.updates')}
+                                        </button>
+                                        <button
+                                            className={styles.advButton}
+                                            onClick={() => setShowSkinCustomizer(true)}
+                                        >
+                                            {t('skin.profileButton')}
+                                        </button>
+                                        <LocaleSwitcher />
+                                    </div>
+                                </header>
+
+                                <main className={styles.main}>
+                                    <div
+                                        className={`${styles.heroText} ${isLoading ? styles.hiddenContent : styles.visibleContent}`}
+                                    >
+                                        <h1>{t('lobby.selectServer')}</h1>
+                                        <p>{t('lobby.chooseMode')}</p>
+                                        <p className={styles.heroTagline}>{t('lobby.tagline')}</p>
+                                    </div>
+
+                                    <div className={styles.serverGrid}>
+                                        {/* Rhythmia (Solo Mode) */}
+                                        <motion.div
+                                            className={`${styles.serverCard} ${styles.vanilla} ${isLoading ? styles.hiddenContent : styles.visibleContent}`}
+                                            onClick={() => launchGame('vanilla')}
+                                            whileHover={{ y: -8, transition: { duration: 0.25 } }}
+                                        >
+                                            <span className={styles.cardBadge}>{t('vanilla.badge')}</span>
+                                            <h2 className={styles.cardTitle}>{t('vanilla.title')}</h2>
+                                            <p className={styles.cardSubtitle}>{t('vanilla.subtitle')}</p>
+                                            <p className={styles.cardDescription}>{t('vanilla.description')}</p>
+                                            <button className={styles.playButton}>{t('lobby.play')}</button>
+                                        </motion.div>
+
+                                        {/* Multiplayer Server (locked until 3 advancements) */}
+                                        <motion.div
+                                            className={`${styles.serverCard} ${styles.multiplayer} ${isArenaLocked ? styles.lockedCard : ''} ${isLoading ? styles.hiddenContent : styles.visibleContent}`}
+                                            onClick={() => launchGame('multiplayer')}
+                                            whileHover={isArenaLocked ? {} : { y: -8, transition: { duration: 0.25 } }}
+                                        >
+                                            {isArenaLocked && (
+                                                <div className={styles.lockOverlay}>
+                                                    <svg className={styles.lockIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+                                                        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                                                        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                                                    </svg>
+                                                    <div className={styles.lockText}>
+                                                        {t('advancements.lockMessage', {
+                                                            current: unlockedCount,
+                                                            required: BATTLE_ARENA_REQUIRED_ADVANCEMENTS,
+                                                        })}
+                                                    </div>
+                                                </div>
+                                            )}
+                                            <span className={`${styles.cardBadge} ${styles.new}`}>{t('multiplayer.badge')}</span>
+                                            <h2 className={styles.cardTitle}>{t('multiplayer.title')}</h2>
+                                            <p className={styles.cardSubtitle}>{t('multiplayer.subtitle')}</p>
+                                            <p className={styles.cardDescription}>
+                                                {t('multiplayer.description')}
+                                            </p>
+                                            <div className={styles.cardFeatures}>
+                                                <span className={styles.featureTag}>{t('multiplayer.features.vs')}</span>
+                                                <span className={styles.featureTag}>{t('multiplayer.features.websocket')}</span>
+                                                <span className={styles.featureTag}>{t('multiplayer.features.ranked')}</span>
+                                            </div>
+                                            <div className={styles.cardStats}>
+                                                <div className={styles.stat}>
+                                                    <div className={styles.statValue}>VS</div>
+                                                    <div className={styles.statLabel}>{t('multiplayer.stats.mode')}</div>
+                                                </div>
+                                                <div className={styles.stat}>
+                                                    <div className={styles.statValue}>1v1</div>
+                                                    <div className={styles.statLabel}>{t('multiplayer.stats.battle')}</div>
+                                                </div>
+                                                <div className={styles.stat}>
+                                                    <div className={styles.statValue}>LIVE</div>
+                                                    <div className={styles.statLabel}>{t('multiplayer.stats.status')}</div>
+                                                </div>
+                                            </div>
+                                            <button className={`${styles.playButton} ${isArenaLocked ? styles.lockedButton : ''}`} disabled={isArenaLocked}>
+                                                {isArenaLocked ? t('advancements.locked') : t('lobby.battle')}
+                                            </button>
+                                        </motion.div>
+
+                                        {/* 9-Player Arena */}
+                                        <motion.div
+                                            className={`${styles.serverCard} ${styles.multiplayer} ${isLoading ? styles.hiddenContent : styles.visibleContent}`}
+                                            onClick={() => router.push('/arena')}
+                                            whileHover={{ y: -8, transition: { duration: 0.25 } }}
+                                        >
+                                            <span className={`${styles.cardBadge} ${styles.new}`}>{t('arena.badge')}</span>
+                                            <h2 className={styles.cardTitle}>{t('arena.title')}</h2>
+                                            <p className={styles.cardSubtitle}>{t('arena.subtitle')}</p>
+                                            <p className={styles.cardDescription}>
+                                                {t('arena.description')}
+                                            </p>
+                                            <div className={styles.cardFeatures}>
+                                                <span className={styles.featureTag}>{t('arena.features.players')}</span>
+                                                <span className={styles.featureTag}>{t('arena.features.chaos')}</span>
+                                                <span className={styles.featureTag}>{t('arena.features.sync')}</span>
+                                            </div>
+                                            <div className={styles.cardStats}>
+                                                <div className={styles.stat}>
+                                                    <div className={styles.statValue}>9</div>
+                                                    <div className={styles.statLabel}>{t('arena.stats.players')}</div>
+                                                </div>
+                                                <div className={styles.stat}>
+                                                    <div className={styles.statValue}>120+</div>
+                                                    <div className={styles.statLabel}>{t('arena.stats.bpm')}</div>
+                                                </div>
+                                                <div className={styles.stat}>
+                                                    <div className={styles.statValue}>LIVE</div>
+                                                    <div className={styles.statLabel}>{t('arena.stats.status')}</div>
+                                                </div>
+                                            </div>
+                                            <button className={styles.playButton}>{t('arena.quickMatch')}</button>
+                                        </motion.div>
+                                    </div>
+                                </main>
+
+                                {/* Scroll hint — only visible on first slide */}
+                                <AnimatePresence>
+                                    {currentSlide === 0 && slidesEnabled && (
+                                        <motion.div
+                                            className={styles.scrollHint}
+                                            initial={{ opacity: 0 }}
+                                            animate={{ opacity: 1 }}
+                                            exit={{ opacity: 0 }}
+                                            transition={{ duration: 0.3 }}
+                                        >
+                                            <svg className={styles.scrollHintIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                                                <path d="M7 13l5 5 5-5" />
+                                                <path d="M7 6l5 5 5-5" />
+                                            </svg>
+                                        </motion.div>
+                                    )}
+                                </AnimatePresence>
+                            </section>
+
+                            {/* Slide 1: For You */}
+                            <section
+                                className={`${styles.slideSection} ${styles.slideSectionPlay}`}
+                                data-slide-scrollable
+                            >
+                                <div
+                                    className={`${styles.forYouSection} ${isLoading ? styles.hiddenContent : styles.visibleContent}`}
+                                >
+                                    <ForYouTab
+                                        locale={locale}
+                                        unlockedAdvancements={unlockedCount}
+                                        totalAdvancements={ADVANCEMENTS.length}
+                                    />
+                                </div>
+                            </section>
+
+                            {/* Slide 2: Loyalty + Footer */}
+                            <section className={`${styles.slideSection} ${styles.slideSectionBottom}`}>
+                                <LoyaltyWidget />
+                                <footer
+                                    className={`${styles.footer} ${isLoading ? styles.hiddenContent : styles.visibleContent}`}
+                                >
+                                    {t('footer.copyright')}
+                                </footer>
+                            </section>
+                        </div>
+
+                        {/* Dot navigation */}
+                        <nav className={`${styles.slideNav} ${!slidesEnabled ? styles.slideNavHidden : ''}`}>
+                            {Array.from({ length: TOTAL_SLIDES }, (_, i) => (
+                                <button
+                                    key={i}
+                                    className={`${styles.slideDot} ${currentSlide === i ? styles.slideDotActive : ''}`}
+                                    onClick={() => goToSlide(i)}
+                                    aria-label={`Go to slide ${i + 1}`}
+                                />
+                            ))}
+                        </nav>
+                    </motion.div>
+                )}
+            </AnimatePresence>
         </div>
     );
 }

--- a/src/components/rhythmia/rhythmia.module.css
+++ b/src/components/rhythmia/rhythmia.module.css
@@ -49,6 +49,28 @@
   opacity: 0.4;
 }
 
+/* Lobby content wrapper (used by AnimatePresence for game mode transitions) */
+.lobbyContent {
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+
+/* Content visibility transitions — replaces per-element motion.div y-translations
+   that caused staggered layout shifts. A single CSS transition on opacity keeps
+   elements in-place while fading in together. */
+.hiddenContent {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.visibleContent {
+  opacity: 1;
+  pointer-events: auto;
+  transition: opacity 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
 /* Slide system */
 .slideContainer {
   transition: transform 0.8s cubic-bezier(0.65, 0, 0.35, 1);

--- a/src/components/rhythmia/tetris/hooks/useDeviceType.ts
+++ b/src/components/rhythmia/tetris/hooks/useDeviceType.ts
@@ -56,7 +56,9 @@ export function useDeviceType(): DeviceInfo {
             setViewportHeight(window.innerHeight);
         };
 
-        handleResize();
+        // Skip the initial call — state already initialized from window dimensions
+        // above. Calling handleResize() here would trigger a redundant re-render
+        // and layout recalculation on mount.
         window.addEventListener('resize', handleResize);
         window.addEventListener('orientationchange', handleResize);
 


### PR DESCRIPTION
…red y-translations

- Replace 6 separate AnimatePresence blocks with coordinated groups using mode="wait"
- Wrap lobby/vanilla/multiplayer game modes in a single AnimatePresence for clean transitions
- Replace per-element motion.div y-translation animations (y: -20, 30, 40 at staggered delays) with CSS opacity transitions that keep elements in-place, eliminating multi-step layout shifts
- Remove redundant handleResize() call on mount in useDeviceType that triggered extra layout pass

https://claude.ai/code/session_016Pu4ECdZdN5xT3haDZJ7Qp