### PR TITLE
Remove gap spacing from grid layouts in MinecraftBoard

### DIFF
--- a/src/components/minecraft-board/MinecraftBoard.module.css
+++ b/src/components/minecraft-board/MinecraftBoard.module.css
@@ -427,7 +427,6 @@
 
 .board {
   display: grid;
-  gap: 1px;
   background: #111;
   border: 3px solid #444;
   position: relative;
@@ -1244,7 +1243,6 @@
 
 .sideBoardGrid {
   display: grid;
-  gap: 1px;
   background: #0a000f;
 }
 


### PR DESCRIPTION
## Summary
Removed the `gap: 1px` CSS property from grid-based layouts in the MinecraftBoard component to eliminate spacing between grid items.

## Changes
- Removed `gap: 1px` from `.board` grid layout
- Removed `gap: 1px` from `.sideBoardGrid` grid layout

## Details
This change eliminates the 1-pixel gap that was previously applied between grid cells in both the main board and side board grid layouts. This results in grid items being rendered directly adjacent to each other without any spacing, which may be desired for a more compact or seamless visual appearance in the Minecraft-style board interface.

https://claude.ai/code/session_01JTz9m696PB6zsd7i4RFTob