### PR TITLE
Configure Firebase authentication rewrites and update auth domain

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,14 @@ const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 const nextConfig = {
   // Empty turbopack config to silence build warnings about webpack config
   turbopack: {},
+  async rewrites() {
+    return [
+      {
+        source: '/__/auth/:path*',
+        destination: 'https://azuret-website.firebaseapp.com/__/auth/:path*',
+      },
+    ];
+  },
   async headers() {
     return [
       {

--- a/src/lib/rhythmia/firebase.ts
+++ b/src/lib/rhythmia/firebase.ts
@@ -11,7 +11,7 @@ const firebaseConfig = {
   //messagingSenderId: process.env.NEXT_PUBLIC_RHYTHMIA_FIREBASE_MESSAGING_SENDER_ID,
   //appId: process.env.NEXT_PUBLIC_RHYTHMIA_FIREBASE_APP_ID,
   apiKey: "AIzaSyBPzQ0xqJYktU6GMp2tzM1nvZJZDz5PWUk",
-  authDomain: "azuret-website.firebaseapp.com",
+  authDomain: "azuretier.net",
   projectId: "azuret-website",
   storageBucket: "azuret-website.firebasestorage.app",
   messagingSenderId: "527106975022",


### PR DESCRIPTION
## Summary
This PR updates the Firebase authentication configuration to use a custom domain while maintaining proper request routing through Next.js rewrites.

## Key Changes
- Added Next.js rewrites configuration to proxy Firebase authentication requests from `/__/auth/*` to the Firebase hosting domain
- Updated Firebase `authDomain` from `azuret-website.firebaseapp.com` to `azuretier.net` to use a custom domain

## Implementation Details
The rewrites configuration ensures that Firebase authentication endpoints (sign-in, sign-up, password reset, etc.) are properly routed to the Firebase backend while allowing the application to use a custom domain (`azuretier.net`) for the auth domain configuration. This approach maintains Firebase authentication functionality while presenting a branded domain to users.

https://claude.ai/code/session_01C9orq4eH8w8ifHbRwVxMPp