### PR TITLE
Fix WorldTransition rendering during non-gameplay states

### DIFF
--- a/src/components/rhythmia/tetris/hooks/useGameState.ts
+++ b/src/components/rhythmia/tetris/hooks/useGameState.ts
@@ -115,7 +115,8 @@ export function useGameState() {
     const [colorTheme, setColorTheme] = useState<ColorTheme>('stage');
 
     // ===== Game Loop Phase =====
-    const [gamePhase, setGamePhase] = useState<GamePhase>('WORLD_CREATION');
+    // Start as PLAYING (inert) — WORLD_CREATION is set by initGame() when the player starts
+    const [gamePhase, setGamePhase] = useState<GamePhase>('PLAYING');
 
     // ===== Item System =====
     const [inventory, setInventory] = useState<InventoryItem[]>([]);

--- a/src/components/rhythmia/tetris/tetris.tsx
+++ b/src/components/rhythmia/tetris/tetris.tsx
@@ -1361,14 +1361,16 @@ export default function Rhythmia({ onQuit }: RhythmiaProps) {
       {/* Floating item drops from terrain */}
       <FloatingItems items={floatingItems} />
 
-      {/* World transition overlays (creation / collapse / reload) */}
-      <WorldTransition
-        phase={gamePhase}
-        worldIdx={worldIdx}
-        stageNumber={stageNumber}
-        terrainPhase={terrainPhase}
-        gameOver={gameOver}
-      />
+      {/* World transition overlays (creation / collapse / reload) — only during gameplay */}
+      {isPlaying && (
+        <WorldTransition
+          phase={gamePhase}
+          worldIdx={worldIdx}
+          stageNumber={stageNumber}
+          terrainPhase={terrainPhase}
+          gameOver={gameOver}
+        />
+      )}
 
       {/* Tutorial Guide — shown on first vanilla play */}
       {showTutorial && (


### PR DESCRIPTION
## Summary
Fixed an issue where the WorldTransition overlay component was rendering during non-gameplay states, causing visual glitches or unintended UI behavior. The component is now conditionally rendered only when the game is actively being played.

## Key Changes
- **Conditional WorldTransition rendering**: Wrapped the `<WorldTransition />` component with an `isPlaying` guard to prevent it from rendering outside of active gameplay
- **Initial game phase state**: Changed the default `gamePhase` state from `'WORLD_CREATION'` to `'PLAYING'`, with `WORLD_CREATION` now being explicitly set by `initGame()` when the player starts a new game

## Implementation Details
- The WorldTransition overlay now only displays during active gameplay (`isPlaying === true`), preventing unwanted overlay rendering during menu states or other non-gameplay phases
- The game phase initialization has been refactored to start in an inert `'PLAYING'` state, with the actual world creation phase being triggered explicitly when the player initiates a game
- Updated the comment to clarify that WorldTransition overlays are only shown during gameplay

https://claude.ai/code/session_01Nr4miVaTXB4UoyXbyxBtqs