### PR TITLE
Fix voxel and terrain cell sizing in tower defense renderer

### DIFF
--- a/src/components/tower-defense/TowerDefenseRenderer3D.tsx
+++ b/src/components/tower-defense/TowerDefenseRenderer3D.tsx
@@ -331,7 +331,7 @@ function VoxelBackgroundStage({ mapWidth, mapHeight }: { mapWidth: number; mapHe
       castShadow
       receiveShadow
     >
-      <boxGeometry args={[0.95, 0.95, 0.95]} />
+      <boxGeometry args={[1, 1, 1]} />
       <meshStandardMaterial roughness={0.75} metalness={0.05} flatShading />
     </instancedMesh>
   );
@@ -433,7 +433,7 @@ function TerrainGrid({ grid, onCellClick, hoveredCell, canPlace }: {
             onClick={(e) => { e.stopPropagation(); onCellClick(cell.x, cell.z); }}
             onPointerEnter={(e) => e.stopPropagation()}
           >
-            <boxGeometry args={[CELL_SIZE * 0.98, height, CELL_SIZE * 0.98]} />
+            <boxGeometry args={[CELL_SIZE, height, CELL_SIZE]} />
             <meshStandardMaterial
               color={color}
               roughness={cell.terrain === 'water' ? 0.2 : 0.8}


### PR DESCRIPTION
## Summary
Adjusted the geometry dimensions for voxel background elements and terrain grid cells to use full unit sizes instead of slightly reduced sizes.

## Key Changes
- **VoxelBackgroundStage**: Changed box geometry from `[0.95, 0.95, 0.95]` to `[1, 1, 1]` to render voxels at their full intended size
- **TerrainGrid**: Changed cell geometry from `[CELL_SIZE * 0.98, height, CELL_SIZE * 0.98]` to `[CELL_SIZE, height, CELL_SIZE]` to render terrain cells at their full dimensions

## Details
These changes remove the scaling factors that were previously reducing the visual size of both voxel background elements and terrain grid cells. This results in a more cohesive visual appearance where geometry elements fill their allocated space completely, eliminating the small gaps that were present before.

https://claude.ai/code/session_01A8snAxL2ma2JNe4TVSSe2N