### PR TITLE
Remove intermediate transition phase before card select

### DIFF
--- a/src/components/rhythmia/tetris/hooks/useGameState.ts
+++ b/src/components/rhythmia/tetris/hooks/useGameState.ts
@@ -952,16 +952,8 @@ export function useGameState() {
             // Abort transition if player died during collapse
             if (gameOverRef.current) return;
 
-            setGamePhase('TRANSITION');
-            gamePhaseRef.current = 'TRANSITION';
-
-            setTimeout(() => {
-                // Abort transition if player died during transition
-                if (gameOverRef.current) return;
-
-                // Enter card select — player picks a rogue card before next stage
-                enterCardSelect();
-            }, 1200);
+            // Enter card select directly — stage transition effects play after selection
+            enterCardSelect();
         }, 1200);
     }, [enterCardSelect]);
 


### PR DESCRIPTION
## Summary
Simplified the stage completion flow by removing the intermediate `TRANSITION` game phase that occurred between stage collapse and card selection. The card select now triggers immediately after collapse, with transition effects playing after the player makes their selection.

## Key Changes
- Removed the `setGamePhase('TRANSITION')` call and associated state update
- Eliminated the nested `setTimeout` that delayed card select entry by 1200ms
- `enterCardSelect()` now executes directly after the collapse animation completes
- Transition effects are now deferred to occur after card selection rather than before

## Implementation Details
- The outer 1200ms timeout (for collapse animation) is preserved
- Game over checks during the transition phase are no longer needed since the phase was removed
- This change streamlines the UX by reducing the number of sequential delays in the stage completion flow

https://claude.ai/code/session_01FePw7E3BZAvUZUXwYCoZTd