### PR TITLE
Fix Minecraft Board reconnection and game state sync issues

### DIFF
--- a/src/components/minecraft-board/MinecraftBoardGame.tsx
+++ b/src/components/minecraft-board/MinecraftBoardGame.tsx
@@ -372,6 +372,18 @@ export default function MinecraftBoardGame() {
     );
   }
 
+  // === Playing Phase - Waiting for initial state ===
+  if (phase === 'playing' && (!selfState || !playerId)) {
+    return (
+      <div className={styles.page}>
+        <div className={styles.centerBox}>
+          <div className={styles.spinner} />
+          <p>Loading world...</p>
+        </div>
+      </div>
+    );
+  }
+
   // === Playing Phase ===
   if (phase === 'playing' && selfState && playerId) {
     return (

--- a/src/lib/minecraft-board/MinecraftBoardManager.ts
+++ b/src/lib/minecraft-board/MinecraftBoardManager.ts
@@ -165,6 +165,32 @@ export class MinecraftBoardManager {
     return { roomCode };
   }
 
+  transferPlayer(oldPlayerId: string, newPlayerId: string): void {
+    const roomCode = this.playerRoomMap.get(oldPlayerId);
+    if (!roomCode) return;
+    const room = this.rooms.get(roomCode);
+    if (!room) return;
+    const player = room.players.get(oldPlayerId);
+    if (!player) return;
+
+    player.id = newPlayerId;
+    player.connected = true;
+    room.players.delete(oldPlayerId);
+    room.players.set(newPlayerId, player);
+    this.playerRoomMap.delete(oldPlayerId);
+    this.playerRoomMap.set(newPlayerId, roomCode);
+    if (room.hostId === oldPlayerId) room.hostId = newPlayerId;
+  }
+
+  markReconnected(playerId: string): void {
+    const roomCode = this.playerRoomMap.get(playerId);
+    if (!roomCode) return;
+    const room = this.rooms.get(roomCode);
+    if (!room) return;
+    const player = room.players.get(playerId);
+    if (player) player.connected = true;
+  }
+
   // === Game Start ===
 
   startGame(playerId: string): { success: boolean; error?: string; gameSeed?: number } {


### PR DESCRIPTION
## Summary
This PR fixes critical issues with player reconnection and game state synchronization in the Minecraft Board game mode. It addresses race conditions during WebSocket reconnection, improves game phase transitions, and implements proper player session recovery.

## Key Changes

### Client-side (useMinecraftBoardSocket.ts)
- **Phase state tracking**: Added `phaseRef` to maintain current phase in a ref alongside state, enabling accurate phase checks in async callbacks
- **Wrapped setPhase**: Created a `setPhase` callback that updates both the ref and state to keep them in sync
- **WebSocket safety checks**: Added guards in `onopen` and `onclose` handlers to ignore stale WebSocket instances when a newer connection replaces an old one
- **Improved reconnection logic**: Modified `attemptReconnect` to only auto-reconnect if a session token exists (i.e., player was in a room)
- **Game state reset timing**: Moved game state cleanup (explored tiles, chat, winner) from `mc_game_started` to the first `mc_countdown` message to prevent premature resets
- **Reconnection handler**: Added `mc_reconnected` message handler to properly restore player state after reconnection
- **Error handling**: Added error code checking for `RECONNECT_FAILED` and `ROOM_GONE` to clear stale tokens and reset to menu

### Server-side (multiplayer-server.ts)
- **Game start sequence**: Changed to send `mc_game_started` message before calling `beginPlaying()` to ensure clients transition to 'playing' phase before receiving state updates
- **Error handling**: Added try-catch around `beginPlaying()` with error broadcast to clients
- **MC Board reconnection**: Implemented fallback logic to check MC Board rooms when standard room lookup fails
- **Player transfer**: Added `transferPlayer()` call to update player ID mappings during reconnection
- **Reconnection response**: Send `mc_reconnected` message with room state and new token to successfully reconnected players

### Manager (MinecraftBoardManager.ts)
- **transferPlayer()**: New method to update player ID mappings and transfer player state when reconnecting with a new socket ID
- **markReconnected()**: New method to mark a player as connected after successful reconnection

### UI (MinecraftBoardGame.tsx)
- **Loading state**: Added intermediate loading screen when in 'playing' phase but waiting for initial state (selfState/playerId) to prevent rendering incomplete game state

## Notable Implementation Details
- The phase ref pattern ensures callbacks like message handlers can accurately check the current phase without stale closures
- WebSocket instance checks prevent race conditions where multiple connection attempts could cause conflicting state updates
- Game state reset is now tied to the countdown phase rather than game start, providing a clearer synchronization point
- The server now sends game_started before state updates, allowing clients to properly initialize before receiving data

https://claude.ai/code/session_01JMirRC53w9acbuKdpPM8S5