### PR TITLE
Remove tower level indicators from UI

### DIFF
--- a/src/components/tower-defense/TowerDefenseGame.tsx
+++ b/src/components/tower-defense/TowerDefenseGame.tsx
@@ -86,7 +86,7 @@ function SelectedTowerInfo({ tower, gold, onUpgrade, onSell, onDeselect }: {
   return (
     <div className={styles.selectedTowerPanel}>
       <h3 style={{ color: def.color }}>
-        {TOWER_ICONS[tower.type]} {def.name} (Lv.{tower.level})
+        {TOWER_ICONS[tower.type]} {def.name}
         <span
           onClick={onDeselect}
           style={{ float: 'right', cursor: 'pointer', color: '#64748b', fontSize: '14px' }}

--- a/src/components/tower-defense/TowerDefenseRenderer3D.tsx
+++ b/src/components/tower-defense/TowerDefenseRenderer3D.tsx
@@ -683,13 +683,6 @@ function TowerMesh({ tower, isSelected, enemies, onClick }: {
       {tower.type === 'frost' && (
         <FrostAoERing range={towerRange} />
       )}
-      {/* Level indicators */}
-      {Array.from({ length: tower.level }).map((_, i) => (
-        <mesh key={i} position={[(i - (tower.level - 1) / 2) * 0.12, charHeight + 0.2, 0]}>
-          <sphereGeometry args={[0.04, 6, 6]} />
-          <meshStandardMaterial color="#fbbf24" emissive="#fbbf24" emissiveIntensity={0.5} />
-        </mesh>
-      ))}
       {/* Range indicator when selected */}
       {isSelected && (
         <mesh position={[0, 0.01, 0]} rotation={[-Math.PI / 2, 0, 0]}>


### PR DESCRIPTION
## Summary
Removed visual level indicators from the tower defense game UI, including both the 3D sphere indicators on towers and the level display in the selected tower info panel.

## Key Changes
- Removed the 3D level indicator spheres that were rendered above each tower in the 3D scene (TowerDefenseRenderer3D.tsx)
- Removed the tower level display from the selected tower info panel header (TowerDefenseGame.tsx)

## Details
The level indicator spheres were being rendered as small golden spheres positioned above towers, with the count matching the tower's level. This visual representation has been completely removed from the 3D renderer.

Additionally, the tower level is no longer displayed in the selected tower information panel, simplifying the UI while the tower level data itself remains available in the game state for upgrade and other mechanics.

https://claude.ai/code/session_014RVWDXYrb5czqWZ7iEoajA