### PR TITLE
Fix stale closure in animation loop for remote player updates

### DIFF
--- a/src/components/minecraft-world/MinecraftWorld.tsx
+++ b/src/components/minecraft-world/MinecraftWorld.tsx
@@ -77,6 +77,10 @@ export default function MinecraftWorld() {
   const remotePlayerMeshes = useRef<Map<string, { group: THREE.Group; lastUpdate: number }>>(new Map());
   const sceneRef = useRef<THREE.Scene | null>(null);
 
+  // Track roomState in a ref so the animation loop always reads fresh data
+  const roomStateRef = useRef(mp.roomState);
+  useEffect(() => { roomStateRef.current = mp.roomState; }, [mp.roomState]);
+
   const handleCreateRoom = useCallback(() => {
     if (!playerName.trim()) return;
     localStorage.setItem('mw_playerName', playerName.trim());
@@ -686,16 +690,21 @@ export default function MinecraftWorld() {
         }
       }
 
-      // Update remote players
+      // Update remote players — read from refs to avoid stale closure
       const playerColors = new Map<string, string>();
       const playerNames = new Map<string, string>();
-      if (mp.roomState) {
-        for (const p of mp.roomState.players) {
+      const currentRoomState = roomStateRef.current;
+      if (currentRoomState) {
+        for (const p of currentRoomState.players) {
           playerColors.set(p.id, p.color);
           playerNames.set(p.id, p.name);
         }
       }
-      updateRemotePlayers(mp.remotePlayerList, playerColors, playerNames);
+      updateRemotePlayers(
+        Array.from(mp.remotePlayers.current.values()),
+        playerColors,
+        playerNames,
+      );
 
       renderer.render(scene, camera);
     }


### PR DESCRIPTION
## Summary
This PR fixes a stale closure issue in the animation loop that was preventing fresh room state data from being read during remote player updates.

## Key Changes
- Added `roomStateRef` to track the current `mp.roomState` and keep it synchronized via `useEffect`
- Updated the animation loop to read from `roomStateRef.current` instead of the stale `mp.roomState` closure
- Changed `updateRemotePlayers` to use `Array.from(mp.remotePlayers.current.values())` instead of `mp.remotePlayerList` for consistency with the ref-based approach

## Implementation Details
The animation loop runs continuously and was capturing `mp.roomState` in its closure at initialization time. This meant it would always read stale player data. By introducing a ref that gets updated whenever `mp.roomState` changes, the animation loop now always reads the current room state when updating remote players. This ensures player positions, colors, and names are kept in sync with the latest data from the multiplayer state.

https://claude.ai/code/session_015MrdgFQuuwiniS27vZq17h