### PR TITLE
Add activeAnomaly prop to BoardRenderer3D component

### DIFF
--- a/src/components/minecraft-board/BoardRenderer3D.tsx
+++ b/src/components/minecraft-board/BoardRenderer3D.tsx
@@ -60,6 +60,7 @@ interface BoardRendererProps {
   onMobClick: (mobId: string) => void;
   onPlayerClick: (targetPlayerId: string) => void;
   onMove: (direction: Direction) => void;
+  activeAnomaly?: boolean;
 }
 
 const TERRAIN_SEED = 42069;


### PR DESCRIPTION
## Summary
Added support for tracking anomaly state in the BoardRenderer3D component by introducing a new optional `activeAnomaly` prop to the BoardRendererProps interface.

## Key Changes
- Added `activeAnomaly?: boolean` property to the `BoardRendererProps` interface
- This prop allows parent components to communicate anomaly activation state to the 3D board renderer

## Implementation Details
The new prop is optional (using TypeScript's optional property syntax with `?`), allowing for backward compatibility with existing implementations that don't yet utilize anomaly state tracking.

https://claude.ai/code/session_01PQWkxgzgNDXBfKmU8CtX2y