### PR TITLE
Fix corruption spawning to only occur during active waves

### DIFF
--- a/src/components/rhythmia/tetris/tetris.tsx
+++ b/src/components/rhythmia/tetris/tetris.tsx
@@ -1125,8 +1125,10 @@ export default function Rhythmia({ onQuit, onGameEnd }: RhythmiaProps) {
           triggerBoardShakeRef.current();
         }
 
-        // Corruption: mature cells may spawn additional enemies
-        spawnFromCorruptionRef.current();
+        // Corruption: mature cells may spawn additional enemies (only while wave active)
+        if (tdBeatsRemainingRef.current > 0) {
+          spawnFromCorruptionRef.current();
+        }
 
         // Check wave complete: no more spawning and all enemies dead
         if (!gameOverRef.current && tdBeatsRemainingRef.current <= 0 && gamePhaseRef.current === 'PLAYING') {


### PR DESCRIPTION
## Summary
Fixed a bug where corruption-spawned enemies could be generated after a wave had ended, causing unexpected enemy spawns during wave transitions or completion states.

## Key Changes
- Added a guard condition to `spawnFromCorruptionRef.current()` to only execute when `tdBeatsRemainingRef.current > 0`
- This ensures corruption mechanics only spawn additional enemies while the current wave is actively running
- Updated the comment to clarify that corruption spawning is restricted to active waves

## Implementation Details
The fix prevents the corruption spawning logic from executing once a wave's beat counter reaches zero or below, which indicates the wave has ended. This maintains proper game state boundaries and prevents unintended enemy spawns during wave completion or transition phases.

https://claude.ai/code/session_01S2iFTtYF8LxQC6GSRcUJa2