### PR TITLE
Refactor GlassCard gradient props to use preset system

### DIFF
--- a/src/components/game/CreateJoinRoom.tsx
+++ b/src/components/game/CreateJoinRoom.tsx
@@ -65,7 +65,7 @@ export default function CreateJoinRoom({
       {/* Create or Join */}
       <div className="grid md:grid-cols-2 gap-6">
         {/* Create Room */}
-        <GlassCard variant="gradient" from="from-yellow-500/20" to="to-pink-500/20" borderColor="border-yellow-500/30">
+        <GlassCard variant="gradient" gradient="yellow-pink">
           <h2 className="text-2xl font-bold mb-4 text-center">Create Room</h2>
           <p className="text-gray-300 text-center mb-6">
             Start a new game and invite friends
@@ -80,7 +80,7 @@ export default function CreateJoinRoom({
         </GlassCard>
 
         {/* Join Room */}
-        <GlassCard variant="gradient" from="from-blue-500/20" to="to-purple-500/20" borderColor="border-blue-500/30">
+        <GlassCard variant="gradient" gradient="blue-purple">
           <h2 className="text-2xl font-bold mb-4 text-center">Join Room</h2>
           <p className="text-gray-300 text-center mb-4">
             Enter a room code to join

--- a/src/components/game/Lobby.tsx
+++ b/src/components/game/Lobby.tsx
@@ -41,7 +41,7 @@ export default function Lobby({ gameSocket }: LobbyProps) {
   return (
     <div className="space-y-6">
       {/* Room Code Display */}
-      <GlassCard variant="gradient" from="from-yellow-500/20" to="to-pink-500/20" borderColor="border-yellow-500/30" className="text-center">
+      <GlassCard variant="gradient" gradient="yellow-pink" className="text-center">
         <h2 className="text-2xl font-bold mb-4">Room Code</h2>
         <div className="flex items-center justify-center gap-4">
           <div className="text-5xl font-bold font-mono tracking-widest bg-white/10 px-8 py-4 rounded-xl">

--- a/src/components/ui/GlassCard.tsx
+++ b/src/components/ui/GlassCard.tsx
@@ -4,12 +4,12 @@ import { cn } from '@/lib/utils';
 
 type GlassVariant = 'default' | 'subtle' | 'gradient';
 
+type GradientPreset = 'yellow-pink' | 'blue-purple';
+
 interface GlassCardProps {
   children: React.ReactNode;
   variant?: GlassVariant;
-  from?: string;
-  to?: string;
-  borderColor?: string;
+  gradient?: GradientPreset;
   className?: string;
 }
 
@@ -19,18 +19,18 @@ const variantClasses: Record<GlassVariant, string> = {
   gradient: 'backdrop-blur-lg rounded-2xl p-8 shadow-2xl',
 };
 
+const gradientPresets: Record<GradientPreset, string> = {
+  'yellow-pink': 'bg-gradient-to-br from-yellow-500/20 to-pink-500/20 border border-yellow-500/30',
+  'blue-purple': 'bg-gradient-to-br from-blue-500/20 to-purple-500/20 border border-blue-500/30',
+};
+
 export default function GlassCard({
   children,
   variant = 'default',
-  from,
-  to,
-  borderColor,
+  gradient,
   className,
 }: GlassCardProps) {
-  const gradientStyle =
-    variant === 'gradient' && from && to
-      ? `bg-gradient-to-br ${from} ${to} border ${borderColor ?? 'border-white/20'}`
-      : '';
+  const gradientStyle = variant === 'gradient' && gradient ? gradientPresets[gradient] : '';
 
   return (
     <div className={cn(variantClasses[variant], gradientStyle, className)}>


### PR DESCRIPTION
## Summary
Refactored the `GlassCard` component to use a preset-based gradient system instead of accepting individual gradient color props. This improves maintainability and consistency across the application by centralizing gradient definitions.

## Key Changes
- Replaced individual `from`, `to`, and `borderColor` props with a single `gradient` prop that accepts preset values
- Added `GradientPreset` type with two predefined options: `'yellow-pink'` and `'blue-purple'`
- Created `gradientPresets` object that maps preset names to their complete Tailwind class strings
- Updated all usages in `CreateJoinRoom.tsx` and `Lobby.tsx` to use the new preset-based API

## Implementation Details
- The gradient presets are defined as a `Record<GradientPreset, string>` containing the full Tailwind classes for each gradient variant
- The component now applies the preset classes directly when `variant="gradient"` and a valid `gradient` preset is provided
- This approach reduces prop drilling and makes it easier to maintain consistent gradient styling across the application

https://claude.ai/code/session_01J4nQ1BdVZ5piQvrmShyKXR