### PR TITLE
Add z-index to miniStep hover state in LoyaltyWidget

### DIFF
--- a/src/components/loyalty/LoyaltyWidget.module.css
+++ b/src/components/loyalty/LoyaltyWidget.module.css
@@ -185,6 +185,7 @@
 .miniStep:hover {
   border-color: rgba(255, 255, 255, 0.15);
   background: rgba(255, 255, 255, 0.04);
+  z-index: 10;
 }
 
 .miniStep.active {


### PR DESCRIPTION
## Summary
Added z-index stacking context to the miniStep hover state to ensure proper layering of interactive elements in the LoyaltyWidget component.

## Changes
- Added `z-index: 10;` to the `.miniStep:hover` CSS rule in LoyaltyWidget.module.css

## Details
This change ensures that when users hover over mini step elements, they appear above other page content with a defined stacking order. This prevents hover states from being obscured by other elements and improves the visual feedback and usability of the loyalty widget interface.

https://claude.ai/code/session_019WTo1K2gQqremsuxZRCDHX