### PR TITLE
Add block change sync and day/night cycle to Minecraft World

### DIFF
--- a/src/types/minecraft-world.ts
+++ b/src/types/minecraft-world.ts
@@ -68,6 +68,8 @@ export type MWClientMessage =
   | { type: 'mw_ready'; ready: boolean }
   | { type: 'mw_start' }
   | { type: 'mw_position'; x: number; y: number; z: number; rx: number; ry: number }
+  | { type: 'mw_break_block'; x: number; y: number; z: number }
+  | { type: 'mw_place_block'; x: number; y: number; z: number; blockType: number }
   | { type: 'mw_chat'; message: string };
 
 // ===== Server → Client Messages =====
@@ -81,11 +83,24 @@ export type MWServerMessage =
   | { type: 'mw_player_left'; playerId: string }
   | { type: 'mw_player_ready'; playerId: string; ready: boolean }
   | { type: 'mw_countdown'; count: number }
-  | { type: 'mw_game_started'; seed: number }
+  | { type: 'mw_game_started'; seed: number; serverTime: number }
   | { type: 'mw_player_position'; player: MWPlayerPosition }
+  | { type: 'mw_block_changed'; playerId: string; x: number; y: number; z: number; blockType: number }
+  | { type: 'mw_time_sync'; dayTime: number }
   | { type: 'mw_chat_message'; playerId: string; playerName: string; message: string }
   | { type: 'mw_error'; message: string; code?: string }
-  | { type: 'mw_reconnected'; roomCode: string; playerId: string; roomState: MWRoomState; reconnectToken: string };
+  | { type: 'mw_reconnected'; roomCode: string; playerId: string; roomState: MWRoomState; reconnectToken: string; blockChanges: MWBlockChange[]; serverTime: number };
+
+// ===== Block Change Record =====
+
+export interface MWBlockChange {
+  playerId: string;
+  x: number;
+  y: number;
+  z: number;
+  blockType: number; // 0 = air (broken)
+  tick: number;
+}
 
 // ===== Firestore Room Document =====
 


### PR DESCRIPTION
## Summary
This PR adds server-side synchronization for block changes (breaking/placing blocks) and implements a synchronized day/night cycle across all players in a Minecraft World multiplayer room.

## Key Changes

**Block Change Synchronization:**
- Added `handleBreakBlock()` and `handlePlaceBlock()` methods to `MinecraftWorldManager` to process block changes from clients
- Block changes are tracked per room with a tick counter for ordering
- Server broadcasts `mw_block_changed` messages to all players (including the sender for confirmation)
- Clients can retrieve pending block changes on reconnection via `getBlockChanges()` to replay missed changes
- Updated `MinecraftWorld.tsx` to send block changes to the server instead of applying them locally, then apply them when the server broadcasts them back

**Day/Night Cycle Synchronization:**
- Implemented server-side day cycle tracking with a 240-second full day duration
- Added `getDayTime()` method to calculate current day time (0-1) based on elapsed time since game start
- Server broadcasts `mw_time_sync` messages every 5 seconds to keep all clients synchronized
- Clients calculate synchronized day time using `getSyncedDayTime()` based on server time offset
- Removed local day time calculation in favor of server-synchronized time

**Message Protocol Updates:**
- Added `mw_break_block` and `mw_place_block` client messages
- Added `mw_block_changed` and `mw_time_sync` server messages
- Updated `mw_game_started` to include `serverTime` for client synchronization
- Updated `mw_reconnected` to include `blockChanges` and `serverTime` for reconnection recovery

**Infrastructure:**
- Added `MWBlockChange` interface to track block modifications with player ID, coordinates, block type, and tick number
- Added room-level state for block change tracking and time sync interval management
- Proper cleanup of time sync intervals when rooms are destroyed or become empty
- Block changes are replayed on reconnection to ensure world state consistency

## Implementation Details

- Block changes are stored in memory per room and replayed to reconnecting clients
- Day/night cycle uses `Date.now()` with a stored game start timestamp for consistent time calculation across all clients
- Time sync broadcasts occur every 5 seconds to maintain synchronization within acceptable tolerance
- Block changes are only processed when the room is in 'playing' status and the player is connected
- Chunk geometry is rebuilt after applying block changes to reflect visual updates

https://claude.ai/code/session_011yC8oFccdjDjAUznoHe2SN