### PR TITLE
Add App Check token validation before auth initialization

### DIFF
--- a/src/lib/advancements/firestore.ts
+++ b/src/lib/advancements/firestore.ts
@@ -3,7 +3,7 @@
  * Uses the Rhythmia Firebase project with anonymous auth for player identification.
  */
 
-import { db, auth } from '@/lib/rhythmia/firebase';
+import { db, auth, appCheckAvailable } from '@/lib/rhythmia/firebase';
 import {
   doc,
   getDoc,
@@ -46,7 +46,14 @@ export function initAuth(): Promise<User | null> {
 
   if (authReady) return authReady;
 
-  authReady = new Promise<User | null>((resolve) => {
+  authReady = new Promise<User | null>(async (resolve) => {
+    // Wait for App Check validation — skip auth if broken
+    const isAppCheckOk = await appCheckAvailable;
+    if (!isAppCheckOk) {
+      resolve(null);
+      return;
+    }
+
     const unsubscribe = onAuthStateChanged(auth!, (user) => {
       if (user) {
         currentUser = user;

--- a/src/lib/google-sync/context.tsx
+++ b/src/lib/google-sync/context.tsx
@@ -9,7 +9,7 @@ import {
   type ReactNode,
 } from 'react';
 import type { User } from 'firebase/auth';
-import { auth } from '@/lib/rhythmia/firebase';
+import { auth, appCheckAvailable } from '@/lib/rhythmia/firebase';
 import {
   isGoogleLinked,
   linkGoogleAccount,
@@ -108,6 +108,15 @@ export function GoogleSyncProvider({ children }: { children: ReactNode }) {
     // Initialize auth (will create anonymous user if needed)
     const initAuthAsync = async () => {
       if (!auth) return;
+
+      // Wait for App Check validation — skip auth if App Check is broken
+      // to avoid 401 errors and noisy console output
+      const isAppCheckOk = await appCheckAvailable;
+      if (!isAppCheckOk) {
+        console.warn('[GoogleSync] Cloud sync unavailable — App Check verification failed.');
+        return;
+      }
+
       const currentUser = auth.currentUser;
       if (!currentUser) {
         try {

--- a/src/lib/loyalty/firestore.ts
+++ b/src/lib/loyalty/firestore.ts
@@ -8,7 +8,7 @@
  *   loyalty_states/{playerId}    — per-player loyalty state sync
  */
 
-import { db, auth } from '@/lib/rhythmia/firebase';
+import { db, auth, appCheckAvailable } from '@/lib/rhythmia/firebase';
 import {
   doc,
   getDoc,
@@ -33,7 +33,14 @@ export function initAuth(): Promise<User | null> {
   if (!auth) return Promise.resolve(null);
   if (authReady) return authReady;
 
-  authReady = new Promise<User | null>((resolve) => {
+  authReady = new Promise<User | null>(async (resolve) => {
+    // Wait for App Check validation — skip auth if broken
+    const isAppCheckOk = await appCheckAvailable;
+    if (!isAppCheckOk) {
+      resolve(null);
+      return;
+    }
+
     const unsubscribe = onAuthStateChanged(auth!, (user) => {
       if (user) {
         currentUser = user;


### PR DESCRIPTION
## Summary
This PR adds validation of Firebase App Check tokens before initializing authentication. If App Check is broken (e.g., due to ReCAPTCHA being blocked), auth initialization is skipped to prevent 401 errors and noisy console output.

## Key Changes
- **initAppCheck.ts**: 
  - Disabled automatic token refresh (`isTokenAutoRefreshEnabled: false`)
  - Added `validateAppCheckToken()` function to verify App Check can retrieve a valid token
  - Imported `getToken` from firebase/app-check

- **firebase.ts**:
  - Created `appCheckAvailable` promise that validates App Check on initialization
  - Exported `appCheckAvailable` for use by auth modules
  - App Check validation runs during app initialization and resolves to `true` if working or not initialized, `false` if broken

- **firestore.ts** (advancements & loyalty):
  - Updated `initAuth()` to await `appCheckAvailable` before proceeding with auth
  - Silently skips auth initialization if App Check validation fails

- **context.tsx** (google-sync):
  - Added App Check validation check before initializing auth
  - Logs warning and returns early if App Check is broken

## Implementation Details
- App Check validation is non-blocking during app initialization — it runs asynchronously
- If App Check fails, auth operations gracefully degrade rather than throwing errors
- The validation check prevents cascading 401 errors when ReCAPTCHA or the site key is misconfigured
- All auth modules now consistently check `appCheckAvailable` before attempting authentication

https://claude.ai/code/session_01FDG6m9GdvUvkyxebQmqbHu