### PR TITLE
Improve WebSocket reconnection handling in ranked matches

### DIFF
--- a/src/components/rhythmia/MultiplayerGame.tsx
+++ b/src/components/rhythmia/MultiplayerGame.tsx
@@ -112,10 +112,9 @@ export default function MultiplayerGame({ onQuit }: MultiplayerGameProps) {
       setConnectionStatus('disconnected');
       wsRef.current = null;
 
-      // Auto-reconnect if we were in a room
-      if (reconnectTokenRef.current) {
-        scheduleReconnect();
-      }
+      // Always reconnect — the WebSocket is needed for heartbeat
+      // even in modes without a server room (e.g., ranked AI matches)
+      scheduleReconnect();
     };
 
     ws.onerror = () => {

--- a/src/components/rhythmia/RankedMatch.module.css
+++ b/src/components/rhythmia/RankedMatch.module.css
@@ -521,6 +521,26 @@
   justify-content: center;
 }
 
+/* ===== Reconnecting Overlay ===== */
+.reconnectingOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  z-index: 1000;
+  font-size: 0.9rem;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.7);
+  letter-spacing: 0.2em;
+  animation: fadeIn 0.3s ease-out;
+}
+
 /* Responsive */
 @media (max-width: 480px) {
   .rankCard {

--- a/src/components/rhythmia/RankedMatch.tsx
+++ b/src/components/rhythmia/RankedMatch.tsx
@@ -59,8 +59,11 @@ interface Props {
 export default function RankedMatch({ playerName, onBack, ws, connectionStatus, playerId }: Props) {
   // Keep a ref to the ws prop for use in effects
   const wsRef = useRef<WebSocket | null>(ws);
+  // Tracks last known good WebSocket — prevents MultiplayerBattle unmount on brief disconnects
+  const [activeWs, setActiveWs] = useState<WebSocket | null>(ws);
   useEffect(() => {
     wsRef.current = ws;
+    if (ws) setActiveWs(ws);
   }, [ws]);
 
   // Ranked state
@@ -94,99 +97,91 @@ export default function RankedMatch({ playerName, onBack, ws, connectionStatus, 
   }, []);
 
   // ===== AI Match Setup =====
-  // The AI runs client-side, relaying board updates through fake WebSocket messages
+  // Effect 1: AI game lifecycle — uses wsRef (always latest) for event dispatch
   useEffect(() => {
     if (phase !== 'playing') return;
-
-    const currentWs = wsRef.current;
-    if (!currentWs) return;
 
     const currentOpponentId = opponentId;
     const difficulty = getDifficultyForRank(rankedState.points);
 
+    const dispatchFakeMessage = (fakeMessage: ServerMessage) => {
+      // Use wsRef.current so we always dispatch to the latest WebSocket,
+      // even after reconnection. dispatchEvent is an EventTarget method
+      // that works regardless of readyState.
+      const currentWs = wsRef.current;
+      if (!currentWs) return;
+      const event = new MessageEvent('message', {
+        data: JSON.stringify(fakeMessage),
+      });
+      currentWs.dispatchEvent(event);
+    };
+
     const aiGame = new TetrisAIGame(gameSeed, difficulty, {
       onBoardUpdate: (board, score, lines, combo, piece, hold) => {
-        if (currentWs.readyState === WebSocket.OPEN) {
-          const fakeMessage: ServerMessage = {
-            type: 'relayed',
-            fromPlayerId: currentOpponentId,
-            payload: {
-              event: 'board_update',
-              board,
-              score,
-              lines,
-              combo,
-              piece,
-              hold,
-            },
-          };
-          const event = new MessageEvent('message', {
-            data: JSON.stringify(fakeMessage),
-          });
-          currentWs.dispatchEvent(event);
-        }
+        dispatchFakeMessage({
+          type: 'relayed',
+          fromPlayerId: currentOpponentId,
+          payload: { event: 'board_update', board, score, lines, combo, piece, hold },
+        });
       },
       onGarbage: (lines) => {
-        if (currentWs.readyState === WebSocket.OPEN) {
-          const fakeMessage: ServerMessage = {
-            type: 'relayed',
-            fromPlayerId: currentOpponentId,
-            payload: { event: 'garbage', lines },
-          };
-          const event = new MessageEvent('message', {
-            data: JSON.stringify(fakeMessage),
-          });
-          currentWs.dispatchEvent(event);
-        }
+        dispatchFakeMessage({
+          type: 'relayed',
+          fromPlayerId: currentOpponentId,
+          payload: { event: 'garbage', lines },
+        });
       },
       onGameOver: () => {
-        if (currentWs.readyState === WebSocket.OPEN) {
-          const fakeMessage: ServerMessage = {
-            type: 'relayed',
-            fromPlayerId: currentOpponentId,
-            payload: { event: 'game_over' },
-          };
-          const event = new MessageEvent('message', {
-            data: JSON.stringify(fakeMessage),
-          });
-          currentWs.dispatchEvent(event);
-        }
+        dispatchFakeMessage({
+          type: 'relayed',
+          fromPlayerId: currentOpponentId,
+          payload: { event: 'game_over' },
+        });
       },
     });
 
     aiGameRef.current = aiGame;
     aiGame.start();
 
-    // Intercept outgoing messages: route relay messages to AI locally,
-    // pass non-relay messages (pong, etc.) through to the server
+    return () => {
+      aiGame.stop();
+      aiGameRef.current = null;
+    };
+  }, [phase, gameSeed, opponentId, rankedState.points]);
+
+  // Effect 2: Intercept ws.send for AI matches — re-runs when ws changes (e.g., after reconnect)
+  useEffect(() => {
+    if (phase !== 'playing') return;
+    if (!ws) return;
+
+    const currentWs = ws;
     const originalSend = currentWs.send.bind(currentWs);
+
+    // Route relay messages to AI locally, pass everything else (pong, etc.) to server
     currentWs.send = (data: string | ArrayBufferLike | Blob | ArrayBufferView) => {
       try {
         if (typeof data === 'string') {
           const msg = JSON.parse(data);
           if (msg.type === 'relay') {
-            if (msg.payload?.event === 'garbage') {
-              aiGame.addGarbage(msg.payload.lines);
+            if (msg.payload?.event === 'garbage' && aiGameRef.current) {
+              aiGameRef.current.addGarbage(msg.payload.lines);
             }
-            if (msg.payload?.event === 'game_over') {
-              aiGame.stop();
+            if (msg.payload?.event === 'game_over' && aiGameRef.current) {
+              aiGameRef.current.stop();
             }
             return; // Don't send relay messages to server for AI matches
           }
         }
         originalSend(data);
-      } catch {}
+      } catch (err) {
+        console.warn('[WS] Ranked send interceptor error:', err);
+      }
     };
 
     return () => {
-      aiGame.stop();
-      aiGameRef.current = null;
-      // Restore original send
-      if (currentWs) {
-        currentWs.send = originalSend;
-      }
+      currentWs.send = originalSend;
     };
-  }, [phase, gameSeed, opponentId, rankedState.points]);
+  }, [phase, ws]);
 
   // ===== Game End =====
   const handleGameEnd = useCallback((winnerId: string) => {
@@ -360,22 +355,29 @@ export default function RankedMatch({ playerName, onBack, ws, connectionStatus, 
       )}
 
       {/* Playing */}
-      {phase === 'playing' && ws && (
-        <MultiplayerBattle
-          ws={ws}
-          roomCode={roomCode}
-          playerId={playerId}
-          playerName={playerName}
-          opponents={[{
-            id: opponentId,
-            name: opponentName,
-            ready: true,
-            connected: true,
-          }]}
-          gameSeed={gameSeed}
-          onGameEnd={handleGameEnd}
-          onBackToLobby={handleBackToLobby}
-        />
+      {phase === 'playing' && activeWs && (
+        <>
+          <MultiplayerBattle
+            ws={activeWs}
+            roomCode={roomCode}
+            playerId={playerId}
+            playerName={playerName}
+            opponents={[{
+              id: opponentId,
+              name: opponentName,
+              ready: true,
+              connected: true,
+            }]}
+            gameSeed={gameSeed}
+            onGameEnd={handleGameEnd}
+            onBackToLobby={handleBackToLobby}
+          />
+          {connectionStatus !== 'connected' && (
+            <div className={styles.reconnectingOverlay}>
+              Reconnecting...
+            </div>
+          )}
+        </>
       )}
 
       {/* Result */}


### PR DESCRIPTION
## Summary
Refactored WebSocket lifecycle management in ranked matches to gracefully handle brief disconnections without unmounting the game UI. The changes separate AI game lifecycle from WebSocket send interception, track the last known good WebSocket connection, and display a reconnecting overlay during connection loss.

## Key Changes

- **Split AI effect into two separate effects**: 
  - Effect 1 manages AI game lifecycle (start/stop) using `wsRef` for event dispatch, independent of connection status
  - Effect 2 intercepts `ws.send()` calls to route relay messages to AI locally, re-runs when `ws` changes (e.g., after reconnect)

- **Added `activeWs` state**: Tracks the last known good WebSocket to prevent `MultiplayerBattle` unmount during brief disconnects. Only updates when a valid WebSocket is provided.

- **Removed readyState checks**: Replaced `currentWs.readyState === WebSocket.OPEN` checks with direct `dispatchEvent()` calls, which work regardless of connection state and allow queued messages to be processed after reconnection.

- **Added reconnecting overlay**: Displays "Reconnecting..." message with blur effect when `connectionStatus !== 'connected'` while game is active.

- **Improved error handling**: Added try-catch logging in the send interceptor for better debugging.

- **Fixed auto-reconnect logic**: Changed `MultiplayerGame` to always schedule reconnect (not just when `reconnectTokenRef` exists) since WebSocket is needed for heartbeat even in ranked AI matches without a server room.

## Implementation Details

- The `dispatchFakeMessage` helper function centralizes fake message creation and dispatch, using `wsRef.current` to always target the latest WebSocket instance
- AI game callbacks no longer check connection state before dispatching events—the framework handles queuing
- The send interceptor uses the current `ws` prop directly (not `wsRef`) to ensure it's always intercepting the active connection
- CSS animation added for smooth fade-in of reconnecting overlay

https://claude.ai/code/session_01JXrV3kYvdaVncLeayx95pB