### PR TITLE
Add Minecraft Dungeons-style isometric map system for story missions

### DIFF
--- a/src/components/rhythmia/tetris/tetris.tsx
+++ b/src/components/rhythmia/tetris/tetris.tsx
@@ -105,13 +105,14 @@ function detectTSpin(
 
 interface RhythmiaProps {
   onQuit?: () => void;
+  onGameEnd?: (stats: { score: number; lines: number; bestCombo: number }) => void;
 }
 
 /**
  * Rhythmia - A rhythm-based Tetris game with full game loop:
  * World Creation → Dig → Item Drop → Craft → Firepower → Collapse → Reload → Next World
  */
-export default function Rhythmia({ onQuit }: RhythmiaProps) {
+export default function Rhythmia({ onQuit, onGameEnd }: RhythmiaProps) {
   // Device type detection for responsive layouts
   const deviceInfo = useDeviceType();
   const { type: deviceType, isLandscape } = deviceInfo;
@@ -1020,8 +1021,14 @@ export default function Rhythmia({ onQuit }: RhythmiaProps) {
       if (result.newlyUnlockedIds.length > 0) {
         setToastIds(prev => [...prev, ...result.newlyUnlockedIds]);
       }
+      // Fire onGameEnd callback with stats for external consumers
+      onGameEnd?.({
+        score: scoreRef.current,
+        lines: linesRef.current,
+        bestCombo: gameBestComboRef.current,
+      });
     }
-  }, [gameOver]);
+  }, [gameOver, onGameEnd]);
 
   // Reset beat timing when unpausing to avoid desync
   useEffect(() => {

--- a/src/components/stories/DungeonExplorer.tsx
+++ b/src/components/stories/DungeonExplorer.tsx
@@ -1,0 +1,558 @@
+'use client';
+
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useLocale } from 'next-intl';
+import type { DungeonLocation, DungeonTile, DungeonMob, DungeonItem } from '@/data/stories/dungeons';
+import styles from './dungeonExplorer.module.css';
+
+// Tile rendering constants
+const TILE_SIZE = 40;
+
+// Tile colors
+const TILE_COLORS: Record<DungeonTile['type'], { bg: string; border: string; icon?: string }> = {
+  floor: { bg: '#3a3a4a', border: '#2a2a3a' },
+  wall: { bg: '#1a1a2a', border: '#0a0a1a' },
+  water: { bg: '#2a4a8a', border: '#1a3a6a', icon: '~' },
+  lava: { bg: '#c04020', border: '#a03010', icon: '🔥' },
+  chest: { bg: '#3a3a4a', border: '#2a2a3a', icon: '📦' },
+  door: { bg: '#6a5a2a', border: '#5a4a1a', icon: '🚪' },
+  exit: { bg: '#2a6a2a', border: '#1a5a1a', icon: '🏁' },
+  entrance: { bg: '#2a4a6a', border: '#1a3a5a', icon: '🏠' },
+  trap: { bg: '#5a3a3a', border: '#4a2a2a', icon: '⚠️' },
+  cracked_wall: { bg: '#2a2a3a', border: '#1a1a2a', icon: '🧱' },
+};
+
+// Mob visuals
+const MOB_ICONS: Record<DungeonMob['type'], string> = {
+  zombie: '🧟',
+  skeleton: '💀',
+  spider: '🕷️',
+  creeper: '💚',
+  enderman: '🟣',
+};
+
+const MOB_NAMES: Record<DungeonMob['type'], { ja: string; en: string }> = {
+  zombie: { ja: 'ゾンビ', en: 'Zombie' },
+  skeleton: { ja: 'スケルトン', en: 'Skeleton' },
+  spider: { ja: 'クモ', en: 'Spider' },
+  creeper: { ja: 'クリーパー', en: 'Creeper' },
+  enderman: { ja: 'エンダーマン', en: 'Enderman' },
+};
+
+// Item icons
+const ITEM_ICONS: Record<DungeonItem['type'], string> = {
+  key: '🗝️',
+  potion: '🧪',
+  emerald: '💎',
+  artifact: '⭐',
+  bread: '🍞',
+  arrow: '🏹',
+};
+
+interface PlayerState {
+  x: number;
+  y: number;
+  health: number;
+  maxHealth: number;
+  attack: number;
+  defense: number;
+  inventory: { type: DungeonItem['type']; name: string }[];
+  emeralds: number;
+  defeated: number;
+}
+
+interface DungeonExplorerProps {
+  location: DungeonLocation;
+  onComplete: (emeralds: number, defeated: number) => void;
+  onExit: () => void;
+}
+
+export default function DungeonExplorer({ location, onComplete, onExit }: DungeonExplorerProps) {
+  const locale = useLocale();
+  const boardRef = useRef<HTMLDivElement>(null);
+
+  // Build the tile map from dungeon data
+  const tileMap = useMemo(() => {
+    const map = new Map<string, DungeonTile>();
+    for (const tile of location.dungeonTiles) {
+      map.set(`${tile.x},${tile.y}`, tile);
+    }
+    // Fill walls for the dungeon boundary
+    for (let y = 0; y < location.dungeonHeight; y++) {
+      for (let x = 0; x < location.dungeonWidth; x++) {
+        const key = `${x},${y}`;
+        if (!map.has(key)) {
+          map.set(key, { x, y, type: 'wall' });
+        }
+      }
+    }
+    return map;
+  }, [location]);
+
+  // Find entrance tile for starting position
+  const entranceTile = useMemo(() => {
+    return location.dungeonTiles.find(t => t.type === 'entrance') || { x: 1, y: 1 };
+  }, [location]);
+
+  // Game state
+  const [player, setPlayer] = useState<PlayerState>({
+    x: entranceTile.x,
+    y: entranceTile.y,
+    health: 10,
+    maxHealth: 10,
+    attack: 2,
+    defense: 0,
+    inventory: [],
+    emeralds: 0,
+    defeated: 0,
+  });
+
+  const [mobs, setMobs] = useState<(DungeonMob & { alive: boolean })[]>(
+    () => location.dungeonMobs.map(m => ({ ...m, alive: true }))
+  );
+
+  const [items, setItems] = useState<(DungeonItem & { collected: boolean })[]>(
+    () => location.dungeonItems.map(i => ({ ...i, collected: false }))
+  );
+
+  const [openedChests, setOpenedChests] = useState<Set<string>>(new Set());
+  const [messages, setMessages] = useState<string[]>([]);
+  const [gameOver, setGameOver] = useState(false);
+  const [completed, setCompleted] = useState(false);
+  const [shakeDir, setShakeDir] = useState<string | null>(null);
+  const [revealedTraps, setRevealedTraps] = useState<Set<string>>(new Set());
+
+  const addMessage = useCallback((msg: string) => {
+    setMessages(prev => [...prev.slice(-5), msg]);
+  }, []);
+
+  // Check if a tile is walkable
+  const isWalkable = useCallback((x: number, y: number): boolean => {
+    const tile = tileMap.get(`${x},${y}`);
+    if (!tile) return false;
+    return tile.type !== 'wall' && tile.type !== 'water' && tile.type !== 'lava' && tile.type !== 'cracked_wall';
+  }, [tileMap]);
+
+  // Movement handler
+  const move = useCallback((dx: number, dy: number) => {
+    if (gameOver || completed) return;
+
+    const newX = player.x + dx;
+    const newY = player.y + dy;
+
+    if (!isWalkable(newX, newY)) {
+      setShakeDir(dx > 0 ? 'right' : dx < 0 ? 'left' : dy > 0 ? 'down' : 'up');
+      setTimeout(() => setShakeDir(null), 200);
+      return;
+    }
+
+    // Check for mob collision (combat)
+    const mobAtPos = mobs.find(m => m.alive && m.x === newX && m.y === newY);
+    if (mobAtPos) {
+      const mobName = locale === 'en' ? MOB_NAMES[mobAtPos.type].en : MOB_NAMES[mobAtPos.type].ja;
+
+      // Player attacks mob
+      const damage = Math.max(1, player.attack - 0);
+      const newMobHealth = mobAtPos.health - damage;
+
+      if (newMobHealth <= 0) {
+        // Mob defeated
+        setMobs(prev => prev.map(m =>
+          m.id === mobAtPos.id ? { ...m, alive: false } : m
+        ));
+        addMessage(`${mobName} を倒した！ (+1 ⚔️)`);
+
+        setPlayer(prev => ({
+          ...prev,
+          x: newX,
+          y: newY,
+          defeated: prev.defeated + 1,
+        }));
+
+        // Drop loot
+        if (mobAtPos.loot === 'artifact') {
+          addMessage(locale === 'en' ? 'Dropped an artifact!' : 'アーティファクトを落とした！');
+          setItems(prev => [...prev, {
+            id: `loot-${mobAtPos.id}`,
+            type: 'artifact',
+            x: newX,
+            y: newY,
+            name: locale === 'en' ? 'Artifact' : 'アーティファクト',
+            nameEn: 'Artifact',
+            collected: false,
+          }]);
+        }
+      } else {
+        // Mob survives, update health and deal damage back
+        setMobs(prev => prev.map(m =>
+          m.id === mobAtPos.id ? { ...m, health: newMobHealth } : m
+        ));
+
+        const mobDamage = Math.max(1, mobAtPos.damage - player.defense);
+        const newPlayerHealth = player.health - mobDamage;
+
+        addMessage(`${mobName} に${damage}ダメージ！ ${mobDamage}ダメージを受けた！`);
+
+        if (newPlayerHealth <= 0) {
+          setPlayer(prev => ({ ...prev, health: 0 }));
+          setGameOver(true);
+          addMessage(locale === 'en' ? 'You were defeated...' : '倒れてしまった...');
+        } else {
+          setPlayer(prev => ({ ...prev, health: newPlayerHealth }));
+        }
+
+        // Don't move into mob's tile
+        setShakeDir(dx > 0 ? 'right' : dx < 0 ? 'left' : dy > 0 ? 'down' : 'up');
+        setTimeout(() => setShakeDir(null), 200);
+        return;
+      }
+    } else {
+      // Normal movement
+      setPlayer(prev => ({ ...prev, x: newX, y: newY }));
+    }
+
+    // Check for item pickup
+    const itemAtPos = items.find(i => !i.collected && i.x === newX && i.y === newY);
+    if (itemAtPos) {
+      setItems(prev => prev.map(i =>
+        i.id === itemAtPos.id ? { ...i, collected: true } : i
+      ));
+      const itemName = locale === 'en' ? itemAtPos.nameEn : itemAtPos.name;
+
+      if (itemAtPos.type === 'emerald') {
+        setPlayer(prev => ({ ...prev, emeralds: prev.emeralds + 1 }));
+        addMessage(`💎 ${itemName} を手に入れた！`);
+      } else if (itemAtPos.type === 'potion') {
+        setPlayer(prev => ({
+          ...prev,
+          health: Math.min(prev.maxHealth, prev.health + 4),
+        }));
+        addMessage(`🧪 HP回復！ (+4)`);
+      } else if (itemAtPos.type === 'bread') {
+        setPlayer(prev => ({
+          ...prev,
+          health: Math.min(prev.maxHealth, prev.health + 2),
+        }));
+        addMessage(`🍞 HP回復！ (+2)`);
+      } else if (itemAtPos.type === 'artifact') {
+        setPlayer(prev => ({
+          ...prev,
+          attack: prev.attack + 1,
+          inventory: [...prev.inventory, { type: itemAtPos.type, name: itemName }],
+        }));
+        addMessage(`⭐ ${itemName}！ 攻撃力UP！`);
+      } else if (itemAtPos.type === 'key') {
+        setPlayer(prev => ({
+          ...prev,
+          inventory: [...prev.inventory, { type: itemAtPos.type, name: itemName }],
+        }));
+        addMessage(`🗝️ ${itemName} を手に入れた！`);
+      } else {
+        setPlayer(prev => ({
+          ...prev,
+          inventory: [...prev.inventory, { type: itemAtPos.type, name: itemName }],
+        }));
+        addMessage(`${ITEM_ICONS[itemAtPos.type]} ${itemName} を手に入れた！`);
+      }
+    }
+
+    // Check for chest
+    const chestKey = `${newX},${newY}`;
+    const tile = tileMap.get(chestKey);
+    if (tile?.type === 'chest' && !openedChests.has(chestKey)) {
+      setOpenedChests(prev => new Set(prev).add(chestKey));
+      setPlayer(prev => ({ ...prev, emeralds: prev.emeralds + 2 }));
+      addMessage(locale === 'en' ? '📦 Opened chest! (+2 💎)' : '📦 宝箱を開けた！ (+2 💎)');
+    }
+
+    // Check for trap
+    if (tile?.type === 'trap' && !revealedTraps.has(chestKey)) {
+      setRevealedTraps(prev => new Set(prev).add(chestKey));
+      const trapDamage = 2;
+      const newHealth = player.health - trapDamage;
+      if (newHealth <= 0) {
+        setPlayer(prev => ({ ...prev, health: 0, x: newX, y: newY }));
+        setGameOver(true);
+        addMessage(locale === 'en' ? 'Trap triggered! You were defeated...' : 'トラップ発動！倒れてしまった...');
+      } else {
+        setPlayer(prev => ({ ...prev, health: newHealth }));
+        addMessage(locale === 'en' ? `⚠️ Trap! (-${trapDamage} HP)` : `⚠️ トラップ！ (-${trapDamage} HP)`);
+      }
+    }
+
+    // Check for door (needs key)
+    if (tile?.type === 'door') {
+      const hasKey = player.inventory.some(i => i.type === 'key');
+      if (!hasKey) {
+        addMessage(locale === 'en' ? '🔒 Locked! Need a key.' : '🔒 鍵が必要！');
+      }
+    }
+
+    // Check for exit
+    if (tile?.type === 'exit') {
+      setCompleted(true);
+      addMessage(locale === 'en' ? '🏁 Dungeon cleared!' : '🏁 ダンジョンクリア！');
+    }
+  }, [player, mobs, items, tileMap, openedChests, revealedTraps, isWalkable, gameOver, completed, locale, addMessage]);
+
+  // Keyboard controls
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement) return;
+      switch (e.key) {
+        case 'ArrowUp': case 'w': case 'W': e.preventDefault(); move(0, -1); break;
+        case 'ArrowDown': case 's': case 'S': e.preventDefault(); move(0, 1); break;
+        case 'ArrowLeft': case 'a': case 'A': e.preventDefault(); move(-1, 0); break;
+        case 'ArrowRight': case 'd': case 'D': e.preventDefault(); move(1, 0); break;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [move]);
+
+  // Viewport offset (center on player)
+  const viewportCols = 9;
+  const viewportRows = 9;
+  const halfVP = Math.floor(viewportCols / 2);
+
+  // Render grid cells
+  const gridCells = useMemo(() => {
+    const cells: React.ReactNode[] = [];
+
+    for (let vy = 0; vy < viewportRows; vy++) {
+      for (let vx = 0; vx < viewportCols; vx++) {
+        const wx = player.x - halfVP + vx;
+        const wy = player.y - halfVP + vy;
+        const key = `${wx},${wy}`;
+
+        // Out of bounds
+        if (wx < 0 || wx >= location.dungeonWidth || wy < 0 || wy >= location.dungeonHeight) {
+          cells.push(
+            <div
+              key={`${vx}-${vy}`}
+              className={styles.tile}
+              style={{
+                left: vx * TILE_SIZE,
+                top: vy * TILE_SIZE,
+                background: '#050410',
+              }}
+            />
+          );
+          continue;
+        }
+
+        const tile = tileMap.get(key);
+        if (!tile) continue;
+
+        const colors = TILE_COLORS[tile.type];
+        const isOpened = tile.type === 'chest' && openedChests.has(key);
+        const isRevealed = tile.type === 'trap' && revealedTraps.has(key);
+
+        // Check if mob is on this tile
+        const mob = mobs.find(m => m.alive && m.x === wx && m.y === wy);
+        // Check if item is on this tile
+        const item = items.find(i => !i.collected && i.x === wx && i.y === wy);
+        // Is this the player?
+        const isPlayer = wx === player.x && wy === player.y;
+
+        cells.push(
+          <div
+            key={`${vx}-${vy}`}
+            className={`${styles.tile} ${tile.type === 'floor' || tile.type === 'entrance' || tile.type === 'exit' ? styles.walkable : ''}`}
+            style={{
+              left: vx * TILE_SIZE,
+              top: vy * TILE_SIZE,
+              background: colors.bg,
+              borderColor: colors.border,
+            }}
+            onClick={() => {
+              // Click to move (if adjacent)
+              const dx = wx - player.x;
+              const dy = wy - player.y;
+              if (Math.abs(dx) + Math.abs(dy) === 1) {
+                move(dx, dy);
+              }
+            }}
+          >
+            {/* Tile icon */}
+            {colors.icon && !isOpened && !isRevealed && tile.type !== 'trap' && (
+              <span className={styles.tileIcon}>{colors.icon}</span>
+            )}
+            {isOpened && <span className={styles.tileIcon} style={{ opacity: 0.3 }}>📦</span>}
+            {isRevealed && <span className={styles.tileIcon}>💥</span>}
+
+            {/* Item */}
+            {item && !isPlayer && (
+              <span className={styles.itemIcon}>{ITEM_ICONS[item.type]}</span>
+            )}
+
+            {/* Mob */}
+            {mob && (
+              <div className={styles.mobContainer}>
+                <span className={styles.mobIcon}>{MOB_ICONS[mob.type]}</span>
+                <div className={styles.mobHealthBar}>
+                  <div
+                    className={styles.mobHealthFill}
+                    style={{
+                      width: `${(mob.health / (location.dungeonMobs.find(m => m.id === mob.id)?.health ?? mob.health)) * 100}%`,
+                    }}
+                  />
+                </div>
+              </div>
+            )}
+
+            {/* Player */}
+            {isPlayer && (
+              <div
+                className={`${styles.player} ${shakeDir ? styles[`shake_${shakeDir}`] : ''}`}
+              >
+                ⚔️
+              </div>
+            )}
+          </div>
+        );
+      }
+    }
+    return cells;
+  }, [player, mobs, items, tileMap, openedChests, revealedTraps, location, shakeDir, halfVP, move]);
+
+  // Mobile D-pad
+  const dpadButton = (label: string, dx: number, dy: number) => (
+    <button
+      className={styles.dpadBtn}
+      onClick={() => move(dx, dy)}
+      disabled={gameOver || completed}
+    >
+      {label}
+    </button>
+  );
+
+  const locationName = locale === 'en' ? location.nameEn : location.name;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.dungeonBg} />
+      <div className={styles.scanlines} />
+
+      {/* Header */}
+      <div className={styles.header}>
+        <button className={styles.exitBtn} onClick={onExit}>
+          ← {locale === 'en' ? 'Map' : 'マップ'}
+        </button>
+        <div className={styles.headerTitle}>
+          {location.icon} {locationName}
+        </div>
+        <div className={styles.headerStats}>
+          💎 {player.emeralds} | ⚔️ {player.defeated}
+        </div>
+      </div>
+
+      {/* Player HUD */}
+      <div className={styles.hud}>
+        <div className={styles.hudRow}>
+          <span className={styles.hudLabel}>HP</span>
+          <div className={styles.healthBar}>
+            <div
+              className={styles.healthFill}
+              style={{ width: `${(player.health / player.maxHealth) * 100}%` }}
+            />
+            <span className={styles.healthText}>{player.health}/{player.maxHealth}</span>
+          </div>
+        </div>
+        <div className={styles.hudRow}>
+          <span className={styles.hudLabel}>ATK</span>
+          <span className={styles.hudValue}>{player.attack}</span>
+          <span className={styles.hudLabel}>DEF</span>
+          <span className={styles.hudValue}>{player.defense}</span>
+        </div>
+        {player.inventory.length > 0 && (
+          <div className={styles.inventoryRow}>
+            {player.inventory.map((item, i) => (
+              <span key={i} className={styles.inventoryItem}>
+                {ITEM_ICONS[item.type]}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Game board */}
+      <div className={styles.boardWrapper}>
+        <div
+          className={styles.board}
+          ref={boardRef}
+          style={{
+            width: viewportCols * TILE_SIZE,
+            height: viewportRows * TILE_SIZE,
+          }}
+        >
+          {gridCells}
+        </div>
+      </div>
+
+      {/* Message log */}
+      <div className={styles.messageLog}>
+        {messages.map((msg, i) => (
+          <div
+            key={i}
+            className={styles.message}
+            style={{ opacity: 1 - (messages.length - 1 - i) * 0.2 }}
+          >
+            {msg}
+          </div>
+        ))}
+      </div>
+
+      {/* Mobile D-pad */}
+      <div className={styles.dpad}>
+        <div className={styles.dpadRow}>
+          {dpadButton('▲', 0, -1)}
+        </div>
+        <div className={styles.dpadRow}>
+          {dpadButton('◄', -1, 0)}
+          {dpadButton('▼', 0, 1)}
+          {dpadButton('►', 1, 0)}
+        </div>
+      </div>
+
+      {/* Game over overlay */}
+      {gameOver && (
+        <div className={styles.overlay}>
+          <div className={styles.overlayContent}>
+            <div className={styles.overlayTitle}>
+              {locale === 'en' ? 'DEFEATED' : '敗北'}
+            </div>
+            <div className={styles.overlayStats}>
+              💎 {player.emeralds} | ⚔️ {player.defeated}
+            </div>
+            <button className={styles.overlayBtn} onClick={onExit}>
+              {locale === 'en' ? 'Return to Map' : 'マップに戻る'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Victory overlay */}
+      {completed && (
+        <div className={`${styles.overlay} ${styles.victoryOverlay}`}>
+          <div className={styles.overlayContent}>
+            <div className={styles.overlayTitle}>
+              {locale === 'en' ? 'DUNGEON CLEARED!' : 'ダンジョンクリア！'}
+            </div>
+            <div className={styles.overlayIcon}>🏆</div>
+            <div className={styles.overlayStats}>
+              💎 {player.emeralds} | ⚔️ {player.defeated}
+            </div>
+            <button
+              className={styles.overlayBtn}
+              onClick={() => onComplete(player.emeralds, player.defeated)}
+            >
+              {locale === 'en' ? 'Continue' : '続ける'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/stories/DungeonMap.tsx
+++ b/src/components/stories/DungeonMap.tsx
@@ -1,0 +1,455 @@
+'use client';
+
+import { useState, useMemo, useCallback } from 'react';
+import { useLocale } from 'next-intl';
+import type { DungeonLocation, DungeonProgress, LocationStatus, MapTile, MapPath } from '@/data/stories/dungeons';
+import {
+  DUNGEON_LOCATIONS, MAP_PATHS, MAP_TERRAIN,
+  MAP_WIDTH, MAP_HEIGHT, getLocationStatus,
+} from '@/data/stories/dungeons';
+import styles from './dungeonMap.module.css';
+
+// Isometric tile dimensions
+const TILE_W = 32;
+const TILE_H = 16;
+const ELEVATION_H = 6;
+
+// Convert grid coords to isometric screen position
+function toIso(gx: number, gy: number, elevation = 0): { x: number; y: number } {
+  return {
+    x: (gx - gy) * (TILE_W / 2),
+    y: (gx + gy) * (TILE_H / 2) - elevation * ELEVATION_H,
+  };
+}
+
+// Terrain tile colors (pixel-art palette)
+const TERRAIN_COLORS: Record<string, string> = {
+  grass: '#5a8f3c',
+  dirt: '#8B6914',
+  stone: '#7a7a7a',
+  water: '#3a7fbf',
+  sand: '#d4b96a',
+  snow: '#e8e8f0',
+  lava: '#e84820',
+  void: '#0a0812',
+  path: '#c4a050',
+  bridge: '#9e7a3a',
+  tree: '#2d6e2d',
+  flower: '#d85a8a',
+  rock: '#6a6a6a',
+  mushroom: '#b04040',
+};
+
+const TERRAIN_DARK: Record<string, string> = {
+  grass: '#4a7a30',
+  dirt: '#7a5a10',
+  stone: '#5a5a5a',
+  water: '#2a5f9f',
+  sand: '#c4a85a',
+  snow: '#d0d0e0',
+  lava: '#c03010',
+  void: '#060410',
+  path: '#b49040',
+  bridge: '#8e6a2a',
+  tree: '#1a5a1a',
+  flower: '#4a7a30',
+  rock: '#505050',
+  mushroom: '#4a7a30',
+};
+
+interface DungeonMapProps {
+  progress: DungeonProgress;
+  onSelectLocation: (location: DungeonLocation) => void;
+  onBack: () => void;
+}
+
+export default function DungeonMap({ progress, onSelectLocation, onBack }: DungeonMapProps) {
+  const locale = useLocale();
+  const [hoveredLocation, setHoveredLocation] = useState<string | null>(null);
+  const [cameraOffset, setCameraOffset] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
+
+  // Compute location statuses
+  const locationStatuses = useMemo(() => {
+    const statuses: Record<string, LocationStatus> = {};
+    for (const loc of DUNGEON_LOCATIONS) {
+      statuses[loc.id] = getLocationStatus(loc.id, progress);
+    }
+    return statuses;
+  }, [progress]);
+
+  // Center of the isometric map
+  const mapCenter = useMemo(() => {
+    const c = toIso(MAP_WIDTH / 2, MAP_HEIGHT / 2);
+    return { x: c.x, y: c.y };
+  }, []);
+
+  // Mouse drag for panning
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    if ((e.target as HTMLElement).closest(`.${styles.locationNode}`)) return;
+    setIsDragging(true);
+    setDragStart({ x: e.clientX - cameraOffset.x, y: e.clientY - cameraOffset.y });
+  }, [cameraOffset]);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!isDragging) return;
+    setCameraOffset({
+      x: e.clientX - dragStart.x,
+      y: e.clientY - dragStart.y,
+    });
+  }, [isDragging, dragStart]);
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  // Touch drag for mobile
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    if ((e.target as HTMLElement).closest(`.${styles.locationNode}`)) return;
+    const touch = e.touches[0];
+    setIsDragging(true);
+    setDragStart({ x: touch.clientX - cameraOffset.x, y: touch.clientY - cameraOffset.y });
+  }, [cameraOffset]);
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    if (!isDragging) return;
+    const touch = e.touches[0];
+    setCameraOffset({
+      x: touch.clientX - dragStart.x,
+      y: touch.clientY - dragStart.y,
+    });
+  }, [isDragging, dragStart]);
+
+  // Render terrain tiles
+  const terrainElements = useMemo(() => {
+    return MAP_TERRAIN.map((tile) => {
+      const pos = toIso(tile.x, tile.y, tile.elevation);
+      const color = TERRAIN_COLORS[tile.terrain] || TERRAIN_COLORS.grass;
+      const darkColor = TERRAIN_DARK[tile.terrain] || TERRAIN_DARK.grass;
+
+      // Isometric diamond shape points
+      const topY = -TILE_H / 2;
+      const bottomY = TILE_H / 2;
+      const leftX = -TILE_W / 2;
+      const rightX = TILE_W / 2;
+
+      // For elevated tiles, render side faces
+      const elevationOffset = tile.elevation * ELEVATION_H;
+
+      return (
+        <g
+          key={`${tile.x}-${tile.y}`}
+          transform={`translate(${pos.x}, ${pos.y})`}
+        >
+          {/* Left face (elevation) */}
+          {tile.elevation > 0 && (
+            <polygon
+              points={`${leftX},0 0,${bottomY} 0,${bottomY + elevationOffset} ${leftX},${elevationOffset}`}
+              fill={darkColor}
+              stroke="rgba(0,0,0,0.15)"
+              strokeWidth="0.5"
+            />
+          )}
+          {/* Right face (elevation) */}
+          {tile.elevation > 0 && (
+            <polygon
+              points={`${rightX},0 0,${bottomY} 0,${bottomY + elevationOffset} ${rightX},${elevationOffset}`}
+              fill={darkColor}
+              stroke="rgba(0,0,0,0.15)"
+              strokeWidth="0.5"
+              opacity="0.85"
+            />
+          )}
+          {/* Top face (main surface) */}
+          <polygon
+            points={`0,${topY} ${rightX},0 0,${bottomY} ${leftX},0`}
+            fill={color}
+            stroke="rgba(0,0,0,0.1)"
+            strokeWidth="0.5"
+          />
+          {/* Tree decoration */}
+          {tile.terrain === 'tree' && (
+            <>
+              <polygon
+                points="0,-14 6,-4 -6,-4"
+                fill="#1a5e1a"
+                stroke="#0a3e0a"
+                strokeWidth="0.5"
+              />
+              <polygon
+                points="0,-20 5,-10 -5,-10"
+                fill="#2a7a2a"
+                stroke="#0a3e0a"
+                strokeWidth="0.5"
+              />
+              <rect x="-1" y="-4" width="2" height="4" fill="#6a4420" />
+            </>
+          )}
+          {/* Flower decoration */}
+          {tile.terrain === 'flower' && (
+            <circle cx="0" cy="-2" r="2" fill="#e85a8a" />
+          )}
+          {/* Mushroom decoration */}
+          {tile.terrain === 'mushroom' && (
+            <>
+              <rect x="-1" y="-3" width="2" height="3" fill="#e8dac0" />
+              <ellipse cx="0" cy="-4" rx="3" ry="2" fill="#c04040" />
+            </>
+          )}
+          {/* Water shimmer */}
+          {tile.terrain === 'water' && (
+            <polygon
+              points={`0,${topY} ${rightX},0 0,${bottomY} ${leftX},0`}
+              fill="rgba(100,200,255,0.2)"
+              className={styles.waterShimmer}
+            />
+          )}
+          {/* Bridge planks */}
+          {tile.terrain === 'bridge' && (
+            <>
+              <line x1="-6" y1="-2" x2="6" y2="-2" stroke="#6a4420" strokeWidth="2" />
+              <line x1="-6" y1="2" x2="6" y2="2" stroke="#6a4420" strokeWidth="2" />
+            </>
+          )}
+        </g>
+      );
+    });
+  }, []);
+
+  // Render paths between locations
+  const pathElements = useMemo(() => {
+    return MAP_PATHS.map((path) => {
+      const fromStatus = locationStatuses[path.from];
+      const toStatus = locationStatuses[path.to];
+      const isActive = fromStatus === 'completed' || toStatus === 'completed';
+      const isLocked = toStatus === 'locked' && fromStatus !== 'completed';
+
+      const points = path.waypoints.map(wp => {
+        const pos = toIso(wp.x, wp.y);
+        return `${pos.x},${pos.y}`;
+      }).join(' ');
+
+      return (
+        <polyline
+          key={`${path.from}-${path.to}`}
+          points={points}
+          fill="none"
+          stroke={isLocked ? 'rgba(255,255,255,0.1)' : isActive ? '#FFD700' : 'rgba(255,215,0,0.3)'}
+          strokeWidth={isActive ? 3 : 2}
+          strokeDasharray={isLocked ? '4 4' : isActive ? 'none' : '6 3'}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={isActive ? styles.activePath : ''}
+        />
+      );
+    });
+  }, [locationStatuses]);
+
+  // Render location markers
+  const locationElements = useMemo(() => {
+    return DUNGEON_LOCATIONS.map((location) => {
+      const pos = toIso(location.mapX, location.mapY);
+      const status = locationStatuses[location.id];
+      const isHovered = hoveredLocation === location.id;
+      const name = locale === 'en' ? location.nameEn : location.name;
+      const desc = locale === 'en' ? location.descriptionEn : location.description;
+
+      return (
+        <g
+          key={location.id}
+          transform={`translate(${pos.x}, ${pos.y})`}
+          className={`${styles.locationNode} ${styles[`status_${status}`]}`}
+          onClick={() => {
+            if (status !== 'locked') onSelectLocation(location);
+          }}
+          onMouseEnter={() => setHoveredLocation(location.id)}
+          onMouseLeave={() => setHoveredLocation(null)}
+          style={{ cursor: status === 'locked' ? 'not-allowed' : 'pointer' }}
+        >
+          {/* Glow ring */}
+          <circle
+            cx="0"
+            cy="-4"
+            r={isHovered ? 20 : 16}
+            fill="none"
+            stroke={status === 'completed' ? '#4CAF50' : status === 'available' ? location.accentColor : 'rgba(255,255,255,0.1)'}
+            strokeWidth={isHovered ? 2.5 : 1.5}
+            opacity={status === 'locked' ? 0.3 : 0.8}
+            className={status === 'available' ? styles.pulseRing : ''}
+          />
+          {/* Base platform */}
+          <polygon
+            points="0,-12 14,-4 0,4 -14,-4"
+            fill={status === 'locked' ? '#2a2a3a' : location.accentColor}
+            stroke={status === 'locked' ? '#3a3a4a' : 'rgba(255,255,255,0.3)'}
+            strokeWidth="1"
+            opacity={status === 'locked' ? 0.5 : 1}
+          />
+          {/* Icon */}
+          <text
+            x="0"
+            y="-2"
+            textAnchor="middle"
+            fontSize="14"
+            style={{ pointerEvents: 'none' }}
+            opacity={status === 'locked' ? 0.3 : 1}
+          >
+            {status === 'locked' ? '🔒' : location.icon}
+          </text>
+          {/* Completion checkmark */}
+          {status === 'completed' && (
+            <g transform="translate(10, -16)">
+              <circle cx="0" cy="0" r="5" fill="#4CAF50" />
+              <polyline
+                points="-2,0 -1,2 3,-2"
+                fill="none"
+                stroke="white"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </g>
+          )}
+          {/* Label */}
+          <text
+            x="0"
+            y="16"
+            textAnchor="middle"
+            fill={status === 'locked' ? 'rgba(255,255,255,0.25)' : 'rgba(255,255,255,0.85)'}
+            fontSize="8"
+            fontFamily="'Press Start 2P', monospace"
+            style={{ pointerEvents: 'none' }}
+          >
+            {name}
+          </text>
+          {/* Difficulty stars */}
+          {location.difficulty > 0 && (
+            <text
+              x="0"
+              y="26"
+              textAnchor="middle"
+              fill={status === 'locked' ? 'rgba(255,215,0,0.15)' : 'rgba(255,215,0,0.7)'}
+              fontSize="6"
+              style={{ pointerEvents: 'none' }}
+            >
+              {'★'.repeat(location.difficulty)}{'☆'.repeat(5 - location.difficulty)}
+            </text>
+          )}
+
+          {/* Hover tooltip */}
+          {isHovered && status !== 'locked' && (
+            <g transform="translate(0, -36)">
+              <rect
+                x="-80"
+                y="-24"
+                width="160"
+                height="20"
+                rx="3"
+                fill="rgba(10,8,20,0.9)"
+                stroke="rgba(255,255,255,0.15)"
+                strokeWidth="1"
+              />
+              <text
+                x="0"
+                y="-12"
+                textAnchor="middle"
+                fill="rgba(255,255,255,0.7)"
+                fontSize="6"
+                fontFamily="'VT323', monospace"
+              >
+                {desc.length > 35 ? desc.slice(0, 35) + '...' : desc}
+              </text>
+            </g>
+          )}
+        </g>
+      );
+    });
+  }, [locationStatuses, hoveredLocation, locale, onSelectLocation]);
+
+  return (
+    <div
+      className={styles.mapContainer}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleMouseUp}
+    >
+      {/* Background gradient */}
+      <div className={styles.mapBg} />
+      <div className={styles.scanlines} />
+
+      {/* Map title */}
+      <div className={styles.mapHeader}>
+        <button className={styles.backButton} onClick={onBack}>
+          ← Back
+        </button>
+        <h1 className={styles.mapTitle}>MISSION SELECT</h1>
+        <div className={styles.mapStats}>
+          <span className={styles.statBadge}>
+            💎 {progress.totalEmeralds}
+          </span>
+          <span className={styles.statBadge}>
+            ⚔️ {progress.totalDefeated}
+          </span>
+        </div>
+      </div>
+
+      {/* Isometric map SVG */}
+      <svg
+        className={styles.mapSvg}
+        viewBox={`${-MAP_WIDTH * TILE_W / 2 - 60} ${-40} ${MAP_WIDTH * TILE_W + 120} ${MAP_HEIGHT * TILE_H + 100}`}
+        preserveAspectRatio="xMidYMid meet"
+        style={{
+          transform: `translate(${cameraOffset.x}px, ${cameraOffset.y}px)`,
+        }}
+      >
+        {/* Terrain tiles */}
+        <g className={styles.terrainLayer}>
+          {terrainElements}
+        </g>
+
+        {/* Paths between locations */}
+        <g className={styles.pathLayer}>
+          {pathElements}
+        </g>
+
+        {/* Location markers */}
+        <g className={styles.locationLayer}>
+          {locationElements}
+        </g>
+      </svg>
+
+      {/* Bottom info panel */}
+      {hoveredLocation && (
+        <div className={styles.infoPanel}>
+          {(() => {
+            const loc = DUNGEON_LOCATIONS.find(l => l.id === hoveredLocation);
+            if (!loc) return null;
+            const status = locationStatuses[loc.id];
+            const name = locale === 'en' ? loc.nameEn : loc.name;
+            const desc = locale === 'en' ? loc.descriptionEn : loc.description;
+            return (
+              <>
+                <div className={styles.infoPanelHeader}>
+                  <span className={styles.infoIcon}>{loc.icon}</span>
+                  <span className={styles.infoName}>{name}</span>
+                  {status === 'completed' && <span className={styles.infoComplete}>CLEARED</span>}
+                </div>
+                <div className={styles.infoDesc}>{desc}</div>
+                {loc.difficulty > 0 && (
+                  <div className={styles.infoMeta}>
+                    <span>{'★'.repeat(loc.difficulty)}{'☆'.repeat(5 - loc.difficulty)}</span>
+                    <span>~{loc.estimatedMinutes}min</span>
+                  </div>
+                )}
+              </>
+            );
+          })()}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/stories/DungeonMapVoxel.tsx
+++ b/src/components/stories/DungeonMapVoxel.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
+import { useState, useMemo, useRef, useEffect } from 'react';
 import { useLocale } from 'next-intl';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
-import { OrthographicCamera, MapControls } from '@react-three/drei';
+import { OrthographicCamera, MapControls, Html } from '@react-three/drei';
 import * as THREE from 'three';
 import type { DungeonLocation, DungeonProgress, LocationStatus, MapTile } from '@/data/stories/dungeons';
 import {
@@ -13,7 +13,7 @@ import {
 import styles from './dungeonMap.module.css';
 
 // ============================================================
-// Noise functions (reused from VoxelWorldBackground.tsx)
+// Noise functions
 // ============================================================
 
 function seededRandom(seed: number) {
@@ -47,27 +47,41 @@ function smoothNoise(x: number, z: number, seed: number): number {
   return nx0 + sz * (nx1 - nx0);
 }
 
+function fractalNoise(x: number, z: number, seed: number, octaves = 3): number {
+  let value = 0;
+  let amplitude = 1;
+  let frequency = 1;
+  let maxAmp = 0;
+  for (let i = 0; i < octaves; i++) {
+    value += smoothNoise(x * frequency, z * frequency, seed + i * 1000) * amplitude;
+    maxAmp += amplitude;
+    amplitude *= 0.5;
+    frequency *= 2;
+  }
+  return value / maxAmp;
+}
+
 // ============================================================
-// Unrailed!-style biome color palettes
+// Warm Minecraft Dungeons–inspired biome palettes
 // ============================================================
 
 type BiomePalette = { top: THREE.Color; mid: THREE.Color; deep: THREE.Color };
 
 const BIOME_PALETTES: Record<string, BiomePalette> = {
-  grass:     { top: new THREE.Color(0.42, 0.72, 0.32), mid: new THREE.Color(0.35, 0.55, 0.25), deep: new THREE.Color(0.30, 0.40, 0.20) },
-  dirt:      { top: new THREE.Color(0.65, 0.50, 0.28), mid: new THREE.Color(0.50, 0.38, 0.20), deep: new THREE.Color(0.40, 0.30, 0.15) },
-  stone:     { top: new THREE.Color(0.55, 0.55, 0.60), mid: new THREE.Color(0.40, 0.40, 0.45), deep: new THREE.Color(0.30, 0.30, 0.35) },
-  water:     { top: new THREE.Color(0.20, 0.50, 0.80), mid: new THREE.Color(0.15, 0.40, 0.70), deep: new THREE.Color(0.10, 0.30, 0.55) },
-  sand:      { top: new THREE.Color(0.85, 0.78, 0.55), mid: new THREE.Color(0.75, 0.68, 0.45), deep: new THREE.Color(0.65, 0.58, 0.38) },
-  snow:      { top: new THREE.Color(0.92, 0.93, 0.96), mid: new THREE.Color(0.80, 0.82, 0.88), deep: new THREE.Color(0.65, 0.68, 0.75) },
-  path:      { top: new THREE.Color(0.78, 0.65, 0.35), mid: new THREE.Color(0.65, 0.52, 0.28), deep: new THREE.Color(0.50, 0.40, 0.20) },
-  bridge:    { top: new THREE.Color(0.55, 0.38, 0.18), mid: new THREE.Color(0.45, 0.30, 0.14), deep: new THREE.Color(0.35, 0.22, 0.10) },
-  tree:      { top: new THREE.Color(0.22, 0.55, 0.22), mid: new THREE.Color(0.18, 0.42, 0.18), deep: new THREE.Color(0.30, 0.40, 0.20) },
-  flower:    { top: new THREE.Color(0.85, 0.45, 0.55), mid: new THREE.Color(0.35, 0.55, 0.25), deep: new THREE.Color(0.30, 0.40, 0.20) },
-  rock:      { top: new THREE.Color(0.48, 0.48, 0.52), mid: new THREE.Color(0.38, 0.38, 0.42), deep: new THREE.Color(0.28, 0.28, 0.32) },
-  mushroom:  { top: new THREE.Color(0.72, 0.28, 0.28), mid: new THREE.Color(0.35, 0.55, 0.25), deep: new THREE.Color(0.30, 0.40, 0.20) },
-  lava:      { top: new THREE.Color(0.90, 0.35, 0.10), mid: new THREE.Color(0.75, 0.25, 0.05), deep: new THREE.Color(0.50, 0.15, 0.02) },
-  void:      { top: new THREE.Color(0.08, 0.06, 0.12), mid: new THREE.Color(0.05, 0.04, 0.08), deep: new THREE.Color(0.03, 0.02, 0.05) },
+  grass:    { top: new THREE.Color('#7db044'), mid: new THREE.Color('#5e8a32'), deep: new THREE.Color('#4a6828') },
+  dirt:     { top: new THREE.Color('#b89060'), mid: new THREE.Color('#956e42'), deep: new THREE.Color('#7a5530') },
+  stone:    { top: new THREE.Color('#8a8890'), mid: new THREE.Color('#6a6870'), deep: new THREE.Color('#504e56') },
+  water:    { top: new THREE.Color('#4a90c8'), mid: new THREE.Color('#3570a0'), deep: new THREE.Color('#2a5580') },
+  sand:     { top: new THREE.Color('#d8c088'), mid: new THREE.Color('#bca068'), deep: new THREE.Color('#a08850') },
+  snow:     { top: new THREE.Color('#e8eaf0'), mid: new THREE.Color('#c8ccd8'), deep: new THREE.Color('#a0a4b0') },
+  path:     { top: new THREE.Color('#c8a868'), mid: new THREE.Color('#a88848'), deep: new THREE.Color('#886830') },
+  bridge:   { top: new THREE.Color('#8a6030'), mid: new THREE.Color('#6a4820'), deep: new THREE.Color('#503818') },
+  tree:     { top: new THREE.Color('#3a7828'), mid: new THREE.Color('#2e6020'), deep: new THREE.Color('#4a6828') },
+  flower:   { top: new THREE.Color('#d06878'), mid: new THREE.Color('#5e8a32'), deep: new THREE.Color('#4a6828') },
+  rock:     { top: new THREE.Color('#6a6870'), mid: new THREE.Color('#585660'), deep: new THREE.Color('#484650') },
+  mushroom: { top: new THREE.Color('#c04030'), mid: new THREE.Color('#5e8a32'), deep: new THREE.Color('#4a6828') },
+  lava:     { top: new THREE.Color('#e85020'), mid: new THREE.Color('#c03810'), deep: new THREE.Color('#802808') },
+  void:     { top: new THREE.Color('#181418'), mid: new THREE.Color('#100e12'), deep: new THREE.Color('#080608') },
 };
 
 function getTerrainPalette(terrain: string): BiomePalette {
@@ -82,7 +96,7 @@ function blockColor(y: number, maxY: number, palette: BiomePalette): THREE.Color
 }
 
 // ============================================================
-// Voxel world generation from MAP_TERRAIN data
+// Shared height calculation — used by terrain, tracks & beacons
 // ============================================================
 
 interface VoxelBlock {
@@ -94,6 +108,39 @@ interface VoxelBlock {
 
 const MAP_SEED = 42069;
 
+function computeTerrainHeight(tile: MapTile): number {
+  const noiseH = fractalNoise(tile.x * 0.15, tile.y * 0.15, MAP_SEED, 3);
+
+  switch (tile.terrain) {
+    case 'water':
+      return 2;
+    case 'stone':
+    case 'rock':
+      return Math.max(1, 5 + tile.elevation * 2 + Math.floor(noiseH * 5));
+    case 'tree':
+      return Math.max(1, 3 + tile.elevation + Math.floor(noiseH * 2));
+    case 'sand':
+      return Math.max(1, 2 + Math.floor(noiseH * 1.5));
+    case 'path':
+    case 'bridge':
+      return Math.max(1, 3 + tile.elevation + Math.floor(noiseH * 1.5));
+    case 'dirt':
+      return Math.max(1, 3 + tile.elevation + Math.floor(noiseH * 2));
+    default:
+      return Math.max(1, 3 + tile.elevation + Math.floor(noiseH * 3));
+  }
+}
+
+function getHeightAt(x: number, y: number): number {
+  const tile = MAP_TERRAIN.find(t => t.x === x && t.y === y);
+  if (!tile) return 3;
+  return computeTerrainHeight(tile);
+}
+
+// ============================================================
+// Terrain voxel generation — dramatic height + warm palette
+// ============================================================
+
 function generateMapVoxels(terrain: MapTile[]): { positions: Float32Array; colors: Float32Array; count: number } {
   const blocks: VoxelBlock[] = [];
   const halfX = MAP_WIDTH / 2;
@@ -103,68 +150,103 @@ function generateMapVoxels(terrain: MapTile[]): { positions: Float32Array; color
     const wx = tile.x - halfX;
     const wz = tile.y - halfZ;
     const palette = getTerrainPalette(tile.terrain);
-
-    // Base height from elevation + noise variation
-    const noiseH = smoothNoise(tile.x * 0.15, tile.y * 0.15, MAP_SEED);
-    let baseHeight = tile.elevation + 1; // min 1 block
-
-    if (tile.terrain === 'water') {
-      // Water at ground level
-      baseHeight = 1;
-    } else if (tile.terrain === 'tree') {
-      // Ground + trunk + canopy
-      baseHeight = tile.elevation + 2;
-    } else if (tile.terrain === 'rock' || tile.terrain === 'stone') {
-      baseHeight = tile.elevation + 2 + Math.floor(noiseH * 2);
-    } else {
-      baseHeight += Math.floor(noiseH * 1.5);
-    }
+    const baseHeight = computeTerrainHeight(tile);
 
     // Stack blocks vertically
     for (let y = 0; y < baseHeight; y++) {
       const col = blockColor(y, baseHeight, palette);
-      // Add slight noise variation to color (Unrailed! style)
-      const colorNoise = (noise2D(tile.x + y * 7, tile.y + y * 13, MAP_SEED + 500) - 0.5) * 0.08;
+      const colorNoise = (noise2D(tile.x + y * 7, tile.y + y * 13, MAP_SEED + 500) - 0.5) * 0.06;
       col.r = Math.max(0, Math.min(1, col.r + colorNoise));
       col.g = Math.max(0, Math.min(1, col.g + colorNoise));
       col.b = Math.max(0, Math.min(1, col.b + colorNoise));
       blocks.push({ x: wx, y, z: wz, color: col });
     }
 
-    // Trees get trunk + leaf blocks on top
+    // Trees: tall trunk + layered canopy
     if (tile.terrain === 'tree') {
-      const trunkColor = new THREE.Color(0.40, 0.28, 0.15);
-      blocks.push({ x: wx, y: baseHeight, z: wz, color: trunkColor });
-      blocks.push({ x: wx, y: baseHeight + 1, z: wz, color: trunkColor });
-      // Leaf canopy
-      const leafColor = new THREE.Color(0.25, 0.60, 0.20);
-      const leafNoise = noise2D(tile.x * 3, tile.y * 3, MAP_SEED + 999);
-      leafColor.g += leafNoise * 0.1;
-      blocks.push({ x: wx, y: baseHeight + 2, z: wz, color: leafColor });
-      // Adjacent leaves
-      for (const [dx, dz] of [[-1, 0], [1, 0], [0, -1], [0, 1]]) {
-        if (noise2D(tile.x + dx, tile.y + dz, MAP_SEED + 777) > 0.3) {
-          blocks.push({ x: wx + dx, y: baseHeight + 1, z: wz + dz, color: leafColor.clone() });
+      const detailNoise = smoothNoise(tile.x * 0.4, tile.y * 0.4, MAP_SEED + 300);
+      const trunkColor = new THREE.Color('#6a4820');
+      const trunkHeight = 2 + Math.floor(detailNoise * 2);
+
+      for (let ty = 0; ty < trunkHeight; ty++) {
+        blocks.push({ x: wx, y: baseHeight + ty, z: wz, color: trunkColor.clone() });
+      }
+
+      const canopyBase = baseHeight + trunkHeight;
+      const leafBase = new THREE.Color('#2e7a20');
+      const leafVar = noise2D(tile.x * 3, tile.y * 3, MAP_SEED + 999) * 0.08;
+
+      // Lower canopy: cross shape
+      for (const [dx, dz] of [[0, 0], [-1, 0], [1, 0], [0, -1], [0, 1]] as [number, number][]) {
+        const lc = leafBase.clone();
+        lc.g += leafVar + (noise2D(tile.x + dx, tile.y + dz, MAP_SEED + 888) - 0.5) * 0.05;
+        blocks.push({ x: wx + dx, y: canopyBase, z: wz + dz, color: lc });
+      }
+
+      // Upper canopy: center + some sides
+      blocks.push({ x: wx, y: canopyBase + 1, z: wz, color: leafBase.clone() });
+      for (const [dx, dz] of [[-1, 0], [1, 0], [0, -1], [0, 1]] as [number, number][]) {
+        if (noise2D(tile.x + dx * 2, tile.y + dz * 2, MAP_SEED + 777) > 0.4) {
+          const lc = leafBase.clone();
+          lc.g += (noise2D(tile.x + dx, tile.y + dz, MAP_SEED + 666) - 0.5) * 0.06;
+          blocks.push({ x: wx + dx, y: canopyBase + 1, z: wz + dz, color: lc });
         }
       }
     }
 
     // Mushroom caps
     if (tile.terrain === 'mushroom') {
-      const capColor = new THREE.Color(0.80, 0.25, 0.20);
-      blocks.push({ x: wx, y: baseHeight, z: wz, color: new THREE.Color(0.85, 0.82, 0.70) }); // stem
-      blocks.push({ x: wx, y: baseHeight + 1, z: wz, color: capColor });
+      blocks.push({ x: wx, y: baseHeight, z: wz, color: new THREE.Color('#e8dcc0') });
+      blocks.push({ x: wx, y: baseHeight + 1, z: wz, color: new THREE.Color('#c04030') });
+      for (const [dx, dz] of [[-1, 0], [1, 0], [0, -1], [0, 1]] as [number, number][]) {
+        if (noise2D(tile.x + dx, tile.y + dz, MAP_SEED + 444) > 0.5) {
+          blocks.push({ x: wx + dx, y: baseHeight + 1, z: wz + dz, color: new THREE.Color('#b83828') });
+        }
+      }
     }
 
-    // Flowers get a colored top block
+    // Flowers
     if (tile.terrain === 'flower') {
       const flowerColors = [
-        new THREE.Color(0.90, 0.40, 0.50),
-        new THREE.Color(0.90, 0.80, 0.30),
-        new THREE.Color(0.60, 0.40, 0.90),
+        new THREE.Color('#e06878'),
+        new THREE.Color('#e0c040'),
+        new THREE.Color('#8060d0'),
+        new THREE.Color('#e08840'),
       ];
       const idx = Math.floor(noise2D(tile.x, tile.y, MAP_SEED + 333) * flowerColors.length);
       blocks.push({ x: wx, y: baseHeight, z: wz, color: flowerColors[idx] });
+    }
+  }
+
+  // Tapered border terrain for natural cliff edges
+  const BORDER = 4;
+  for (let bx = -BORDER; bx < MAP_WIDTH + BORDER; bx++) {
+    for (let bz = -BORDER; bz < MAP_HEIGHT + BORDER; bz++) {
+      if (bx >= 0 && bx < MAP_WIDTH && bz >= 0 && bz < MAP_HEIGHT) continue;
+
+      const dx = bx < 0 ? -bx : bx >= MAP_WIDTH ? bx - MAP_WIDTH + 1 : 0;
+      const dz = bz < 0 ? -bz : bz >= MAP_HEIGHT ? bz - MAP_HEIGHT + 1 : 0;
+      const dist = Math.max(dx, dz);
+      if (dist > BORDER) continue;
+
+      // Get nearest edge tile height and taper from it
+      const edgeX = Math.max(0, Math.min(MAP_WIDTH - 1, bx));
+      const edgeZ = Math.max(0, Math.min(MAP_HEIGHT - 1, bz));
+      const edgeHeight = getHeightAt(edgeX, edgeZ);
+      const height = Math.max(1, Math.floor(edgeHeight * (1 - dist / (BORDER + 1))));
+
+      const palette = BIOME_PALETTES.grass;
+      const wx = bx - halfX;
+      const wz = bz - halfZ;
+
+      for (let y = 0; y < height; y++) {
+        const col = blockColor(y, height, palette);
+        const cn = (noise2D(bx + y * 7, bz + y * 13, MAP_SEED + 600) - 0.5) * 0.04;
+        col.r = Math.max(0, Math.min(1, col.r + cn));
+        col.g = Math.max(0, Math.min(1, col.g + cn));
+        col.b = Math.max(0, Math.min(1, col.b + cn));
+        blocks.push({ x: wx, y, z: wz, color: col });
+      }
     }
   }
 
@@ -185,37 +267,33 @@ function generateMapVoxels(terrain: MapTile[]): { positions: Float32Array; color
 }
 
 // ============================================================
-// Track/path block generation (Unrailed! railroad style)
+// Path blocks connecting locations (warm dirt-trail style)
 // ============================================================
 
 function generateTrackVoxels(locationStatuses: Record<string, LocationStatus>): { positions: Float32Array; colors: Float32Array; count: number } {
   const blocks: VoxelBlock[] = [];
   const halfX = MAP_WIDTH / 2;
   const halfZ = MAP_HEIGHT / 2;
-  const trackColor = new THREE.Color(0.45, 0.30, 0.15);
-  const railColor = new THREE.Color(0.60, 0.60, 0.65);
-  const activeRailColor = new THREE.Color(0.95, 0.85, 0.30);
+  const pathColor = new THREE.Color('#c8a060');
+  const activePathColor = new THREE.Color('#e8c878');
 
   for (const path of MAP_PATHS) {
     const fromStatus = locationStatuses[path.from];
     const toStatus = locationStatuses[path.to];
     const isActive = fromStatus === 'completed' || toStatus === 'completed';
 
-    for (let i = 0; i < path.waypoints.length; i++) {
-      const wp = path.waypoints[i];
+    for (const wp of path.waypoints) {
       const wx = wp.x - halfX;
       const wz = wp.y - halfZ;
+      const baseY = getHeightAt(wp.x, wp.y);
 
-      // Determine height at this point from terrain
-      const terrainTile = MAP_TERRAIN.find(t => t.x === wp.x && t.y === wp.y);
-      const baseY = terrainTile ? terrainTile.elevation + 1 : 1;
+      const col = isActive ? activePathColor.clone() : pathColor.clone();
+      const cn = (noise2D(wp.x * 3, wp.y * 3, MAP_SEED + 700) - 0.5) * 0.05;
+      col.r = Math.max(0, Math.min(1, col.r + cn));
+      col.g = Math.max(0, Math.min(1, col.g + cn));
+      col.b = Math.max(0, Math.min(1, col.b + cn));
 
-      // Track sleeper (wooden tie)
-      blocks.push({ x: wx, y: baseY, z: wz, color: trackColor.clone() });
-
-      // Rail on top
-      const rc = isActive ? activeRailColor.clone() : railColor.clone();
-      blocks.push({ x: wx, y: baseY + 1, z: wz, color: rc });
+      blocks.push({ x: wx, y: baseY, z: wz, color: col });
     }
   }
 
@@ -241,7 +319,7 @@ function generateTrackVoxels(locationStatuses: Record<string, LocationStatus>): 
 
 function VoxelTerrain({ data }: { data: { positions: Float32Array; colors: Float32Array; count: number } }) {
   const meshRef = useRef<THREE.InstancedMesh>(null);
-  const geo = useMemo(() => new THREE.BoxGeometry(0.92, 0.92, 0.92), []);
+  const geo = useMemo(() => new THREE.BoxGeometry(0.95, 0.95, 0.95), []);
   const mat = useMemo(() => new THREE.MeshStandardMaterial({
     roughness: 0.75,
     metalness: 0.05,
@@ -278,10 +356,10 @@ function VoxelTerrain({ data }: { data: { positions: Float32Array; colors: Float
 
 function TrackBlocks({ data }: { data: { positions: Float32Array; colors: Float32Array; count: number } }) {
   const meshRef = useRef<THREE.InstancedMesh>(null);
-  const geo = useMemo(() => new THREE.BoxGeometry(0.7, 0.4, 0.7), []);
+  const geo = useMemo(() => new THREE.BoxGeometry(0.85, 0.35, 0.85), []);
   const mat = useMemo(() => new THREE.MeshStandardMaterial({
-    roughness: 0.6,
-    metalness: 0.2,
+    roughness: 0.7,
+    metalness: 0.05,
     flatShading: true,
   }), []);
 
@@ -295,7 +373,7 @@ function TrackBlocks({ data }: { data: { positions: Float32Array; colors: Float3
     for (let i = 0; i < data.count; i++) {
       dummy.position.set(
         data.positions[i * 3],
-        data.positions[i * 3 + 1] + 0.2,
+        data.positions[i * 3 + 1] + 0.15,
         data.positions[i * 3 + 2],
       );
       dummy.updateMatrix();
@@ -313,11 +391,15 @@ function TrackBlocks({ data }: { data: { positions: Float32Array; colors: Float3
   );
 }
 
-// Location marker beacon
+// ============================================================
+// Location beacon + floating HTML label
+// ============================================================
+
 function LocationBeacon({
   location,
   status,
   isHovered,
+  locale,
   onClick,
   onPointerEnter,
   onPointerLeave,
@@ -325,122 +407,106 @@ function LocationBeacon({
   location: DungeonLocation;
   status: LocationStatus;
   isHovered: boolean;
+  locale: string;
   onClick: () => void;
   onPointerEnter: () => void;
   onPointerLeave: () => void;
 }) {
-  const groupRef = useRef<THREE.Group>(null);
+  const markerRef = useRef<THREE.Group>(null);
   const halfX = MAP_WIDTH / 2;
   const halfZ = MAP_HEIGHT / 2;
 
   const wx = location.mapX - halfX;
   const wz = location.mapY - halfZ;
+  const terrainHeight = getHeightAt(location.mapX, location.mapY);
+  const baseY = terrainHeight + 1;
 
-  // Determine base height from terrain
-  const terrainTile = MAP_TERRAIN.find(t => t.x === location.mapX && t.y === location.mapY);
-  const baseY = terrainTile ? terrainTile.elevation + 2 : 2;
+  const name = locale === 'en' ? location.nameEn : location.name;
+  const accentColor = new THREE.Color(location.accentColor);
 
-  // Animate beacon
+  const markerColor = status === 'locked'
+    ? new THREE.Color(0.35, 0.35, 0.38)
+    : status === 'completed'
+      ? new THREE.Color(0.35, 0.72, 0.35)
+      : accentColor;
+
+  const emissiveColor = status === 'available'
+    ? accentColor
+    : status === 'completed'
+      ? new THREE.Color(0.2, 0.6, 0.2)
+      : new THREE.Color(0, 0, 0);
+  const emissiveIntensity = status === 'locked' ? 0 : isHovered ? 1.5 : 0.7;
+  const scale = isHovered && status !== 'locked' ? 1.12 : 1;
+
+  // Gentle float animation for available locations
   useFrame(({ clock }) => {
-    if (!groupRef.current) return;
+    if (!markerRef.current) return;
     if (status === 'available') {
-      groupRef.current.position.y = baseY + Math.sin(clock.elapsedTime * 2) * 0.15;
+      markerRef.current.position.y = Math.sin(clock.elapsedTime * 2) * 0.15;
     }
   });
 
-  const accentColor = new THREE.Color(location.accentColor);
-
-  // Colors based on status
-  const pillarColor = status === 'locked'
-    ? new THREE.Color(0.2, 0.2, 0.25)
-    : status === 'completed'
-      ? new THREE.Color(0.3, 0.7, 0.3)
-      : accentColor;
-
-  const emissiveColor = status === 'available' ? accentColor : status === 'completed' ? new THREE.Color(0.2, 0.6, 0.2) : new THREE.Color(0, 0, 0);
-  const emissiveIntensity = status === 'locked' ? 0 : isHovered ? 1.2 : 0.6;
-  const scale = isHovered && status !== 'locked' ? 1.15 : 1;
-
   return (
     <group
-      ref={groupRef}
       position={[wx, baseY, wz]}
-      scale={[scale, scale, scale]}
       onClick={(e) => { e.stopPropagation(); if (status !== 'locked') onClick(); }}
       onPointerEnter={(e) => { e.stopPropagation(); onPointerEnter(); }}
       onPointerLeave={(e) => { e.stopPropagation(); onPointerLeave(); }}
     >
-      {/* Base pillar blocks */}
-      <mesh position={[0, 0, 0]} castShadow>
-        <boxGeometry args={[0.8, 0.8, 0.8]} />
-        <meshStandardMaterial
-          color={pillarColor}
-          roughness={0.6}
-          flatShading
-        />
-      </mesh>
-      <mesh position={[0, 0.8, 0]} castShadow>
-        <boxGeometry args={[0.7, 0.7, 0.7]} />
-        <meshStandardMaterial
-          color={pillarColor}
-          roughness={0.6}
-          flatShading
-        />
-      </mesh>
-      <mesh position={[0, 1.5, 0]} castShadow>
-        <boxGeometry args={[0.6, 0.6, 0.6]} />
-        <meshStandardMaterial
-          color={pillarColor}
-          roughness={0.6}
-          flatShading
-        />
-      </mesh>
+      {/* Glowing marker block */}
+      <group ref={markerRef} scale={[scale, scale, scale]}>
+        <mesh castShadow>
+          <boxGeometry args={[0.9, 0.9, 0.9]} />
+          <meshStandardMaterial
+            color={markerColor}
+            emissive={emissiveColor}
+            emissiveIntensity={emissiveIntensity}
+            roughness={0.3}
+            metalness={0.2}
+            flatShading
+          />
+        </mesh>
 
-      {/* Top beacon block (emissive) */}
-      <mesh position={[0, 2.2, 0]}>
-        <boxGeometry args={[0.5, 0.5, 0.5]} />
-        <meshStandardMaterial
-          color={pillarColor}
-          emissive={emissiveColor}
-          emissiveIntensity={emissiveIntensity}
-          roughness={0.3}
-          metalness={0.3}
-        />
-      </mesh>
+        {/* Point light for glow */}
+        {status !== 'locked' && (
+          <pointLight
+            position={[0, 1.2, 0]}
+            color={markerColor}
+            intensity={isHovered ? 3 : 1.2}
+            distance={8}
+          />
+        )}
+      </group>
 
-      {/* Point light for available/completed */}
-      {status !== 'locked' && (
-        <pointLight
-          position={[0, 2.8, 0]}
-          color={pillarColor}
-          intensity={isHovered ? 2 : 0.8}
-          distance={6}
-        />
-      )}
-
-      {/* Completed flag */}
-      {status === 'completed' && (
-        <group position={[0.5, 2.5, 0]}>
-          <mesh>
-            <boxGeometry args={[0.08, 1.2, 0.08]} />
-            <meshStandardMaterial color="#5a3a1a" flatShading />
-          </mesh>
-          <mesh position={[0.25, 0.4, 0]}>
-            <boxGeometry args={[0.5, 0.35, 0.05]} />
-            <meshStandardMaterial color="#4CAF50" emissive="#2a7a2a" emissiveIntensity={0.3} flatShading />
-          </mesh>
-        </group>
-      )}
+      {/* Floating HTML label */}
+      <Html
+        position={[0, 2.8, 0]}
+        center
+        style={{ pointerEvents: 'none' }}
+      >
+        <div className={`${styles.locationLabel} ${status === 'locked' ? styles.locationLocked : ''} ${isHovered ? styles.locationHovered : ''}`}>
+          <div
+            className={styles.locationIconBadge}
+            style={{ borderColor: status === 'locked' ? '#555' : location.accentColor }}
+          >
+            {location.icon}
+          </div>
+          <div className={styles.locationLabelName}>{name}</div>
+          {status === 'completed' && (
+            <div className={styles.locationCleared}>✓</div>
+          )}
+        </div>
+      </Html>
     </group>
   );
 }
 
-// Camera controller - auto-frame the map on mount
+// Camera controller
 function CameraSetup() {
   const { camera } = useThree();
   useEffect(() => {
-    camera.position.set(18, 18, 18);
-    camera.lookAt(0, 0, 0);
+    camera.position.set(20, 22, 20);
+    camera.lookAt(0, 3, 0);
   }, [camera]);
   return null;
 }
@@ -481,52 +547,52 @@ export default function DungeonMapVoxel({ progress, onSelectLocation, onBack }: 
       <Canvas
         className={styles.mapCanvas}
         shadows
-        gl={{ antialias: true, alpha: true }}
+        gl={{ antialias: true, alpha: false }}
         style={{ position: 'absolute', inset: 0 }}
       >
+        <color attach="background" args={['#1e1812']} />
         <CameraSetup />
         <OrthographicCamera
           makeDefault
-          position={[18, 18, 18]}
-          zoom={28}
+          position={[20, 22, 20]}
+          zoom={22}
           near={0.1}
           far={200}
         />
 
-        {/* Lighting */}
-        <ambientLight intensity={1.2} />
+        {/* Warm, bright lighting — like sunlit diorama */}
+        <ambientLight intensity={1.6} color="#fff8f0" />
+        <hemisphereLight args={['#ffeedd', '#556644', 0.6]} />
         <directionalLight
-          position={[15, 25, 10]}
-          intensity={2.0}
+          position={[15, 30, 10]}
+          intensity={2.5}
+          color="#fff0d8"
           castShadow
-          shadow-mapSize-width={1024}
-          shadow-mapSize-height={1024}
+          shadow-mapSize-width={2048}
+          shadow-mapSize-height={2048}
           shadow-camera-near={0.5}
-          shadow-camera-far={80}
-          shadow-camera-left={-20}
-          shadow-camera-right={20}
-          shadow-camera-top={20}
-          shadow-camera-bottom={-20}
+          shadow-camera-far={100}
+          shadow-camera-left={-25}
+          shadow-camera-right={25}
+          shadow-camera-top={25}
+          shadow-camera-bottom={-25}
         />
         <directionalLight
-          position={[-10, 10, -5]}
-          intensity={0.8}
-          color="#aabbff"
+          position={[-10, 15, -5]}
+          intensity={0.6}
+          color="#ffd8a0"
         />
 
-        {/* Subtle fog for depth — pushed far back so terrain stays bright */}
-        <fog attach="fog" args={['#0a0812', 55, 90]} />
-
-        {/* Ground plane */}
+        {/* Ground plane — warm dark below terrain */}
         <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.5, 0]} receiveShadow>
-          <planeGeometry args={[60, 60]} />
-          <meshStandardMaterial color="#2a3a2a" roughness={1} />
+          <planeGeometry args={[80, 80]} />
+          <meshStandardMaterial color="#1a1410" roughness={1} />
         </mesh>
 
         {/* Terrain voxels */}
         <VoxelTerrain data={terrainData} />
 
-        {/* Track/path voxels */}
+        {/* Path blocks */}
         <TrackBlocks data={trackData} />
 
         {/* Location beacons */}
@@ -536,6 +602,7 @@ export default function DungeonMapVoxel({ progress, onSelectLocation, onBack }: 
             location={location}
             status={locationStatuses[location.id]}
             isHovered={hoveredLocation === location.id}
+            locale={locale}
             onClick={() => {
               if (locationStatuses[location.id] !== 'locked') {
                 onSelectLocation(location);
@@ -550,15 +617,12 @@ export default function DungeonMapVoxel({ progress, onSelectLocation, onBack }: 
         <MapControls
           enableRotate={false}
           enableZoom={true}
-          minZoom={15}
-          maxZoom={60}
+          minZoom={12}
+          maxZoom={50}
           panSpeed={1.5}
           screenSpacePanning
         />
       </Canvas>
-
-      {/* Scanlines overlay */}
-      <div className={styles.scanlines} />
 
       {/* Header */}
       <div className={styles.mapHeader}>
@@ -583,13 +647,13 @@ export default function DungeonMapVoxel({ progress, onSelectLocation, onBack }: 
             const loc = DUNGEON_LOCATIONS.find(l => l.id === hoveredLocation);
             if (!loc) return null;
             const status = locationStatuses[loc.id];
-            const name = locale === 'en' ? loc.nameEn : loc.name;
+            const locName = locale === 'en' ? loc.nameEn : loc.name;
             const desc = locale === 'en' ? loc.descriptionEn : loc.description;
             return (
               <>
                 <div className={styles.infoPanelHeader}>
                   <span className={styles.infoIcon}>{loc.icon}</span>
-                  <span className={styles.infoName}>{name}</span>
+                  <span className={styles.infoName}>{locName}</span>
                   {status === 'completed' && <span className={styles.infoComplete}>CLEARED</span>}
                 </div>
                 <div className={styles.infoDesc}>{desc}</div>

--- a/src/components/stories/DungeonMapVoxel.tsx
+++ b/src/components/stories/DungeonMapVoxel.tsx
@@ -246,7 +246,6 @@ function VoxelTerrain({ data }: { data: { positions: Float32Array; colors: Float
     roughness: 0.75,
     metalness: 0.05,
     flatShading: true,
-    vertexColors: true,
   }), []);
 
   useEffect(() => {
@@ -284,7 +283,6 @@ function TrackBlocks({ data }: { data: { positions: Float32Array; colors: Float3
     roughness: 0.6,
     metalness: 0.2,
     flatShading: true,
-    vertexColors: true,
   }), []);
 
   useEffect(() => {

--- a/src/components/stories/DungeonMapVoxel.tsx
+++ b/src/components/stories/DungeonMapVoxel.tsx
@@ -1,0 +1,611 @@
+'use client';
+
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
+import { useLocale } from 'next-intl';
+import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { OrthographicCamera, MapControls } from '@react-three/drei';
+import * as THREE from 'three';
+import type { DungeonLocation, DungeonProgress, LocationStatus, MapTile } from '@/data/stories/dungeons';
+import {
+  DUNGEON_LOCATIONS, MAP_PATHS, MAP_TERRAIN,
+  MAP_WIDTH, MAP_HEIGHT, getLocationStatus,
+} from '@/data/stories/dungeons';
+import styles from './dungeonMap.module.css';
+
+// ============================================================
+// Noise functions (reused from VoxelWorldBackground.tsx)
+// ============================================================
+
+function seededRandom(seed: number) {
+  let s = seed;
+  return () => {
+    s = (s * 16807 + 0) % 2147483647;
+    return (s - 1) / 2147483646;
+  };
+}
+
+function noise2D(x: number, z: number, seed: number): number {
+  const rand = seededRandom(
+    Math.floor(x * 73856093) ^ Math.floor(z * 19349663) ^ seed
+  );
+  return rand();
+}
+
+function smoothNoise(x: number, z: number, seed: number): number {
+  const ix = Math.floor(x);
+  const iz = Math.floor(z);
+  const fx = x - ix;
+  const fz = z - iz;
+  const sx = fx * fx * (3 - 2 * fx);
+  const sz = fz * fz * (3 - 2 * fz);
+  const n00 = noise2D(ix, iz, seed);
+  const n10 = noise2D(ix + 1, iz, seed);
+  const n01 = noise2D(ix, iz + 1, seed);
+  const n11 = noise2D(ix + 1, iz + 1, seed);
+  const nx0 = n00 + sx * (n10 - n00);
+  const nx1 = n01 + sx * (n11 - n01);
+  return nx0 + sz * (nx1 - nx0);
+}
+
+// ============================================================
+// Unrailed!-style biome color palettes
+// ============================================================
+
+type BiomePalette = { top: THREE.Color; mid: THREE.Color; deep: THREE.Color };
+
+const BIOME_PALETTES: Record<string, BiomePalette> = {
+  grass:     { top: new THREE.Color(0.42, 0.72, 0.32), mid: new THREE.Color(0.35, 0.55, 0.25), deep: new THREE.Color(0.30, 0.40, 0.20) },
+  dirt:      { top: new THREE.Color(0.65, 0.50, 0.28), mid: new THREE.Color(0.50, 0.38, 0.20), deep: new THREE.Color(0.40, 0.30, 0.15) },
+  stone:     { top: new THREE.Color(0.55, 0.55, 0.60), mid: new THREE.Color(0.40, 0.40, 0.45), deep: new THREE.Color(0.30, 0.30, 0.35) },
+  water:     { top: new THREE.Color(0.20, 0.50, 0.80), mid: new THREE.Color(0.15, 0.40, 0.70), deep: new THREE.Color(0.10, 0.30, 0.55) },
+  sand:      { top: new THREE.Color(0.85, 0.78, 0.55), mid: new THREE.Color(0.75, 0.68, 0.45), deep: new THREE.Color(0.65, 0.58, 0.38) },
+  snow:      { top: new THREE.Color(0.92, 0.93, 0.96), mid: new THREE.Color(0.80, 0.82, 0.88), deep: new THREE.Color(0.65, 0.68, 0.75) },
+  path:      { top: new THREE.Color(0.78, 0.65, 0.35), mid: new THREE.Color(0.65, 0.52, 0.28), deep: new THREE.Color(0.50, 0.40, 0.20) },
+  bridge:    { top: new THREE.Color(0.55, 0.38, 0.18), mid: new THREE.Color(0.45, 0.30, 0.14), deep: new THREE.Color(0.35, 0.22, 0.10) },
+  tree:      { top: new THREE.Color(0.22, 0.55, 0.22), mid: new THREE.Color(0.18, 0.42, 0.18), deep: new THREE.Color(0.30, 0.40, 0.20) },
+  flower:    { top: new THREE.Color(0.85, 0.45, 0.55), mid: new THREE.Color(0.35, 0.55, 0.25), deep: new THREE.Color(0.30, 0.40, 0.20) },
+  rock:      { top: new THREE.Color(0.48, 0.48, 0.52), mid: new THREE.Color(0.38, 0.38, 0.42), deep: new THREE.Color(0.28, 0.28, 0.32) },
+  mushroom:  { top: new THREE.Color(0.72, 0.28, 0.28), mid: new THREE.Color(0.35, 0.55, 0.25), deep: new THREE.Color(0.30, 0.40, 0.20) },
+  lava:      { top: new THREE.Color(0.90, 0.35, 0.10), mid: new THREE.Color(0.75, 0.25, 0.05), deep: new THREE.Color(0.50, 0.15, 0.02) },
+  void:      { top: new THREE.Color(0.08, 0.06, 0.12), mid: new THREE.Color(0.05, 0.04, 0.08), deep: new THREE.Color(0.03, 0.02, 0.05) },
+};
+
+function getTerrainPalette(terrain: string): BiomePalette {
+  return BIOME_PALETTES[terrain] || BIOME_PALETTES.grass;
+}
+
+function blockColor(y: number, maxY: number, palette: BiomePalette): THREE.Color {
+  const t = maxY > 1 ? y / (maxY - 1) : 1;
+  if (t > 0.7) return palette.top.clone();
+  if (t > 0.3) return palette.mid.clone();
+  return palette.deep.clone();
+}
+
+// ============================================================
+// Voxel world generation from MAP_TERRAIN data
+// ============================================================
+
+interface VoxelBlock {
+  x: number;
+  y: number;
+  z: number;
+  color: THREE.Color;
+}
+
+const MAP_SEED = 42069;
+
+function generateMapVoxels(terrain: MapTile[]): { positions: Float32Array; colors: Float32Array; count: number } {
+  const blocks: VoxelBlock[] = [];
+  const halfX = MAP_WIDTH / 2;
+  const halfZ = MAP_HEIGHT / 2;
+
+  for (const tile of terrain) {
+    const wx = tile.x - halfX;
+    const wz = tile.y - halfZ;
+    const palette = getTerrainPalette(tile.terrain);
+
+    // Base height from elevation + noise variation
+    const noiseH = smoothNoise(tile.x * 0.15, tile.y * 0.15, MAP_SEED);
+    let baseHeight = tile.elevation + 1; // min 1 block
+
+    if (tile.terrain === 'water') {
+      // Water at ground level
+      baseHeight = 1;
+    } else if (tile.terrain === 'tree') {
+      // Ground + trunk + canopy
+      baseHeight = tile.elevation + 2;
+    } else if (tile.terrain === 'rock' || tile.terrain === 'stone') {
+      baseHeight = tile.elevation + 2 + Math.floor(noiseH * 2);
+    } else {
+      baseHeight += Math.floor(noiseH * 1.5);
+    }
+
+    // Stack blocks vertically
+    for (let y = 0; y < baseHeight; y++) {
+      const col = blockColor(y, baseHeight, palette);
+      // Add slight noise variation to color (Unrailed! style)
+      const colorNoise = (noise2D(tile.x + y * 7, tile.y + y * 13, MAP_SEED + 500) - 0.5) * 0.08;
+      col.r = Math.max(0, Math.min(1, col.r + colorNoise));
+      col.g = Math.max(0, Math.min(1, col.g + colorNoise));
+      col.b = Math.max(0, Math.min(1, col.b + colorNoise));
+      blocks.push({ x: wx, y, z: wz, color: col });
+    }
+
+    // Trees get trunk + leaf blocks on top
+    if (tile.terrain === 'tree') {
+      const trunkColor = new THREE.Color(0.40, 0.28, 0.15);
+      blocks.push({ x: wx, y: baseHeight, z: wz, color: trunkColor });
+      blocks.push({ x: wx, y: baseHeight + 1, z: wz, color: trunkColor });
+      // Leaf canopy
+      const leafColor = new THREE.Color(0.25, 0.60, 0.20);
+      const leafNoise = noise2D(tile.x * 3, tile.y * 3, MAP_SEED + 999);
+      leafColor.g += leafNoise * 0.1;
+      blocks.push({ x: wx, y: baseHeight + 2, z: wz, color: leafColor });
+      // Adjacent leaves
+      for (const [dx, dz] of [[-1, 0], [1, 0], [0, -1], [0, 1]]) {
+        if (noise2D(tile.x + dx, tile.y + dz, MAP_SEED + 777) > 0.3) {
+          blocks.push({ x: wx + dx, y: baseHeight + 1, z: wz + dz, color: leafColor.clone() });
+        }
+      }
+    }
+
+    // Mushroom caps
+    if (tile.terrain === 'mushroom') {
+      const capColor = new THREE.Color(0.80, 0.25, 0.20);
+      blocks.push({ x: wx, y: baseHeight, z: wz, color: new THREE.Color(0.85, 0.82, 0.70) }); // stem
+      blocks.push({ x: wx, y: baseHeight + 1, z: wz, color: capColor });
+    }
+
+    // Flowers get a colored top block
+    if (tile.terrain === 'flower') {
+      const flowerColors = [
+        new THREE.Color(0.90, 0.40, 0.50),
+        new THREE.Color(0.90, 0.80, 0.30),
+        new THREE.Color(0.60, 0.40, 0.90),
+      ];
+      const idx = Math.floor(noise2D(tile.x, tile.y, MAP_SEED + 333) * flowerColors.length);
+      blocks.push({ x: wx, y: baseHeight, z: wz, color: flowerColors[idx] });
+    }
+  }
+
+  const count = blocks.length;
+  const positions = new Float32Array(count * 3);
+  const colors = new Float32Array(count * 3);
+
+  blocks.forEach((block, i) => {
+    positions[i * 3] = block.x;
+    positions[i * 3 + 1] = block.y;
+    positions[i * 3 + 2] = block.z;
+    colors[i * 3] = block.color.r;
+    colors[i * 3 + 1] = block.color.g;
+    colors[i * 3 + 2] = block.color.b;
+  });
+
+  return { positions, colors, count };
+}
+
+// ============================================================
+// Track/path block generation (Unrailed! railroad style)
+// ============================================================
+
+function generateTrackVoxels(locationStatuses: Record<string, LocationStatus>): { positions: Float32Array; colors: Float32Array; count: number } {
+  const blocks: VoxelBlock[] = [];
+  const halfX = MAP_WIDTH / 2;
+  const halfZ = MAP_HEIGHT / 2;
+  const trackColor = new THREE.Color(0.45, 0.30, 0.15);
+  const railColor = new THREE.Color(0.60, 0.60, 0.65);
+  const activeRailColor = new THREE.Color(0.95, 0.85, 0.30);
+
+  for (const path of MAP_PATHS) {
+    const fromStatus = locationStatuses[path.from];
+    const toStatus = locationStatuses[path.to];
+    const isActive = fromStatus === 'completed' || toStatus === 'completed';
+
+    for (let i = 0; i < path.waypoints.length; i++) {
+      const wp = path.waypoints[i];
+      const wx = wp.x - halfX;
+      const wz = wp.y - halfZ;
+
+      // Determine height at this point from terrain
+      const terrainTile = MAP_TERRAIN.find(t => t.x === wp.x && t.y === wp.y);
+      const baseY = terrainTile ? terrainTile.elevation + 1 : 1;
+
+      // Track sleeper (wooden tie)
+      blocks.push({ x: wx, y: baseY, z: wz, color: trackColor.clone() });
+
+      // Rail on top
+      const rc = isActive ? activeRailColor.clone() : railColor.clone();
+      blocks.push({ x: wx, y: baseY + 1, z: wz, color: rc });
+    }
+  }
+
+  const count = blocks.length;
+  const positions = new Float32Array(count * 3);
+  const colors = new Float32Array(count * 3);
+
+  blocks.forEach((block, i) => {
+    positions[i * 3] = block.x;
+    positions[i * 3 + 1] = block.y;
+    positions[i * 3 + 2] = block.z;
+    colors[i * 3] = block.color.r;
+    colors[i * 3 + 1] = block.color.g;
+    colors[i * 3 + 2] = block.color.b;
+  });
+
+  return { positions, colors, count };
+}
+
+// ============================================================
+// Three.js sub-components
+// ============================================================
+
+function VoxelTerrain({ data }: { data: { positions: Float32Array; colors: Float32Array; count: number } }) {
+  const meshRef = useRef<THREE.InstancedMesh>(null);
+  const geo = useMemo(() => new THREE.BoxGeometry(0.92, 0.92, 0.92), []);
+  const mat = useMemo(() => new THREE.MeshStandardMaterial({
+    roughness: 0.75,
+    metalness: 0.05,
+    flatShading: true,
+    vertexColors: true,
+  }), []);
+
+  useEffect(() => {
+    const mesh = meshRef.current;
+    if (!mesh) return;
+
+    const dummy = new THREE.Object3D();
+    const color = new THREE.Color();
+
+    for (let i = 0; i < data.count; i++) {
+      dummy.position.set(
+        data.positions[i * 3],
+        data.positions[i * 3 + 1],
+        data.positions[i * 3 + 2],
+      );
+      dummy.updateMatrix();
+      mesh.setMatrixAt(i, dummy.matrix);
+      color.setRGB(data.colors[i * 3], data.colors[i * 3 + 1], data.colors[i * 3 + 2]);
+      mesh.setColorAt(i, color);
+    }
+
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [data]);
+
+  return (
+    <instancedMesh ref={meshRef} args={[geo, mat, data.count]} castShadow receiveShadow />
+  );
+}
+
+function TrackBlocks({ data }: { data: { positions: Float32Array; colors: Float32Array; count: number } }) {
+  const meshRef = useRef<THREE.InstancedMesh>(null);
+  const geo = useMemo(() => new THREE.BoxGeometry(0.7, 0.4, 0.7), []);
+  const mat = useMemo(() => new THREE.MeshStandardMaterial({
+    roughness: 0.6,
+    metalness: 0.2,
+    flatShading: true,
+    vertexColors: true,
+  }), []);
+
+  useEffect(() => {
+    const mesh = meshRef.current;
+    if (!mesh) return;
+
+    const dummy = new THREE.Object3D();
+    const color = new THREE.Color();
+
+    for (let i = 0; i < data.count; i++) {
+      dummy.position.set(
+        data.positions[i * 3],
+        data.positions[i * 3 + 1] + 0.2,
+        data.positions[i * 3 + 2],
+      );
+      dummy.updateMatrix();
+      mesh.setMatrixAt(i, dummy.matrix);
+      color.setRGB(data.colors[i * 3], data.colors[i * 3 + 1], data.colors[i * 3 + 2]);
+      mesh.setColorAt(i, color);
+    }
+
+    mesh.instanceMatrix.needsUpdate = true;
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+  }, [data]);
+
+  return (
+    <instancedMesh ref={meshRef} args={[geo, mat, data.count]} />
+  );
+}
+
+// Location marker beacon
+function LocationBeacon({
+  location,
+  status,
+  isHovered,
+  onClick,
+  onPointerEnter,
+  onPointerLeave,
+}: {
+  location: DungeonLocation;
+  status: LocationStatus;
+  isHovered: boolean;
+  onClick: () => void;
+  onPointerEnter: () => void;
+  onPointerLeave: () => void;
+}) {
+  const groupRef = useRef<THREE.Group>(null);
+  const halfX = MAP_WIDTH / 2;
+  const halfZ = MAP_HEIGHT / 2;
+
+  const wx = location.mapX - halfX;
+  const wz = location.mapY - halfZ;
+
+  // Determine base height from terrain
+  const terrainTile = MAP_TERRAIN.find(t => t.x === location.mapX && t.y === location.mapY);
+  const baseY = terrainTile ? terrainTile.elevation + 2 : 2;
+
+  // Animate beacon
+  useFrame(({ clock }) => {
+    if (!groupRef.current) return;
+    if (status === 'available') {
+      groupRef.current.position.y = baseY + Math.sin(clock.elapsedTime * 2) * 0.15;
+    }
+  });
+
+  const accentColor = new THREE.Color(location.accentColor);
+
+  // Colors based on status
+  const pillarColor = status === 'locked'
+    ? new THREE.Color(0.2, 0.2, 0.25)
+    : status === 'completed'
+      ? new THREE.Color(0.3, 0.7, 0.3)
+      : accentColor;
+
+  const emissiveColor = status === 'available' ? accentColor : status === 'completed' ? new THREE.Color(0.2, 0.6, 0.2) : new THREE.Color(0, 0, 0);
+  const emissiveIntensity = status === 'locked' ? 0 : isHovered ? 1.2 : 0.6;
+  const scale = isHovered && status !== 'locked' ? 1.15 : 1;
+
+  return (
+    <group
+      ref={groupRef}
+      position={[wx, baseY, wz]}
+      scale={[scale, scale, scale]}
+      onClick={(e) => { e.stopPropagation(); if (status !== 'locked') onClick(); }}
+      onPointerEnter={(e) => { e.stopPropagation(); onPointerEnter(); }}
+      onPointerLeave={(e) => { e.stopPropagation(); onPointerLeave(); }}
+    >
+      {/* Base pillar blocks */}
+      <mesh position={[0, 0, 0]} castShadow>
+        <boxGeometry args={[0.8, 0.8, 0.8]} />
+        <meshStandardMaterial
+          color={pillarColor}
+          roughness={0.6}
+          flatShading
+        />
+      </mesh>
+      <mesh position={[0, 0.8, 0]} castShadow>
+        <boxGeometry args={[0.7, 0.7, 0.7]} />
+        <meshStandardMaterial
+          color={pillarColor}
+          roughness={0.6}
+          flatShading
+        />
+      </mesh>
+      <mesh position={[0, 1.5, 0]} castShadow>
+        <boxGeometry args={[0.6, 0.6, 0.6]} />
+        <meshStandardMaterial
+          color={pillarColor}
+          roughness={0.6}
+          flatShading
+        />
+      </mesh>
+
+      {/* Top beacon block (emissive) */}
+      <mesh position={[0, 2.2, 0]}>
+        <boxGeometry args={[0.5, 0.5, 0.5]} />
+        <meshStandardMaterial
+          color={pillarColor}
+          emissive={emissiveColor}
+          emissiveIntensity={emissiveIntensity}
+          roughness={0.3}
+          metalness={0.3}
+        />
+      </mesh>
+
+      {/* Point light for available/completed */}
+      {status !== 'locked' && (
+        <pointLight
+          position={[0, 2.8, 0]}
+          color={pillarColor}
+          intensity={isHovered ? 2 : 0.8}
+          distance={6}
+        />
+      )}
+
+      {/* Completed flag */}
+      {status === 'completed' && (
+        <group position={[0.5, 2.5, 0]}>
+          <mesh>
+            <boxGeometry args={[0.08, 1.2, 0.08]} />
+            <meshStandardMaterial color="#5a3a1a" flatShading />
+          </mesh>
+          <mesh position={[0.25, 0.4, 0]}>
+            <boxGeometry args={[0.5, 0.35, 0.05]} />
+            <meshStandardMaterial color="#4CAF50" emissive="#2a7a2a" emissiveIntensity={0.3} flatShading />
+          </mesh>
+        </group>
+      )}
+    </group>
+  );
+}
+
+// Camera controller - auto-frame the map on mount
+function CameraSetup() {
+  const { camera } = useThree();
+  useEffect(() => {
+    camera.position.set(18, 18, 18);
+    camera.lookAt(0, 0, 0);
+  }, [camera]);
+  return null;
+}
+
+// ============================================================
+// Main DungeonMapVoxel component
+// ============================================================
+
+interface DungeonMapProps {
+  progress: DungeonProgress;
+  onSelectLocation: (location: DungeonLocation) => void;
+  onBack: () => void;
+}
+
+export default function DungeonMapVoxel({ progress, onSelectLocation, onBack }: DungeonMapProps) {
+  const locale = useLocale();
+  const [hoveredLocation, setHoveredLocation] = useState<string | null>(null);
+
+  // Compute location statuses
+  const locationStatuses = useMemo(() => {
+    const statuses: Record<string, LocationStatus> = {};
+    for (const loc of DUNGEON_LOCATIONS) {
+      statuses[loc.id] = getLocationStatus(loc.id, progress);
+    }
+    return statuses;
+  }, [progress]);
+
+  // Generate voxel data (memoized)
+  const terrainData = useMemo(() => generateMapVoxels(MAP_TERRAIN), []);
+  const trackData = useMemo(() => generateTrackVoxels(locationStatuses), [locationStatuses]);
+
+  return (
+    <div className={styles.mapContainer}>
+      {/* Background */}
+      <div className={styles.mapBg} />
+
+      {/* Three.js Canvas */}
+      <Canvas
+        className={styles.mapCanvas}
+        shadows
+        gl={{ antialias: true, alpha: true }}
+        style={{ position: 'absolute', inset: 0 }}
+      >
+        <CameraSetup />
+        <OrthographicCamera
+          makeDefault
+          position={[18, 18, 18]}
+          zoom={28}
+          near={0.1}
+          far={200}
+        />
+
+        {/* Lighting */}
+        <ambientLight intensity={0.5} />
+        <directionalLight
+          position={[15, 25, 10]}
+          intensity={1.2}
+          castShadow
+          shadow-mapSize-width={1024}
+          shadow-mapSize-height={1024}
+          shadow-camera-near={0.5}
+          shadow-camera-far={80}
+          shadow-camera-left={-20}
+          shadow-camera-right={20}
+          shadow-camera-top={20}
+          shadow-camera-bottom={-20}
+        />
+        <directionalLight
+          position={[-10, 10, -5]}
+          intensity={0.3}
+          color="#8888ff"
+        />
+
+        {/* Fog for atmosphere */}
+        <fog attach="fog" args={['#0a0812', 30, 55]} />
+
+        {/* Ground plane */}
+        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.5, 0]} receiveShadow>
+          <planeGeometry args={[60, 60]} />
+          <meshStandardMaterial color="#1a2a1a" roughness={1} />
+        </mesh>
+
+        {/* Terrain voxels */}
+        <VoxelTerrain data={terrainData} />
+
+        {/* Track/path voxels */}
+        <TrackBlocks data={trackData} />
+
+        {/* Location beacons */}
+        {DUNGEON_LOCATIONS.map((location) => (
+          <LocationBeacon
+            key={location.id}
+            location={location}
+            status={locationStatuses[location.id]}
+            isHovered={hoveredLocation === location.id}
+            onClick={() => {
+              if (locationStatuses[location.id] !== 'locked') {
+                onSelectLocation(location);
+              }
+            }}
+            onPointerEnter={() => setHoveredLocation(location.id)}
+            onPointerLeave={() => setHoveredLocation(null)}
+          />
+        ))}
+
+        {/* Camera controls */}
+        <MapControls
+          enableRotate={false}
+          enableZoom={true}
+          minZoom={15}
+          maxZoom={60}
+          panSpeed={1.5}
+          screenSpacePanning
+        />
+      </Canvas>
+
+      {/* Scanlines overlay */}
+      <div className={styles.scanlines} />
+
+      {/* Header */}
+      <div className={styles.mapHeader}>
+        <button className={styles.backButton} onClick={onBack}>
+          ← Back
+        </button>
+        <h1 className={styles.mapTitle}>MISSION SELECT</h1>
+        <div className={styles.mapStats}>
+          <span className={styles.statBadge}>
+            💎 {progress.totalEmeralds}
+          </span>
+          <span className={styles.statBadge}>
+            ⚔️ {progress.totalDefeated}
+          </span>
+        </div>
+      </div>
+
+      {/* Bottom info panel */}
+      {hoveredLocation && (
+        <div className={styles.infoPanel}>
+          {(() => {
+            const loc = DUNGEON_LOCATIONS.find(l => l.id === hoveredLocation);
+            if (!loc) return null;
+            const status = locationStatuses[loc.id];
+            const name = locale === 'en' ? loc.nameEn : loc.name;
+            const desc = locale === 'en' ? loc.descriptionEn : loc.description;
+            return (
+              <>
+                <div className={styles.infoPanelHeader}>
+                  <span className={styles.infoIcon}>{loc.icon}</span>
+                  <span className={styles.infoName}>{name}</span>
+                  {status === 'completed' && <span className={styles.infoComplete}>CLEARED</span>}
+                </div>
+                <div className={styles.infoDesc}>{desc}</div>
+                {loc.difficulty > 0 && (
+                  <div className={styles.infoMeta}>
+                    <span>{'★'.repeat(loc.difficulty)}{'☆'.repeat(5 - loc.difficulty)}</span>
+                    <span>~{loc.estimatedMinutes}min</span>
+                  </div>
+                )}
+              </>
+            );
+          })()}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/stories/DungeonMapVoxel.tsx
+++ b/src/components/stories/DungeonMapVoxel.tsx
@@ -494,10 +494,10 @@ export default function DungeonMapVoxel({ progress, onSelectLocation, onBack }: 
         />
 
         {/* Lighting */}
-        <ambientLight intensity={0.5} />
+        <ambientLight intensity={1.2} />
         <directionalLight
           position={[15, 25, 10]}
-          intensity={1.2}
+          intensity={2.0}
           castShadow
           shadow-mapSize-width={1024}
           shadow-mapSize-height={1024}
@@ -510,17 +510,17 @@ export default function DungeonMapVoxel({ progress, onSelectLocation, onBack }: 
         />
         <directionalLight
           position={[-10, 10, -5]}
-          intensity={0.3}
-          color="#8888ff"
+          intensity={0.8}
+          color="#aabbff"
         />
 
-        {/* Fog for atmosphere */}
-        <fog attach="fog" args={['#0a0812', 30, 55]} />
+        {/* Subtle fog for depth — pushed far back so terrain stays bright */}
+        <fog attach="fog" args={['#0a0812', 55, 90]} />
 
         {/* Ground plane */}
         <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.5, 0]} receiveShadow>
           <planeGeometry args={[60, 60]} />
-          <meshStandardMaterial color="#1a2a1a" roughness={1} />
+          <meshStandardMaterial color="#2a3a2a" roughness={1} />
         </mesh>
 
         {/* Terrain voxels */}

--- a/src/components/stories/DungeonStage.tsx
+++ b/src/components/stories/DungeonStage.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { useLocale } from 'next-intl';
+import dynamic from 'next/dynamic';
+import type { DungeonLocation } from '@/data/stories/dungeons';
+import styles from './dungeonStage.module.css';
+
+const VanillaGame = dynamic(() => import('@/components/rhythmia/tetris'), {
+  ssr: false,
+  loading: () => (
+    <div className={styles.loading}>
+      <div className={styles.loadingText}>LOADING...</div>
+    </div>
+  ),
+});
+
+interface GameStats {
+  score: number;
+  lines: number;
+  bestCombo: number;
+}
+
+interface DungeonStageProps {
+  location: DungeonLocation;
+  onComplete: (emeralds: number, defeated: number) => void;
+  onExit: () => void;
+}
+
+export default function DungeonStage({ location, onComplete, onExit }: DungeonStageProps) {
+  const locale = useLocale();
+  const [showBriefing, setShowBriefing] = useState(true);
+  const [showResults, setShowResults] = useState(false);
+  const gameStatsRef = useRef<GameStats>({ score: 0, lines: 0, bestCombo: 0 });
+
+  // Auto-hide mission briefing after 3 seconds
+  useEffect(() => {
+    const timer = setTimeout(() => setShowBriefing(false), 3000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // Handle game end stats from VanillaGame
+  const handleGameEnd = useCallback((stats: GameStats) => {
+    gameStatsRef.current = stats;
+  }, []);
+
+  // Handle quit from VanillaGame
+  const handleQuit = useCallback(() => {
+    setShowResults(true);
+  }, []);
+
+  // Calculate rewards from game stats
+  const stats = gameStatsRef.current;
+  const earnedEmeralds = Math.floor(stats.lines / 10) + location.difficulty;
+  const earnedDefeated = stats.bestCombo;
+
+  const locationName = locale === 'en' ? location.nameEn : location.name;
+
+  return (
+    <div className={styles.container}>
+      {/* Tetris game */}
+      <VanillaGame onQuit={handleQuit} onGameEnd={handleGameEnd} />
+
+      {/* Mission briefing banner (auto-fades) */}
+      {showBriefing && (
+        <div className={styles.briefing}>
+          <div className={styles.briefingContent}>
+            <div className={styles.briefingIcon}>{location.icon}</div>
+            <div className={styles.briefingInfo}>
+              <div className={styles.briefingName}>{locationName}</div>
+              <div className={styles.briefingDifficulty}>
+                {'★'.repeat(location.difficulty)}{'☆'.repeat(5 - location.difficulty)}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Mission results overlay */}
+      {showResults && (
+        <div className={styles.resultsOverlay}>
+          <div className={styles.resultsCard}>
+            <div className={styles.resultsTitle}>
+              {locale === 'en' ? 'MISSION RESULTS' : 'ミッション結果'}
+            </div>
+            <div className={styles.resultsIcon}>{location.icon}</div>
+            <div className={styles.resultsName}>{locationName}</div>
+
+            <div className={styles.statsGrid}>
+              <div className={styles.statItem}>
+                <div className={styles.statLabel}>SCORE</div>
+                <div className={styles.statValue}>{stats.score.toLocaleString()}</div>
+              </div>
+              <div className={styles.statItem}>
+                <div className={styles.statLabel}>LINES</div>
+                <div className={styles.statValue}>{stats.lines}</div>
+              </div>
+              <div className={styles.statItem}>
+                <div className={styles.statLabel}>BEST COMBO</div>
+                <div className={styles.statValue}>{stats.bestCombo}</div>
+              </div>
+            </div>
+
+            <div className={styles.rewardsSection}>
+              <div className={styles.rewardsTitle}>
+                {locale === 'en' ? 'REWARDS' : '報酬'}
+              </div>
+              <div className={styles.rewardsList}>
+                <span className={styles.reward}>💎 ×{earnedEmeralds}</span>
+                <span className={styles.reward}>⚔️ ×{earnedDefeated}</span>
+              </div>
+            </div>
+
+            <div className={styles.resultsActions}>
+              <button
+                className={styles.completeBtn}
+                onClick={() => onComplete(earnedEmeralds, earnedDefeated)}
+              >
+                {locale === 'en' ? 'COMPLETE MISSION' : 'ミッション完了'}
+              </button>
+              <button
+                className={styles.retreatBtn}
+                onClick={onExit}
+              >
+                {locale === 'en' ? 'RETURN TO MAP' : 'マップに戻る'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/stories/StoryViewer.tsx
+++ b/src/components/stories/StoryViewer.tsx
@@ -5,13 +5,35 @@ import { useTranslations, useLocale } from 'next-intl';
 import { useRouter } from '@/i18n/navigation';
 import { CHAPTERS, PARTICLE_EMOJIS } from '@/data/stories/chapters';
 import type { Chapter, StoryScene, DialogueLine } from '@/data/stories/chapters';
+import type { DungeonLocation, DungeonProgress } from '@/data/stories/dungeons';
+import { DUNGEON_LOCATIONS, getChapterForLocation, DEFAULT_PROGRESS } from '@/data/stories/dungeons';
+import DungeonMap from './DungeonMap';
+import DungeonExplorer from './DungeonExplorer';
 import styles from './stories.module.css';
 
-type ViewState = 'chapter-select' | 'playing';
+type ViewState = 'dungeon-map' | 'story-intro' | 'playing' | 'exploring';
 
 interface LogEntry {
     speaker: string | null;
     text: string;
+}
+
+// Local storage key for dungeon progress
+const PROGRESS_KEY = 'azuretier_dungeon_progress';
+
+function loadProgress(): DungeonProgress {
+    if (typeof window === 'undefined') return DEFAULT_PROGRESS;
+    try {
+        const saved = localStorage.getItem(PROGRESS_KEY);
+        if (saved) return JSON.parse(saved);
+    } catch { /* ignore */ }
+    return DEFAULT_PROGRESS;
+}
+
+function saveProgress(progress: DungeonProgress) {
+    try {
+        localStorage.setItem(PROGRESS_KEY, JSON.stringify(progress));
+    } catch { /* ignore */ }
 }
 
 export default function StoryViewer() {
@@ -19,7 +41,12 @@ export default function StoryViewer() {
     const locale = useLocale();
     const router = useRouter();
 
-    const [viewState, setViewState] = useState<ViewState>('chapter-select');
+    // Dungeon map state
+    const [viewState, setViewState] = useState<ViewState>('dungeon-map');
+    const [progress, setProgress] = useState<DungeonProgress>(DEFAULT_PROGRESS);
+    const [selectedLocation, setSelectedLocation] = useState<DungeonLocation | null>(null);
+
+    // Visual novel state
     const [currentChapter, setCurrentChapter] = useState<Chapter | null>(null);
     const [sceneIndex, setSceneIndex] = useState(0);
     const [lineIndex, setLineIndex] = useState(0);
@@ -34,6 +61,11 @@ export default function StoryViewer() {
     const typingRef = useRef<NodeJS.Timeout | null>(null);
     const autoRef = useRef<NodeJS.Timeout | null>(null);
     const fullTextRef = useRef('');
+
+    // Load progress from local storage on mount
+    useEffect(() => {
+        setProgress(loadProgress());
+    }, []);
 
     const currentScene: StoryScene | null = currentChapter
         ? currentChapter.scenes[sceneIndex] ?? null
@@ -57,7 +89,7 @@ export default function StoryViewer() {
 
     // Typing effect
     useEffect(() => {
-        if (!currentLine || viewState !== 'playing') return;
+        if (!currentLine || (viewState !== 'playing' && viewState !== 'story-intro')) return;
 
         const text = getLineText(currentLine);
         fullTextRef.current = text;
@@ -81,7 +113,7 @@ export default function StoryViewer() {
 
     // Auto-advance
     useEffect(() => {
-        if (!autoMode || isTyping || viewState !== 'playing') return;
+        if (!autoMode || isTyping || (viewState !== 'playing' && viewState !== 'story-intro')) return;
 
         autoRef.current = setTimeout(() => {
             advance();
@@ -121,19 +153,25 @@ export default function StoryViewer() {
                     setTransitioning(false);
                 }, 600);
             } else {
-                // Chapter complete — return to select
+                // Chapter/story complete — transition to exploration or map
                 setTransitioning(true);
                 setTimeout(() => {
-                    setViewState('chapter-select');
+                    if (viewState === 'story-intro' && selectedLocation && selectedLocation.dungeonTiles.length > 0) {
+                        // Story intro finished — start dungeon exploration
+                        setViewState('exploring');
+                    } else {
+                        // Story-only location or chapter replay — complete and return to map
+                        handleLocationComplete(0, 0);
+                    }
                     setTransitioning(false);
                 }, 600);
             }
         }
-    }, [currentChapter, currentScene, isTyping, lineIndex, sceneIndex, showLog, showMenu, completeTyping]);
+    }, [currentChapter, currentScene, isTyping, lineIndex, sceneIndex, showLog, showMenu, completeTyping, viewState, selectedLocation]);
 
     // Add to log when line advances
     useEffect(() => {
-        if (!currentLine || viewState !== 'playing') return;
+        if (!currentLine || (viewState !== 'playing' && viewState !== 'story-intro')) return;
         const speaker = getSpeaker(currentLine);
         const text = getLineText(currentLine);
         setLog(prev => [...prev, { speaker, text }]);
@@ -142,7 +180,7 @@ export default function StoryViewer() {
     // Keyboard controls
     useEffect(() => {
         const handleKey = (e: KeyboardEvent) => {
-            if (viewState !== 'playing') return;
+            if (viewState !== 'playing' && viewState !== 'story-intro') return;
 
             switch (e.key.toLowerCase()) {
                 case ' ':
@@ -172,6 +210,64 @@ export default function StoryViewer() {
         return () => window.removeEventListener('keydown', handleKey);
     }, [viewState, advance]);
 
+    // Handle location selection from dungeon map
+    const handleSelectLocation = useCallback((location: DungeonLocation) => {
+        setSelectedLocation(location);
+
+        // Check if location has a story chapter
+        const chapter = getChapterForLocation(location);
+        if (chapter) {
+            // Start with story intro
+            setCurrentChapter(chapter);
+            setSceneIndex(0);
+            setLineIndex(0);
+            setLog([]);
+            setAutoMode(false);
+            setShowLog(false);
+            setShowMenu(false);
+            setTransitioning(true);
+            setTimeout(() => {
+                setViewState('story-intro');
+                setTransitioning(false);
+            }, 400);
+        } else if (location.dungeonTiles.length > 0) {
+            // No story — go straight to exploration
+            setTransitioning(true);
+            setTimeout(() => {
+                setViewState('exploring');
+                setTransitioning(false);
+            }, 400);
+        }
+    }, []);
+
+    // Handle dungeon exploration complete
+    const handleLocationComplete = useCallback((emeralds: number, defeated: number) => {
+        if (!selectedLocation) return;
+
+        const newProgress: DungeonProgress = {
+            ...progress,
+            completedLocations: progress.completedLocations.includes(selectedLocation.id)
+                ? progress.completedLocations
+                : [...progress.completedLocations, selectedLocation.id],
+            currentLocation: null,
+            totalEmeralds: progress.totalEmeralds + emeralds,
+            totalDefeated: progress.totalDefeated + defeated,
+        };
+
+        setProgress(newProgress);
+        saveProgress(newProgress);
+        setViewState('dungeon-map');
+        setSelectedLocation(null);
+        setCurrentChapter(null);
+    }, [selectedLocation, progress]);
+
+    // Handle exit from exploration back to map
+    const handleExplorationExit = useCallback(() => {
+        setViewState('dungeon-map');
+        setSelectedLocation(null);
+        setCurrentChapter(null);
+    }, []);
+
     const startChapter = (chapter: Chapter) => {
         setCurrentChapter(chapter);
         setSceneIndex(0);
@@ -200,69 +296,59 @@ export default function StoryViewer() {
         } else {
             setTransitioning(true);
             setTimeout(() => {
-                setViewState('chapter-select');
+                if (viewState === 'story-intro' && selectedLocation && selectedLocation.dungeonTiles.length > 0) {
+                    setViewState('exploring');
+                } else {
+                    handleLocationComplete(0, 0);
+                }
                 setTransitioning(false);
             }, 400);
         }
     };
 
-    // ---- Chapter Select Screen ----
-    if (viewState === 'chapter-select') {
+    // ---- Dungeon Map Screen ----
+    if (viewState === 'dungeon-map') {
         return (
-            <div className={styles.chapterSelect}>
-                <div className={styles.chapterSelectBg} />
-                <div className={styles.scanlines} />
-
-                <h1 className={styles.chapterSelectTitle}>{t('title')}</h1>
-
-                <div className={styles.chapterGrid}>
-                    {CHAPTERS.map((chapter) => (
-                        <button
-                            key={chapter.id}
-                            className={styles.chapterCard}
-                            onClick={() => startChapter(chapter)}
-                        >
-                            <div
-                                className={styles.chapterCardAccent}
-                                style={{ background: chapter.accent }}
-                            />
-                            <div className={styles.chapterCardNumber}>
-                                {t('chapter')} {String(chapter.number).padStart(2, '0')}
-                            </div>
-                            <div className={styles.chapterCardTitle}>
-                                {locale === 'en' ? chapter.titleEn : chapter.title}
-                            </div>
-                            <div className={styles.chapterCardSubtitle}>
-                                {chapter.subtitle}
-                            </div>
-                        </button>
-                    ))}
-                </div>
-
-                <div className={styles.chapterSelectBack}>
-                    <button
-                        className={styles.backButton}
-                        style={{ position: 'relative', top: 'auto', left: 'auto' }}
-                        onClick={() => router.push('/')}
-                    >
-                        {t('backToLobby')}
-                    </button>
-                </div>
-
+            <>
+                <DungeonMap
+                    progress={progress}
+                    onSelectLocation={handleSelectLocation}
+                    onBack={() => router.push('/')}
+                />
                 {transitioning && (
                     <div
                         className={styles.transitionOverlay}
                         style={{ opacity: 1 }}
                     />
                 )}
-            </div>
+            </>
         );
     }
 
-    // ---- Playing Screen ----
+    // ---- Dungeon Exploration Screen ----
+    if (viewState === 'exploring' && selectedLocation) {
+        return (
+            <>
+                <DungeonExplorer
+                    location={selectedLocation}
+                    onComplete={handleLocationComplete}
+                    onExit={handleExplorationExit}
+                />
+                {transitioning && (
+                    <div
+                        className={styles.transitionOverlay}
+                        style={{ opacity: 1 }}
+                    />
+                )}
+            </>
+        );
+    }
+
+    // ---- Story Playing Screen (both story-intro and playing) ----
     if (!currentScene || !currentLine || !currentChapter) return null;
 
     const particles = PARTICLE_EMOJIS[currentScene.particleType ?? 'butterflies'] ?? PARTICLE_EMOJIS.butterflies;
+    const isStoryIntro = viewState === 'story-intro';
 
     return (
         <div className={styles.container} onClick={advance}>
@@ -348,13 +434,24 @@ export default function StoryViewer() {
                     className={styles.backButton}
                     style={{ position: 'relative', top: 'auto', left: 'auto' }}
                     onClick={() => {
-                        setViewState('chapter-select');
+                        if (isStoryIntro) {
+                            setViewState('dungeon-map');
+                            setSelectedLocation(null);
+                            setCurrentChapter(null);
+                        } else {
+                            setViewState('dungeon-map');
+                        }
                         setAutoMode(false);
                     }}
                 >
                     {t('backToLobby')}
                 </button>
                 <span className={styles.chapterInfo}>
+                    {isStoryIntro && selectedLocation && (
+                        <span className={styles.missionLabel}>
+                            {selectedLocation.icon}{' '}
+                        </span>
+                    )}
                     {t('chapter')} {String(currentChapter.number).padStart(2, '0')} — {locale === 'en' ? currentChapter.titleEn : currentChapter.title}
                 </span>
             </div>
@@ -450,7 +547,9 @@ export default function StoryViewer() {
                         className={styles.menuItem}
                         onClick={() => {
                             setShowMenu(false);
-                            setViewState('chapter-select');
+                            setViewState('dungeon-map');
+                            setSelectedLocation(null);
+                            setCurrentChapter(null);
                             setAutoMode(false);
                         }}
                     >

--- a/src/components/stories/StoryViewer.tsx
+++ b/src/components/stories/StoryViewer.tsx
@@ -3,15 +3,13 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslations, useLocale } from 'next-intl';
 import { useRouter } from '@/i18n/navigation';
-import dynamic from 'next/dynamic';
 import { CHAPTERS, PARTICLE_EMOJIS } from '@/data/stories/chapters';
 import type { Chapter, StoryScene, DialogueLine } from '@/data/stories/chapters';
 import type { DungeonLocation, DungeonProgress } from '@/data/stories/dungeons';
 import { DUNGEON_LOCATIONS, getChapterForLocation, DEFAULT_PROGRESS } from '@/data/stories/dungeons';
+import DungeonMap from './DungeonMap';
 import DungeonStage from './DungeonStage';
 import styles from './stories.module.css';
-
-const DungeonMapVoxel = dynamic(() => import('./DungeonMapVoxel'), { ssr: false });
 
 type ViewState = 'dungeon-map' | 'story-intro' | 'playing' | 'exploring';
 
@@ -312,7 +310,7 @@ export default function StoryViewer() {
     if (viewState === 'dungeon-map') {
         return (
             <>
-                <DungeonMapVoxel
+                <DungeonMap
                     progress={progress}
                     onSelectLocation={handleSelectLocation}
                     onBack={() => router.push('/')}

--- a/src/components/stories/StoryViewer.tsx
+++ b/src/components/stories/StoryViewer.tsx
@@ -3,13 +3,15 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslations, useLocale } from 'next-intl';
 import { useRouter } from '@/i18n/navigation';
+import dynamic from 'next/dynamic';
 import { CHAPTERS, PARTICLE_EMOJIS } from '@/data/stories/chapters';
 import type { Chapter, StoryScene, DialogueLine } from '@/data/stories/chapters';
 import type { DungeonLocation, DungeonProgress } from '@/data/stories/dungeons';
 import { DUNGEON_LOCATIONS, getChapterForLocation, DEFAULT_PROGRESS } from '@/data/stories/dungeons';
-import DungeonMap from './DungeonMap';
-import DungeonExplorer from './DungeonExplorer';
+import DungeonStage from './DungeonStage';
 import styles from './stories.module.css';
+
+const DungeonMapVoxel = dynamic(() => import('./DungeonMapVoxel'), { ssr: false });
 
 type ViewState = 'dungeon-map' | 'story-intro' | 'playing' | 'exploring';
 
@@ -310,7 +312,7 @@ export default function StoryViewer() {
     if (viewState === 'dungeon-map') {
         return (
             <>
-                <DungeonMap
+                <DungeonMapVoxel
                     progress={progress}
                     onSelectLocation={handleSelectLocation}
                     onBack={() => router.push('/')}
@@ -329,7 +331,7 @@ export default function StoryViewer() {
     if (viewState === 'exploring' && selectedLocation) {
         return (
             <>
-                <DungeonExplorer
+                <DungeonStage
                     location={selectedLocation}
                     onComplete={handleLocationComplete}
                     onExit={handleExplorationExit}

--- a/src/components/stories/dungeonExplorer.module.css
+++ b/src/components/stories/dungeonExplorer.module.css
@@ -1,0 +1,455 @@
+/* ============================================
+   Minecraft Dungeons — Tile-Based Explorer
+   ============================================ */
+
+.container {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+  background: #0a0812;
+  font-family: 'VT323', monospace;
+  image-rendering: pixelated;
+  user-select: none;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.dungeonBg {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 50% 50%, rgba(40, 30, 60, 0.3) 0%, transparent 70%);
+}
+
+.scanlines {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  opacity: 0.04;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0, 0, 0, 0.3) 2px,
+    rgba(0, 0, 0, 0.3) 4px
+  );
+}
+
+/* ---- Header ---- */
+.header {
+  position: relative;
+  z-index: 10;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 12px 20px;
+  background: rgba(10, 8, 18, 0.9);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.exitBtn {
+  padding: 6px 12px;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 2px;
+  color: rgba(255, 255, 255, 0.6);
+  font-family: 'VT323', monospace;
+  font-size: 16px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.exitBtn:hover {
+  color: rgba(255, 255, 255, 0.9);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.headerTitle {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.7);
+  letter-spacing: 2px;
+}
+
+.headerStats {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 9px;
+  color: rgba(255, 215, 0, 0.7);
+  letter-spacing: 1px;
+}
+
+/* ---- HUD ---- */
+.hud {
+  position: relative;
+  z-index: 10;
+  width: 100%;
+  max-width: 400px;
+  padding: 8px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.hudRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hudLabel {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  color: rgba(255, 255, 255, 0.4);
+  letter-spacing: 1px;
+  min-width: 28px;
+}
+
+.hudValue {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 9px;
+  color: rgba(255, 255, 255, 0.7);
+  min-width: 20px;
+}
+
+.healthBar {
+  position: relative;
+  flex: 1;
+  height: 14px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.healthFill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background: linear-gradient(180deg, #4CAF50 0%, #388E3C 100%);
+  transition: width 0.3s ease;
+}
+
+.healthText {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 7px;
+  color: white;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  z-index: 1;
+}
+
+.inventoryRow {
+  display: flex;
+  gap: 4px;
+  padding: 2px 0;
+}
+
+.inventoryItem {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 2px;
+  font-size: 14px;
+}
+
+/* ---- Board ---- */
+.boardWrapper {
+  position: relative;
+  z-index: 5;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+}
+
+.board {
+  position: relative;
+  border: 2px solid rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.3);
+  box-shadow:
+    0 0 30px rgba(0, 0, 0, 0.5),
+    inset 0 0 20px rgba(0, 0, 0, 0.3);
+}
+
+/* ---- Tiles ---- */
+.tile {
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  border: 1px solid;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s ease;
+  font-size: 16px;
+}
+
+.walkable:hover {
+  filter: brightness(1.3);
+  cursor: pointer;
+}
+
+.tileIcon {
+  font-size: 14px;
+  pointer-events: none;
+}
+
+.itemIcon {
+  position: absolute;
+  font-size: 16px;
+  pointer-events: none;
+  animation: itemBob 1.5s ease-in-out infinite;
+  z-index: 2;
+}
+
+@keyframes itemBob {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+}
+
+/* ---- Mob ---- */
+.mobContainer {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  pointer-events: none;
+  z-index: 3;
+}
+
+.mobIcon {
+  font-size: 20px;
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.5));
+  animation: mobIdle 2s ease-in-out infinite;
+}
+
+@keyframes mobIdle {
+  0%, 100% { transform: translateY(0) scale(1); }
+  50% { transform: translateY(-2px) scale(1.05); }
+}
+
+.mobHealthBar {
+  width: 24px;
+  height: 3px;
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 1px;
+  overflow: hidden;
+  margin-top: 1px;
+}
+
+.mobHealthFill {
+  height: 100%;
+  background: #e53935;
+  transition: width 0.3s ease;
+}
+
+/* ---- Player ---- */
+.player {
+  position: absolute;
+  font-size: 22px;
+  z-index: 5;
+  filter: drop-shadow(0 0 6px rgba(255, 215, 0, 0.4));
+  transition: transform 0.1s ease;
+}
+
+.shake_up { animation: shakeUp 0.2s ease; }
+.shake_down { animation: shakeDown 0.2s ease; }
+.shake_left { animation: shakeLeft 0.2s ease; }
+.shake_right { animation: shakeRight 0.2s ease; }
+
+@keyframes shakeUp { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-4px); } }
+@keyframes shakeDown { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(4px); } }
+@keyframes shakeLeft { 0%, 100% { transform: translateX(0); } 50% { transform: translateX(-4px); } }
+@keyframes shakeRight { 0%, 100% { transform: translateX(0); } 50% { transform: translateX(4px); } }
+
+/* ---- Message Log ---- */
+.messageLog {
+  position: relative;
+  z-index: 10;
+  width: 100%;
+  max-width: 400px;
+  padding: 8px 16px;
+  min-height: 80px;
+}
+
+.message {
+  font-family: 'VT323', monospace;
+  font-size: 16px;
+  color: rgba(255, 255, 255, 0.7);
+  padding: 2px 0;
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ---- Mobile D-pad ---- */
+.dpad {
+  position: relative;
+  z-index: 10;
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 0 16px;
+}
+
+.dpadRow {
+  display: flex;
+  gap: 4px;
+}
+
+.dpadBtn {
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 18px;
+  cursor: pointer;
+  transition: all 0.1s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.dpadBtn:active {
+  background: rgba(255, 255, 255, 0.15);
+  transform: scale(0.95);
+}
+
+.dpadBtn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+/* ---- Overlays ---- */
+.overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(10, 5, 15, 0.88);
+  backdrop-filter: blur(8px);
+  animation: fadeIn 0.5s ease;
+}
+
+.victoryOverlay {
+  background: rgba(5, 15, 10, 0.88);
+}
+
+.overlayContent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+.overlayTitle {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 20px;
+  color: rgba(255, 255, 255, 0.85);
+  letter-spacing: 4px;
+  text-shadow: 0 0 20px rgba(255, 215, 0, 0.3);
+}
+
+.overlayIcon {
+  font-size: 48px;
+  animation: trophyBounce 1s ease-in-out infinite;
+}
+
+@keyframes trophyBounce {
+  0%, 100% { transform: translateY(0) scale(1); }
+  50% { transform: translateY(-10px) scale(1.1); }
+}
+
+.overlayStats {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 12px;
+  color: rgba(255, 215, 0, 0.7);
+  letter-spacing: 2px;
+}
+
+.overlayBtn {
+  padding: 12px 28px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 2px;
+  color: rgba(255, 255, 255, 0.8);
+  font-family: 'Press Start 2P', monospace;
+  font-size: 10px;
+  letter-spacing: 2px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.overlayBtn:hover {
+  background: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.3);
+  color: white;
+}
+
+/* ---- Responsive ---- */
+@media (max-width: 768px) {
+  .dpad {
+    display: flex;
+  }
+
+  .boardWrapper {
+    padding: 8px;
+  }
+
+  .headerTitle {
+    font-size: 8px;
+  }
+
+  .headerStats {
+    font-size: 7px;
+  }
+
+  .messageLog {
+    min-height: 40px;
+    padding: 4px 12px;
+  }
+
+  .message {
+    font-size: 14px;
+  }
+}
+
+@media (max-width: 480px) {
+  .board {
+    transform: scale(0.85);
+    transform-origin: center center;
+  }
+
+  .dpadBtn {
+    width: 44px;
+    height: 44px;
+  }
+
+  .overlayTitle {
+    font-size: 14px;
+  }
+}

--- a/src/components/stories/dungeonMap.module.css
+++ b/src/components/stories/dungeonMap.module.css
@@ -1,5 +1,5 @@
 /* ============================================
-   Minecraft Dungeons — Voxel Map
+   Minecraft Dungeons — Voxel Map (Warm Theme)
    ============================================ */
 
 .mapContainer {
@@ -7,7 +7,7 @@
   width: 100vw;
   height: 100vh;
   overflow: hidden;
-  background: #0a0812;
+  background: #1e1812;
   font-family: 'VT323', monospace;
   user-select: none;
 }
@@ -17,8 +17,8 @@
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(ellipse at 30% 60%, rgba(50, 80, 30, 0.15) 0%, transparent 60%),
-    radial-gradient(ellipse at 70% 30%, rgba(30, 50, 100, 0.12) 0%, transparent 60%);
+    radial-gradient(ellipse at 30% 60%, rgba(80, 60, 30, 0.12) 0%, transparent 60%),
+    radial-gradient(ellipse at 70% 30%, rgba(60, 40, 20, 0.10) 0%, transparent 60%);
   z-index: 0;
 }
 
@@ -27,21 +27,6 @@
   position: absolute;
   inset: 0;
   z-index: 1;
-}
-
-.scanlines {
-  position: absolute;
-  inset: 0;
-  z-index: 5;
-  pointer-events: none;
-  opacity: 0.03;
-  background: repeating-linear-gradient(
-    0deg,
-    transparent,
-    transparent 2px,
-    rgba(0, 0, 0, 0.3) 2px,
-    rgba(0, 0, 0, 0.3) 4px
-  );
 }
 
 /* ---- Header ---- */
@@ -56,16 +41,16 @@
   align-items: center;
   padding: 16px 24px;
   pointer-events: none;
-  background: linear-gradient(180deg, rgba(10, 8, 18, 0.85) 0%, rgba(10, 8, 18, 0) 100%);
+  background: linear-gradient(180deg, rgba(30, 24, 18, 0.88) 0%, rgba(30, 24, 18, 0) 100%);
 }
 
 .mapTitle {
   font-family: 'Press Start 2P', 'VT323', monospace;
   font-size: 14px;
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 240, 210, 0.7);
   letter-spacing: 4px;
   text-transform: uppercase;
-  text-shadow: 0 0 12px rgba(255, 215, 0, 0.2);
+  text-shadow: 0 0 12px rgba(255, 200, 100, 0.2);
   pointer-events: auto;
 }
 
@@ -79,12 +64,12 @@
   align-items: center;
   gap: 4px;
   padding: 4px 10px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 240, 210, 0.06);
+  border: 1px solid rgba(255, 240, 210, 0.1);
   border-radius: 2px;
   font-family: 'Press Start 2P', monospace;
   font-size: 9px;
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 240, 210, 0.65);
   letter-spacing: 1px;
 }
 
@@ -93,10 +78,10 @@
   align-items: center;
   gap: 6px;
   padding: 8px 14px;
-  background: rgba(0, 0, 0, 0.5);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(30, 24, 18, 0.7);
+  border: 1px solid rgba(255, 240, 210, 0.12);
   border-radius: 2px;
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 240, 210, 0.65);
   font-family: 'VT323', monospace;
   font-size: 18px;
   cursor: pointer;
@@ -106,12 +91,72 @@
 }
 
 .backButton:hover {
-  color: rgba(255, 255, 255, 0.9);
-  border-color: rgba(255, 255, 255, 0.25);
-  background: rgba(0, 0, 0, 0.7);
+  color: rgba(255, 240, 210, 0.95);
+  border-color: rgba(255, 240, 210, 0.3);
+  background: rgba(30, 24, 18, 0.9);
 }
 
-/* ---- Location beacon glow animation (used by DungeonMapVoxel) ---- */
+/* ---- Location labels (rendered via drei Html) ---- */
+.locationLabel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  text-align: center;
+  transition: transform 0.15s ease, opacity 0.15s ease;
+}
+
+.locationLocked {
+  opacity: 0.35;
+  filter: grayscale(0.8);
+}
+
+.locationHovered {
+  transform: scale(1.1);
+}
+
+.locationIconBadge {
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(20, 16, 10, 0.88);
+  border: 2px solid #888;
+  border-radius: 8px;
+  font-size: 18px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+}
+
+.locationLabelName {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 7px;
+  color: #fff;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.9), 0 0 8px rgba(0, 0, 0, 0.6);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.locationCleared {
+  position: absolute;
+  top: -4px;
+  right: -6px;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #4caf50;
+  border-radius: 50%;
+  font-size: 9px;
+  color: white;
+  font-weight: bold;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+}
+
+/* ---- Beacon glow animation ---- */
 @keyframes beaconPulse {
   0%, 100% { opacity: 0.6; }
   50% { opacity: 1; }
@@ -127,8 +172,8 @@
   width: 380px;
   max-width: calc(100vw - 40px);
   padding: 16px 20px;
-  background: linear-gradient(180deg, rgba(10, 8, 20, 0.92) 0%, rgba(6, 4, 14, 0.96) 100%);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: linear-gradient(180deg, rgba(36, 28, 20, 0.94) 0%, rgba(24, 18, 12, 0.97) 100%);
+  border: 1px solid rgba(255, 240, 210, 0.1);
   border-radius: 4px;
   backdrop-filter: blur(8px);
   box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.5);
@@ -155,7 +200,7 @@
 .infoName {
   font-family: 'Press Start 2P', monospace;
   font-size: 11px;
-  color: rgba(255, 255, 255, 0.85);
+  color: rgba(255, 240, 210, 0.9);
   letter-spacing: 1px;
 }
 
@@ -174,7 +219,7 @@
   font-family: 'VT323', monospace;
   font-size: 18px;
   line-height: 1.5;
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 240, 210, 0.6);
   margin-bottom: 8px;
 }
 
@@ -184,7 +229,7 @@
   align-items: center;
   font-family: 'Press Start 2P', monospace;
   font-size: 8px;
-  color: rgba(255, 215, 0, 0.6);
+  color: rgba(255, 215, 0, 0.7);
   letter-spacing: 1px;
 }
 
@@ -215,6 +260,16 @@
 
   .infoDesc {
     font-size: 16px;
+  }
+
+  .locationIconBadge {
+    width: 32px;
+    height: 32px;
+    font-size: 15px;
+  }
+
+  .locationLabelName {
+    font-size: 6px;
   }
 }
 

--- a/src/components/stories/dungeonMap.module.css
+++ b/src/components/stories/dungeonMap.module.css
@@ -1,0 +1,296 @@
+/* ============================================
+   Minecraft Dungeons — Isometric Map
+   ============================================ */
+
+.mapContainer {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+  background: #0a0812;
+  font-family: 'VT323', monospace;
+  image-rendering: pixelated;
+  cursor: grab;
+  user-select: none;
+}
+
+.mapContainer:active {
+  cursor: grabbing;
+}
+
+.mapBg {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 30% 60%, rgba(50, 80, 30, 0.25) 0%, transparent 60%),
+    radial-gradient(ellipse at 70% 30%, rgba(30, 50, 100, 0.2) 0%, transparent 60%),
+    radial-gradient(ellipse at 50% 80%, rgba(80, 40, 20, 0.15) 0%, transparent 50%);
+}
+
+.scanlines {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  opacity: 0.04;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0, 0, 0, 0.3) 2px,
+    rgba(0, 0, 0, 0.3) 4px
+  );
+}
+
+/* ---- Header ---- */
+.mapHeader {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 24px;
+  background: linear-gradient(180deg, rgba(10, 8, 18, 0.9) 0%, rgba(10, 8, 18, 0) 100%);
+}
+
+.mapTitle {
+  font-family: 'Press Start 2P', 'VT323', monospace;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.6);
+  letter-spacing: 4px;
+  text-transform: uppercase;
+  text-shadow: 0 0 12px rgba(255, 215, 0, 0.2);
+}
+
+.mapStats {
+  display: flex;
+  gap: 12px;
+}
+
+.statBadge {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 2px;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 9px;
+  color: rgba(255, 255, 255, 0.6);
+  letter-spacing: 1px;
+}
+
+.backButton {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 2px;
+  color: rgba(255, 255, 255, 0.6);
+  font-family: 'VT323', monospace;
+  font-size: 18px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  backdrop-filter: blur(4px);
+}
+
+.backButton:hover {
+  color: rgba(255, 255, 255, 0.9);
+  border-color: rgba(255, 255, 255, 0.25);
+  background: rgba(0, 0, 0, 0.7);
+}
+
+/* ---- Map SVG ---- */
+.mapSvg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 2;
+  transition: transform 0.05s linear;
+}
+
+.terrainLayer {
+  opacity: 0.85;
+}
+
+.pathLayer {
+  filter: drop-shadow(0 0 4px rgba(255, 215, 0, 0.3));
+}
+
+.locationLayer {
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.5));
+}
+
+/* ---- Location node states ---- */
+.locationNode {
+  transition: transform 0.2s ease;
+}
+
+.locationNode:hover {
+  filter: brightness(1.2);
+}
+
+.status_locked {
+  opacity: 0.5;
+}
+
+.status_available {
+  animation: locationGlow 3s ease-in-out infinite;
+}
+
+.status_completed {
+  opacity: 1;
+}
+
+/* ---- Water shimmer animation ---- */
+.waterShimmer {
+  animation: shimmer 4s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0%, 100% { opacity: 0.1; }
+  50% { opacity: 0.35; }
+}
+
+/* ---- Active path glow ---- */
+.activePath {
+  filter: drop-shadow(0 0 6px rgba(255, 215, 0, 0.5));
+  animation: pathPulse 2s ease-in-out infinite;
+}
+
+@keyframes pathPulse {
+  0%, 100% { stroke-opacity: 0.8; }
+  50% { stroke-opacity: 1; }
+}
+
+/* ---- Pulse ring for available locations ---- */
+.pulseRing {
+  animation: ringPulse 2s ease-in-out infinite;
+}
+
+@keyframes ringPulse {
+  0%, 100% { r: 16; opacity: 0.8; }
+  50% { r: 20; opacity: 0.5; }
+}
+
+@keyframes locationGlow {
+  0%, 100% { filter: drop-shadow(0 0 4px rgba(255, 215, 0, 0.3)); }
+  50% { filter: drop-shadow(0 0 8px rgba(255, 215, 0, 0.6)); }
+}
+
+/* ---- Bottom info panel ---- */
+.infoPanel {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  width: 380px;
+  max-width: calc(100vw - 40px);
+  padding: 16px 20px;
+  background: linear-gradient(180deg, rgba(10, 8, 20, 0.92) 0%, rgba(6, 4, 14, 0.96) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.5);
+  animation: fadeInUp 0.2s ease;
+}
+
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateX(-50%) translateY(10px); }
+  to { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+
+.infoPanelHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.infoIcon {
+  font-size: 20px;
+}
+
+.infoName {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.85);
+  letter-spacing: 1px;
+}
+
+.infoComplete {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 7px;
+  color: #4CAF50;
+  letter-spacing: 2px;
+  padding: 2px 6px;
+  border: 1px solid rgba(76, 175, 80, 0.3);
+  border-radius: 2px;
+  margin-left: auto;
+}
+
+.infoDesc {
+  font-family: 'VT323', monospace;
+  font-size: 18px;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 8px;
+}
+
+.infoMeta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  color: rgba(255, 215, 0, 0.6);
+  letter-spacing: 1px;
+}
+
+/* ---- Responsive ---- */
+@media (max-width: 768px) {
+  .mapTitle {
+    font-size: 10px;
+    letter-spacing: 2px;
+  }
+
+  .mapHeader {
+    padding: 12px 16px;
+  }
+
+  .statBadge {
+    font-size: 8px;
+    padding: 3px 6px;
+  }
+
+  .infoPanel {
+    width: 320px;
+    padding: 12px 16px;
+  }
+
+  .infoName {
+    font-size: 9px;
+  }
+
+  .infoDesc {
+    font-size: 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .mapStats {
+    gap: 6px;
+  }
+
+  .mapTitle {
+    font-size: 8px;
+  }
+}

--- a/src/components/stories/dungeonMap.module.css
+++ b/src/components/stories/dungeonMap.module.css
@@ -1,5 +1,5 @@
 /* ============================================
-   Minecraft Dungeons — Isometric Map
+   Minecraft Dungeons — Voxel Map
    ============================================ */
 
 .mapContainer {
@@ -9,30 +9,32 @@
   overflow: hidden;
   background: #0a0812;
   font-family: 'VT323', monospace;
-  image-rendering: pixelated;
-  cursor: grab;
   user-select: none;
 }
 
-.mapContainer:active {
-  cursor: grabbing;
-}
-
+/* ---- Background (behind canvas) ---- */
 .mapBg {
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(ellipse at 30% 60%, rgba(50, 80, 30, 0.25) 0%, transparent 60%),
-    radial-gradient(ellipse at 70% 30%, rgba(30, 50, 100, 0.2) 0%, transparent 60%),
-    radial-gradient(ellipse at 50% 80%, rgba(80, 40, 20, 0.15) 0%, transparent 50%);
+    radial-gradient(ellipse at 30% 60%, rgba(50, 80, 30, 0.15) 0%, transparent 60%),
+    radial-gradient(ellipse at 70% 30%, rgba(30, 50, 100, 0.12) 0%, transparent 60%);
+  z-index: 0;
+}
+
+/* ---- R3F Canvas ---- */
+.mapCanvas {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
 }
 
 .scanlines {
   position: absolute;
   inset: 0;
-  z-index: 1;
+  z-index: 5;
   pointer-events: none;
-  opacity: 0.04;
+  opacity: 0.03;
   background: repeating-linear-gradient(
     0deg,
     transparent,
@@ -53,7 +55,8 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 24px;
-  background: linear-gradient(180deg, rgba(10, 8, 18, 0.9) 0%, rgba(10, 8, 18, 0) 100%);
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(10, 8, 18, 0.85) 0%, rgba(10, 8, 18, 0) 100%);
 }
 
 .mapTitle {
@@ -63,6 +66,7 @@
   letter-spacing: 4px;
   text-transform: uppercase;
   text-shadow: 0 0 12px rgba(255, 215, 0, 0.2);
+  pointer-events: auto;
 }
 
 .mapStats {
@@ -98,6 +102,7 @@
   cursor: pointer;
   transition: all 0.15s ease;
   backdrop-filter: blur(4px);
+  pointer-events: auto;
 }
 
 .backButton:hover {
@@ -106,83 +111,10 @@
   background: rgba(0, 0, 0, 0.7);
 }
 
-/* ---- Map SVG ---- */
-.mapSvg {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 2;
-  transition: transform 0.05s linear;
-}
-
-.terrainLayer {
-  opacity: 0.85;
-}
-
-.pathLayer {
-  filter: drop-shadow(0 0 4px rgba(255, 215, 0, 0.3));
-}
-
-.locationLayer {
-  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.5));
-}
-
-/* ---- Location node states ---- */
-.locationNode {
-  transition: transform 0.2s ease;
-}
-
-.locationNode:hover {
-  filter: brightness(1.2);
-}
-
-.status_locked {
-  opacity: 0.5;
-}
-
-.status_available {
-  animation: locationGlow 3s ease-in-out infinite;
-}
-
-.status_completed {
-  opacity: 1;
-}
-
-/* ---- Water shimmer animation ---- */
-.waterShimmer {
-  animation: shimmer 4s ease-in-out infinite;
-}
-
-@keyframes shimmer {
-  0%, 100% { opacity: 0.1; }
-  50% { opacity: 0.35; }
-}
-
-/* ---- Active path glow ---- */
-.activePath {
-  filter: drop-shadow(0 0 6px rgba(255, 215, 0, 0.5));
-  animation: pathPulse 2s ease-in-out infinite;
-}
-
-@keyframes pathPulse {
-  0%, 100% { stroke-opacity: 0.8; }
-  50% { stroke-opacity: 1; }
-}
-
-/* ---- Pulse ring for available locations ---- */
-.pulseRing {
-  animation: ringPulse 2s ease-in-out infinite;
-}
-
-@keyframes ringPulse {
-  0%, 100% { r: 16; opacity: 0.8; }
-  50% { r: 20; opacity: 0.5; }
-}
-
-@keyframes locationGlow {
-  0%, 100% { filter: drop-shadow(0 0 4px rgba(255, 215, 0, 0.3)); }
-  50% { filter: drop-shadow(0 0 8px rgba(255, 215, 0, 0.6)); }
+/* ---- Location beacon glow animation (used by DungeonMapVoxel) ---- */
+@keyframes beaconPulse {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 1; }
 }
 
 /* ---- Bottom info panel ---- */
@@ -200,6 +132,7 @@
   border-radius: 4px;
   backdrop-filter: blur(8px);
   box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.5);
+  pointer-events: auto;
   animation: fadeInUp 0.2s ease;
 }
 

--- a/src/components/stories/dungeonStage.module.css
+++ b/src/components/stories/dungeonStage.module.css
@@ -1,0 +1,279 @@
+/* ============================================
+   Dungeon Stage — Tetris Game Wrapper
+   ============================================ */
+
+.container {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* ---- Loading state ---- */
+.loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #0a0812;
+}
+
+.loadingText {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.5);
+  letter-spacing: 4px;
+  animation: loadPulse 1.5s ease-in-out infinite;
+}
+
+@keyframes loadPulse {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 0.8; }
+}
+
+/* ---- Mission Briefing Banner ---- */
+.briefing {
+  position: absolute;
+  top: 60px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 100;
+  pointer-events: none;
+  animation: briefingFade 3s ease forwards;
+}
+
+@keyframes briefingFade {
+  0% { opacity: 0; transform: translateX(-50%) translateY(-10px); }
+  15% { opacity: 1; transform: translateX(-50%) translateY(0); }
+  70% { opacity: 1; }
+  100% { opacity: 0; transform: translateX(-50%) translateY(-5px); }
+}
+
+.briefingContent {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 24px;
+  background: linear-gradient(180deg, rgba(10, 8, 20, 0.92) 0%, rgba(6, 4, 14, 0.96) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+}
+
+.briefingIcon {
+  font-size: 28px;
+}
+
+.briefingInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.briefingName {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.85);
+  letter-spacing: 2px;
+}
+
+.briefingDifficulty {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  color: rgba(255, 215, 0, 0.7);
+  letter-spacing: 2px;
+}
+
+/* ---- Mission Results Overlay ---- */
+.resultsOverlay {
+  position: absolute;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(5, 3, 10, 0.88);
+  backdrop-filter: blur(12px);
+  animation: fadeIn 0.5s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.resultsCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  width: 360px;
+  max-width: calc(100vw - 40px);
+  padding: 32px 28px;
+  background: linear-gradient(180deg, rgba(15, 12, 25, 0.95) 0%, rgba(8, 6, 16, 0.98) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
+}
+
+.resultsTitle {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 14px;
+  color: rgba(255, 215, 0, 0.8);
+  letter-spacing: 4px;
+  text-shadow: 0 0 12px rgba(255, 215, 0, 0.3);
+}
+
+.resultsIcon {
+  font-size: 40px;
+  margin: 4px 0;
+}
+
+.resultsName {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.7);
+  letter-spacing: 2px;
+}
+
+/* ---- Stats Grid ---- */
+.statsGrid {
+  display: flex;
+  gap: 16px;
+  width: 100%;
+  justify-content: center;
+  padding: 12px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.statItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  min-width: 80px;
+}
+
+.statLabel {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 7px;
+  color: rgba(255, 255, 255, 0.35);
+  letter-spacing: 1px;
+}
+
+.statValue {
+  font-family: 'VT323', monospace;
+  font-size: 28px;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+/* ---- Rewards Section ---- */
+.rewardsSection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.rewardsTitle {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  color: rgba(255, 215, 0, 0.5);
+  letter-spacing: 3px;
+}
+
+.rewardsList {
+  display: flex;
+  gap: 20px;
+}
+
+.reward {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.75);
+  letter-spacing: 1px;
+}
+
+/* ---- Action Buttons ---- */
+.resultsActions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  margin-top: 8px;
+}
+
+.completeBtn {
+  width: 100%;
+  padding: 14px 0;
+  background: rgba(76, 175, 80, 0.15);
+  border: 1px solid rgba(76, 175, 80, 0.3);
+  border-radius: 3px;
+  color: #4CAF50;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 10px;
+  letter-spacing: 2px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.completeBtn:hover {
+  background: rgba(76, 175, 80, 0.25);
+  border-color: rgba(76, 175, 80, 0.5);
+  color: #66BB6A;
+  text-shadow: 0 0 8px rgba(76, 175, 80, 0.3);
+}
+
+.retreatBtn {
+  width: 100%;
+  padding: 10px 0;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 3px;
+  color: rgba(255, 255, 255, 0.45);
+  font-family: 'Press Start 2P', monospace;
+  font-size: 8px;
+  letter-spacing: 2px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.retreatBtn:hover {
+  color: rgba(255, 255, 255, 0.7);
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+/* ---- Responsive ---- */
+@media (max-width: 768px) {
+  .briefingName {
+    font-size: 10px;
+  }
+
+  .briefingIcon {
+    font-size: 22px;
+  }
+
+  .resultsCard {
+    padding: 24px 20px;
+  }
+
+  .resultsTitle {
+    font-size: 11px;
+  }
+
+  .statValue {
+    font-size: 22px;
+  }
+
+  .statsGrid {
+    gap: 10px;
+  }
+
+  .statItem {
+    min-width: 60px;
+  }
+}

--- a/src/components/stories/stories.module.css
+++ b/src/components/stories/stories.module.css
@@ -334,6 +334,13 @@
     font-size: 16px;
     color: rgba(255, 255, 255, 0.35);
     letter-spacing: 1px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.missionLabel {
+    font-size: 18px;
 }
 
 /* ---- Back Button ---- */

--- a/src/data/stories/dungeons.ts
+++ b/src/data/stories/dungeons.ts
@@ -95,8 +95,18 @@ export interface DungeonProgress {
 const MAP_WIDTH = 24;
 const MAP_HEIGHT = 16;
 
+// Seeded PRNG for deterministic terrain (stable across renders)
+function mapSeededRandom(seed: number) {
+  let s = seed;
+  return () => {
+    s = (s * 16807 + 0) % 2147483647;
+    return (s - 1) / 2147483646;
+  };
+}
+
 function generateMapTerrain(): MapTile[] {
   const tiles: MapTile[] = [];
+  const rand = mapSeededRandom(54321);
 
   for (let y = 0; y < MAP_HEIGHT; y++) {
     for (let x = 0; x < MAP_WIDTH; x++) {
@@ -105,8 +115,8 @@ function generateMapTerrain(): MapTile[] {
 
       // Forest region (left side)
       if (x < 8 && y > 3 && y < 13) {
-        terrain = Math.random() > 0.7 ? 'tree' : 'grass';
-        elevation = Math.random() > 0.8 ? 1 : 0;
+        terrain = rand() > 0.7 ? 'tree' : 'grass';
+        elevation = rand() > 0.8 ? 1 : 0;
         if (x < 3) terrain = 'tree';
       }
 
@@ -118,7 +128,7 @@ function generateMapTerrain(): MapTile[] {
 
       // Storm/mountain region (right side)
       if (x > 16 && y < 10) {
-        terrain = Math.random() > 0.5 ? 'stone' : 'rock';
+        terrain = rand() > 0.5 ? 'stone' : 'rock';
         elevation = Math.min(3, Math.floor((x - 16) / 2) + 1);
       }
 
@@ -148,10 +158,10 @@ function generateMapTerrain(): MapTile[] {
       }
 
       // Decorative elements
-      if (terrain === 'grass' && Math.random() > 0.92) {
+      if (terrain === 'grass' && rand() > 0.92) {
         terrain = 'flower';
       }
-      if (terrain === 'grass' && y > 12 && Math.random() > 0.85) {
+      if (terrain === 'grass' && y > 12 && rand() > 0.85) {
         terrain = 'mushroom';
       }
 
@@ -161,7 +171,6 @@ function generateMapTerrain(): MapTile[] {
           [x - 1, y], [x + 1, y], [x, y - 1], [x, y + 1],
         ].some(([nx, ny]) => {
           if (nx < 0 || nx >= MAP_WIDTH || ny < 0 || ny >= MAP_HEIGHT) return false;
-          // Check inline (simplified — terrain gen is deterministic by position)
           return (
             (nx >= 7 && nx <= 8 && ny >= 0 && ny <= 7) ||
             (nx >= 8 && nx <= 10 && ny >= 7 && ny <= 8) ||
@@ -178,7 +187,7 @@ function generateMapTerrain(): MapTile[] {
   return tiles;
 }
 
-// Use a stable seeded generation (call once)
+// Deterministic terrain (stable across renders)
 export const MAP_TERRAIN: MapTile[] = generateMapTerrain();
 export { MAP_WIDTH, MAP_HEIGHT };
 

--- a/src/data/stories/dungeons.ts
+++ b/src/data/stories/dungeons.ts
@@ -1,0 +1,445 @@
+// =============================================================
+// Minecraft Dungeons Map System — Data & Types
+// Defines dungeon locations, isometric map layout, terrain,
+// paths, and connections to story chapters
+// =============================================================
+
+import type { Chapter } from './chapters';
+import { CHAPTERS } from './chapters';
+
+// === Types ===
+
+export type TerrainType =
+  | 'grass' | 'dirt' | 'stone' | 'water' | 'sand'
+  | 'snow' | 'lava' | 'void' | 'path' | 'bridge'
+  | 'tree' | 'flower' | 'rock' | 'mushroom';
+
+export type LocationStatus = 'locked' | 'available' | 'completed';
+
+export interface MapTile {
+  x: number;
+  y: number;
+  terrain: TerrainType;
+  elevation: number; // 0-3 height levels for isometric depth
+}
+
+export interface MapPath {
+  from: string; // location ID
+  to: string;   // location ID
+  // waypoints for the path curve (isometric grid coords)
+  waypoints: { x: number; y: number }[];
+}
+
+export interface DungeonLocation {
+  id: string;
+  name: string;
+  nameEn: string;
+  description: string;
+  descriptionEn: string;
+  // Position on the isometric map grid
+  mapX: number;
+  mapY: number;
+  // Visual properties
+  icon: string;     // emoji icon for the location marker
+  accentColor: string;
+  biome: 'forest' | 'village' | 'storm' | 'mountain' | 'cave';
+  // Gameplay
+  chapterId: string | null;    // links to a Chapter from chapters.ts
+  difficulty: number;           // 1-5 stars
+  estimatedMinutes: number;
+  // Exploration dungeon data
+  dungeonWidth: number;
+  dungeonHeight: number;
+  dungeonTiles: DungeonTile[];
+  dungeonMobs: DungeonMob[];
+  dungeonItems: DungeonItem[];
+  // Prerequisites (location IDs that must be completed first)
+  requires: string[];
+}
+
+export interface DungeonTile {
+  x: number;
+  y: number;
+  type: 'floor' | 'wall' | 'water' | 'lava' | 'chest' | 'door' | 'exit' | 'entrance' | 'trap' | 'cracked_wall';
+  variant?: number; // visual variation
+}
+
+export interface DungeonMob {
+  id: string;
+  type: 'zombie' | 'skeleton' | 'spider' | 'creeper' | 'enderman';
+  x: number;
+  y: number;
+  health: number;
+  damage: number;
+  loot?: string;
+}
+
+export interface DungeonItem {
+  id: string;
+  type: 'key' | 'potion' | 'emerald' | 'artifact' | 'bread' | 'arrow';
+  x: number;
+  y: number;
+  name: string;
+  nameEn: string;
+}
+
+export interface DungeonProgress {
+  completedLocations: string[];
+  currentLocation: string | null;
+  totalEmeralds: number;
+  totalDefeated: number;
+}
+
+// === Map terrain data (isometric grid 24x16) ===
+
+const MAP_WIDTH = 24;
+const MAP_HEIGHT = 16;
+
+function generateMapTerrain(): MapTile[] {
+  const tiles: MapTile[] = [];
+
+  for (let y = 0; y < MAP_HEIGHT; y++) {
+    for (let x = 0; x < MAP_WIDTH; x++) {
+      let terrain: TerrainType = 'grass';
+      let elevation = 0;
+
+      // Forest region (left side)
+      if (x < 8 && y > 3 && y < 13) {
+        terrain = Math.random() > 0.7 ? 'tree' : 'grass';
+        elevation = Math.random() > 0.8 ? 1 : 0;
+        if (x < 3) terrain = 'tree';
+      }
+
+      // Village region (center)
+      if (x >= 9 && x <= 15 && y >= 5 && y <= 10) {
+        terrain = 'dirt';
+        elevation = 0;
+      }
+
+      // Storm/mountain region (right side)
+      if (x > 16 && y < 10) {
+        terrain = Math.random() > 0.5 ? 'stone' : 'rock';
+        elevation = Math.min(3, Math.floor((x - 16) / 2) + 1);
+      }
+
+      // River flowing through
+      if (
+        (x >= 7 && x <= 8 && y >= 0 && y <= 7) ||
+        (x >= 8 && x <= 10 && y >= 7 && y <= 8) ||
+        (x >= 10 && x <= 11 && y >= 8 && y <= 15)
+      ) {
+        terrain = 'water';
+        elevation = 0;
+      }
+
+      // Bridges over water at path crossings
+      if (terrain === 'water' && ((x === 8 && y === 5) || (x === 10 && y === 10))) {
+        terrain = 'bridge';
+      }
+
+      // Path connections (will be overridden by paths between locations)
+      if (
+        (y === 8 && x >= 4 && x <= 18) ||
+        (x === 12 && y >= 4 && y <= 12)
+      ) {
+        if (terrain !== 'water' && terrain !== 'bridge') {
+          terrain = 'path';
+        }
+      }
+
+      // Decorative elements
+      if (terrain === 'grass' && Math.random() > 0.92) {
+        terrain = 'flower';
+      }
+      if (terrain === 'grass' && y > 12 && Math.random() > 0.85) {
+        terrain = 'mushroom';
+      }
+
+      // Sandy edges near water
+      if (terrain === 'grass') {
+        const nearWater = [
+          [x - 1, y], [x + 1, y], [x, y - 1], [x, y + 1],
+        ].some(([nx, ny]) => {
+          if (nx < 0 || nx >= MAP_WIDTH || ny < 0 || ny >= MAP_HEIGHT) return false;
+          // Check inline (simplified — terrain gen is deterministic by position)
+          return (
+            (nx >= 7 && nx <= 8 && ny >= 0 && ny <= 7) ||
+            (nx >= 8 && nx <= 10 && ny >= 7 && ny <= 8) ||
+            (nx >= 10 && nx <= 11 && ny >= 8 && ny <= 15)
+          );
+        });
+        if (nearWater) terrain = 'sand';
+      }
+
+      tiles.push({ x, y, terrain, elevation });
+    }
+  }
+
+  return tiles;
+}
+
+// Use a stable seeded generation (call once)
+export const MAP_TERRAIN: MapTile[] = generateMapTerrain();
+export { MAP_WIDTH, MAP_HEIGHT };
+
+// === Dungeon location definitions ===
+
+export const DUNGEON_LOCATIONS: DungeonLocation[] = [
+  {
+    id: 'camp',
+    name: 'キャンプ',
+    nameEn: 'Camp',
+    description: '冒険者たちの集う拠点。ここから旅が始まる。',
+    descriptionEn: 'The base where adventurers gather. Your journey begins here.',
+    mapX: 4,
+    mapY: 8,
+    icon: '🏕️',
+    accentColor: '#8B6914',
+    biome: 'forest',
+    chapterId: null, // Hub — no chapter
+    difficulty: 0,
+    estimatedMinutes: 0,
+    dungeonWidth: 0,
+    dungeonHeight: 0,
+    dungeonTiles: [],
+    dungeonMobs: [],
+    dungeonItems: [],
+    requires: [],
+  },
+  {
+    id: 'creeper-woods',
+    name: '目覚めの森',
+    nameEn: 'Creeper Woods',
+    description: '深い森の奥、朝靄が木々の間を漂っている。アズレアとの出会いの場所。',
+    descriptionEn: 'Deep in the forest, morning mist drifts between the trees. The place where you meet Azurea.',
+    mapX: 6,
+    mapY: 5,
+    icon: '🌲',
+    accentColor: '#4CAF50',
+    biome: 'forest',
+    chapterId: 'awakening',
+    difficulty: 1,
+    estimatedMinutes: 5,
+    dungeonWidth: 12,
+    dungeonHeight: 10,
+    dungeonTiles: [
+      // Entrance area
+      ...Array.from({ length: 4 }, (_, i) => ({ x: 1, y: 4 + i, type: 'floor' as const })),
+      { x: 0, y: 5, type: 'entrance' as const },
+      // Main corridor
+      ...Array.from({ length: 8 }, (_, i) => ({ x: 2 + i, y: 5, type: 'floor' as const })),
+      ...Array.from({ length: 8 }, (_, i) => ({ x: 2 + i, y: 6, type: 'floor' as const })),
+      // Side rooms
+      ...Array.from({ length: 3 }, (_, i) => ({ x: 4 + i, y: 3, type: 'floor' as const })),
+      ...Array.from({ length: 3 }, (_, i) => ({ x: 4 + i, y: 4, type: 'floor' as const })),
+      { x: 5, y: 3, type: 'chest' as const },
+      // Bottom room
+      ...Array.from({ length: 4 }, (_, i) => ({ x: 7 + i, y: 7, type: 'floor' as const })),
+      ...Array.from({ length: 4 }, (_, i) => ({ x: 7 + i, y: 8, type: 'floor' as const })),
+      { x: 9, y: 8, type: 'chest' as const },
+      // Exit
+      { x: 10, y: 5, type: 'door' as const },
+      { x: 11, y: 5, type: 'exit' as const },
+    ],
+    dungeonMobs: [
+      { id: 'z1', type: 'zombie', x: 5, y: 5, health: 3, damage: 1 },
+      { id: 'z2', type: 'zombie', x: 7, y: 6, health: 3, damage: 1 },
+      { id: 's1', type: 'spider', x: 8, y: 8, health: 2, damage: 1 },
+    ],
+    dungeonItems: [
+      { id: 'bread1', type: 'bread', x: 3, y: 6, name: 'パン', nameEn: 'Bread' },
+      { id: 'em1', type: 'emerald', x: 5, y: 4, name: 'エメラルド', nameEn: 'Emerald' },
+    ],
+    requires: ['camp'],
+  },
+  {
+    id: 'soggy-village',
+    name: 'メロディア村',
+    nameEn: 'Melodia Village',
+    description: '青い光に包まれた村。リズミアで最初に生まれた場所。',
+    descriptionEn: 'A village bathed in blue light. The first place born in Rhythmia.',
+    mapX: 12,
+    mapY: 7,
+    icon: '🏘️',
+    accentColor: '#2196F3',
+    biome: 'village',
+    chapterId: 'melodia',
+    difficulty: 2,
+    estimatedMinutes: 8,
+    dungeonWidth: 14,
+    dungeonHeight: 12,
+    dungeonTiles: [
+      // Village entrance
+      { x: 0, y: 6, type: 'entrance' as const },
+      ...Array.from({ length: 12 }, (_, i) => ({ x: 1 + i, y: 6, type: 'floor' as const })),
+      ...Array.from({ length: 12 }, (_, i) => ({ x: 1 + i, y: 7, type: 'floor' as const })),
+      // Upper area
+      ...Array.from({ length: 6 }, (_, i) => ({ x: 3 + i, y: 3, type: 'floor' as const })),
+      ...Array.from({ length: 6 }, (_, i) => ({ x: 3 + i, y: 4, type: 'floor' as const })),
+      ...Array.from({ length: 6 }, (_, i) => ({ x: 3 + i, y: 5, type: 'floor' as const })),
+      // Water feature in center
+      { x: 6, y: 4, type: 'water' as const },
+      { x: 7, y: 4, type: 'water' as const },
+      { x: 6, y: 5, type: 'water' as const },
+      // Lower area
+      ...Array.from({ length: 8 }, (_, i) => ({ x: 3 + i, y: 8, type: 'floor' as const })),
+      ...Array.from({ length: 8 }, (_, i) => ({ x: 3 + i, y: 9, type: 'floor' as const })),
+      ...Array.from({ length: 4 }, (_, i) => ({ x: 5 + i, y: 10, type: 'floor' as const })),
+      // Chests
+      { x: 4, y: 3, type: 'chest' as const },
+      { x: 10, y: 9, type: 'chest' as const },
+      // Exit
+      { x: 13, y: 6, type: 'door' as const },
+      { x: 13, y: 7, type: 'exit' as const },
+    ],
+    dungeonMobs: [
+      { id: 'z3', type: 'zombie', x: 5, y: 6, health: 4, damage: 1 },
+      { id: 'sk1', type: 'skeleton', x: 8, y: 4, health: 3, damage: 2 },
+      { id: 'z4', type: 'zombie', x: 9, y: 8, health: 4, damage: 1 },
+      { id: 'sp1', type: 'spider', x: 6, y: 9, health: 3, damage: 1 },
+    ],
+    dungeonItems: [
+      { id: 'pot1', type: 'potion', x: 4, y: 7, name: 'ポーション', nameEn: 'Potion' },
+      { id: 'em2', type: 'emerald', x: 11, y: 7, name: 'エメラルド', nameEn: 'Emerald' },
+      { id: 'em3', type: 'emerald', x: 4, y: 3, name: 'エメラルド', nameEn: 'Emerald' },
+      { id: 'key1', type: 'key', x: 7, y: 9, name: '鍵', nameEn: 'Key' },
+    ],
+    requires: ['creeper-woods'],
+  },
+  {
+    id: 'highblock-halls',
+    name: '嵐の高台',
+    nameEn: 'Highblock Halls',
+    description: '空が暗くなり、不穏なリズムが大地を揺らし始めた。ディスコードの波が迫る。',
+    descriptionEn: 'The sky darkens, and an ominous rhythm shakes the earth. The wave of Discord approaches.',
+    mapX: 18,
+    mapY: 5,
+    icon: '⛈️',
+    accentColor: '#FF6B6B',
+    biome: 'storm',
+    chapterId: 'crescendo',
+    difficulty: 3,
+    estimatedMinutes: 10,
+    dungeonWidth: 16,
+    dungeonHeight: 14,
+    dungeonTiles: [
+      // Entry hall
+      { x: 0, y: 7, type: 'entrance' as const },
+      ...Array.from({ length: 6 }, (_, i) => ({ x: 1 + i, y: 7, type: 'floor' as const })),
+      ...Array.from({ length: 6 }, (_, i) => ({ x: 1 + i, y: 8, type: 'floor' as const })),
+      // Central chamber
+      ...Array.from({ length: 6 }, (_, i) => ({ x: 5 + i, y: 4, type: 'floor' as const })),
+      ...Array.from({ length: 6 }, (_, i) => ({ x: 5 + i, y: 5, type: 'floor' as const })),
+      ...Array.from({ length: 6 }, (_, i) => ({ x: 5 + i, y: 6, type: 'floor' as const })),
+      ...Array.from({ length: 6 }, (_, i) => ({ x: 5 + i, y: 7, type: 'floor' as const })),
+      ...Array.from({ length: 6 }, (_, i) => ({ x: 5 + i, y: 8, type: 'floor' as const })),
+      ...Array.from({ length: 6 }, (_, i) => ({ x: 5 + i, y: 9, type: 'floor' as const })),
+      // Lava hazards
+      { x: 6, y: 5, type: 'lava' as const },
+      { x: 9, y: 5, type: 'lava' as const },
+      { x: 7, y: 9, type: 'lava' as const },
+      { x: 8, y: 9, type: 'lava' as const },
+      // Traps
+      { x: 6, y: 7, type: 'trap' as const },
+      { x: 9, y: 6, type: 'trap' as const },
+      // Right wing
+      ...Array.from({ length: 4 }, (_, i) => ({ x: 11 + i, y: 6, type: 'floor' as const })),
+      ...Array.from({ length: 4 }, (_, i) => ({ x: 11 + i, y: 7, type: 'floor' as const })),
+      ...Array.from({ length: 4 }, (_, i) => ({ x: 11 + i, y: 8, type: 'floor' as const })),
+      // Chests
+      { x: 13, y: 6, type: 'chest' as const },
+      { x: 8, y: 4, type: 'chest' as const },
+      // Boss door and exit
+      { x: 14, y: 7, type: 'door' as const },
+      { x: 15, y: 7, type: 'exit' as const },
+    ],
+    dungeonMobs: [
+      { id: 'z5', type: 'zombie', x: 6, y: 6, health: 5, damage: 2 },
+      { id: 'sk2', type: 'skeleton', x: 9, y: 7, health: 4, damage: 2 },
+      { id: 'sk3', type: 'skeleton', x: 12, y: 7, health: 4, damage: 2 },
+      { id: 'cr1', type: 'creeper', x: 7, y: 8, health: 5, damage: 3 },
+      { id: 'en1', type: 'enderman', x: 13, y: 7, health: 8, damage: 3, loot: 'artifact' },
+    ],
+    dungeonItems: [
+      { id: 'pot2', type: 'potion', x: 5, y: 8, name: 'ポーション', nameEn: 'Potion' },
+      { id: 'pot3', type: 'potion', x: 11, y: 8, name: 'ポーション', nameEn: 'Potion' },
+      { id: 'em4', type: 'emerald', x: 8, y: 4, name: 'エメラルド', nameEn: 'Emerald' },
+      { id: 'em5', type: 'emerald', x: 14, y: 6, name: 'エメラルド', nameEn: 'Emerald' },
+      { id: 'art1', type: 'artifact', x: 10, y: 6, name: 'リズムの欠片', nameEn: 'Rhythm Shard' },
+    ],
+    requires: ['soggy-village'],
+  },
+];
+
+// === Map paths connecting locations ===
+
+export const MAP_PATHS: MapPath[] = [
+  {
+    from: 'camp',
+    to: 'creeper-woods',
+    waypoints: [
+      { x: 4, y: 8 },
+      { x: 5, y: 7 },
+      { x: 5, y: 6 },
+      { x: 6, y: 5 },
+    ],
+  },
+  {
+    from: 'creeper-woods',
+    to: 'soggy-village',
+    waypoints: [
+      { x: 6, y: 5 },
+      { x: 7, y: 6 },
+      { x: 8, y: 6 },
+      { x: 9, y: 7 },
+      { x: 10, y: 7 },
+      { x: 12, y: 7 },
+    ],
+  },
+  {
+    from: 'soggy-village',
+    to: 'highblock-halls',
+    waypoints: [
+      { x: 12, y: 7 },
+      { x: 13, y: 7 },
+      { x: 14, y: 6 },
+      { x: 15, y: 6 },
+      { x: 16, y: 5 },
+      { x: 18, y: 5 },
+    ],
+  },
+];
+
+// === Helpers ===
+
+export function getChapterForLocation(location: DungeonLocation): Chapter | null {
+  if (!location.chapterId) return null;
+  return CHAPTERS.find(c => c.id === location.chapterId) ?? null;
+}
+
+export function getLocationStatus(
+  locationId: string,
+  progress: DungeonProgress
+): LocationStatus {
+  if (progress.completedLocations.includes(locationId)) return 'completed';
+
+  const location = DUNGEON_LOCATIONS.find(l => l.id === locationId);
+  if (!location) return 'locked';
+
+  // Camp is always available
+  if (location.requires.length === 0) return 'available';
+
+  // Check if all prerequisites are completed
+  const allRequirementsMet = location.requires.every(
+    req => progress.completedLocations.includes(req)
+  );
+
+  return allRequirementsMet ? 'available' : 'locked';
+}
+
+export const DEFAULT_PROGRESS: DungeonProgress = {
+  completedLocations: ['camp'], // Camp starts as completed
+  currentLocation: null,
+  totalEmeralds: 0,
+  totalDefeated: 0,
+};


### PR DESCRIPTION
Replaces the flat chapter select screen in StoryViewer with an isometric pixel-art overworld map (Minecraft Dungeons style). Each map location links to a story chapter and includes a tile-based dungeon exploration mini-game that plays after the visual novel cutscene.

Key additions:
- DungeonMap: Isometric SVG-rendered overworld with terrain tiles (grass, trees, water, bridges, mountains), animated paths between locations, and clickable mission nodes with status indicators (locked/available/ completed)
- DungeonExplorer: Grid-based dungeon crawler with WASD/arrow movement, turn-based combat against mobs, item pickups (potions, emeralds, keys, artifacts), chests, traps, and victory/defeat screens
- dungeons.ts: Data model with 4 locations (Camp hub, Creeper Woods, Melodia Village, Highblock Halls) mapped to existing story chapters, including dungeon tile layouts, mob placements, and item positions
- Progression tracking persisted to localStorage with emerald/defeat counters and location completion state
- Flow: Map → Story cutscene (visual novel) → Dungeon exploration → Map with progression updated
- Mobile support with touch-drag map panning and on-screen D-pad for dungeon exploration

https://claude.ai/code/session_01Hmb8bL54Bc6p1RVyvKcVcG