### PR TITLE
Improve loyalty tier popup styling and transitions

### DIFF
--- a/src/components/loyalty/LoyaltyWidget.module.css
+++ b/src/components/loyalty/LoyaltyWidget.module.css
@@ -178,7 +178,7 @@
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.02);
   border: 1px solid rgba(255, 255, 255, 0.05);
-  transition: all 0.3s;
+  transition: border-color 0.3s, background 0.3s;
   cursor: default;
 }
 
@@ -233,6 +233,15 @@
   border-radius: 12px;
   box-shadow: 0 10px 32px rgba(0, 0, 0, 0.45);
   animation: barPopIn 0.15s ease-out;
+}
+
+.tierBarPopup::before {
+  content: '';
+  position: absolute;
+  top: -10px;
+  left: 0;
+  right: 0;
+  height: 10px;
 }
 
 @keyframes barPopIn {

--- a/src/components/loyalty/loyalty.module.css
+++ b/src/components/loyalty/loyalty.module.css
@@ -230,7 +230,7 @@
   padding: 20px 16px;
   text-align: center;
   position: relative;
-  transition: all 0.3s;
+  transition: border-color 0.3s, background 0.3s;
   cursor: default;
 }
 
@@ -294,6 +294,15 @@
   border-radius: 12px;
   box-shadow: 0 10px 32px rgba(0, 0, 0, 0.45);
   animation: barPopIn 0.15s ease-out;
+}
+
+.tierBarPopup::before {
+  content: '';
+  position: absolute;
+  top: -10px;
+  left: 0;
+  right: 0;
+  height: 10px;
 }
 
 @keyframes barPopIn {


### PR DESCRIPTION
## Summary
This PR refines the CSS styling for loyalty tier components by optimizing CSS transitions and improving the visual presentation of tier bar popups with a clickable hover area.

## Key Changes
- **Optimized transitions**: Changed from `transition: all 0.3s` to `transition: border-color 0.3s, background 0.3s` in both `LoyaltyWidget.module.css` and `loyalty.module.css`. This improves performance by only animating relevant properties instead of all properties.
- **Added popup hover area**: Introduced a `::before` pseudo-element on `.tierBarPopup` that creates a 10px invisible clickable area above the popup. This improves UX by extending the interactive zone and making it easier to interact with the popup.

## Implementation Details
- The `::before` pseudo-element uses `position: absolute` with `top: -10px` to position it above the popup
- The element spans the full width (`left: 0; right: 0`) with a fixed height of 10px
- Changes were applied consistently across both CSS modules to maintain parity

https://claude.ai/code/session_01ArPTG8oaeXdyXf3c9BukJZ