### PR TITLE
Fix stale closure in multiplayer WebSocket connection

### DIFF
--- a/src/components/rhythmia/RhythmiaLobby.tsx
+++ b/src/components/rhythmia/RhythmiaLobby.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslations, useLocale } from 'next-intl';
 import type { ServerMessage, OnlineUser } from '@/types/multiplayer';
+import type { UserProfile } from '@/lib/profile/types';
 import { getUnlockedCount } from '@/lib/advancements/storage';
 import { ADVANCEMENTS, BATTLE_ARENA_REQUIRED_ADVANCEMENTS } from '@/lib/advancements/definitions';
 import { useProfile } from '@/lib/profile/context';
@@ -38,11 +39,17 @@ export default function RhythmiaLobby() {
     const [showLogoAnimation, setShowLogoAnimation] = useState(false);
     const wsRef = useRef<WebSocket | null>(null);
     const profileSentRef = useRef(false);
+    const profileRef = useRef<UserProfile | null>(null);
 
     const t = useTranslations();
     const locale = useLocale();
     const router = useRouter();
     const { profile, showProfileSetup } = useProfile();
+
+    // Keep profileRef in sync so connectMultiplayerWs can read latest profile without dependency
+    useEffect(() => {
+        profileRef.current = profile;
+    }, [profile]);
 
     const isArenaLocked = unlockedCount < BATTLE_ARENA_REQUIRED_ADVANCEMENTS;
 
@@ -90,13 +97,14 @@ export default function RhythmiaLobby() {
         profileSentRef.current = false;
 
         ws.onopen = () => {
-            // Send profile info once connected
-            if (profile) {
+            // Send profile info once connected (use ref to avoid stale closure)
+            const currentProfile = profileRef.current;
+            if (currentProfile) {
                 ws.send(JSON.stringify({
                     type: 'set_profile',
-                    name: profile.name,
-                    icon: profile.icon,
-                    isPrivate: profile.isPrivate,
+                    name: currentProfile.name,
+                    icon: currentProfile.icon,
+                    isPrivate: currentProfile.isPrivate,
                 }));
                 profileSentRef.current = true;
             }
@@ -121,7 +129,7 @@ export default function RhythmiaLobby() {
         };
 
         wsRef.current = ws;
-    }, [profile]);
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
         connectMultiplayerWs();


### PR DESCRIPTION
## Summary
Fixed a stale closure issue in the `connectMultiplayerWs` function where the `profile` dependency was causing unnecessary reconnections and potential race conditions. The WebSocket connection now uses a ref to access the latest profile without triggering effect re-runs.

## Key Changes
- Added `profileRef` to store the current user profile and keep it in sync via a separate effect
- Modified `connectMultiplayerWs` to read from `profileRef.current` instead of the `profile` dependency, avoiding stale closures
- Removed `profile` from the dependency array of `connectMultiplayerWs` effect and added an eslint disable comment to document the intentional omission
- Added `UserProfile` type import to support the new ref typing

## Implementation Details
The fix uses a common React pattern where a ref is kept in sync with state via a separate effect. This allows the WebSocket connection setup to access the latest profile data without creating a dependency on the `profile` state variable, which would cause the effect to re-run every time the profile changes. The `profileSentRef` continues to track whether the profile has been sent to prevent duplicate messages.

https://claude.ai/code/session_018HnqJdJwSDFAiW2VVUqTHH