### PR TITLE
Fix frustum culling for tower defense voxel rendering

### DIFF
--- a/src/components/tower-defense/TowerDefenseRenderer3D.tsx
+++ b/src/components/tower-defense/TowerDefenseRenderer3D.tsx
@@ -365,6 +365,10 @@ function VoxelBackgroundStage({ mapWidth, mapHeight }: { mapWidth: number; mapHe
 
     mesh.instanceMatrix.needsUpdate = true;
     if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+
+    // Compute correct bounding sphere so frustum culling uses actual
+    // spatial extent instead of the unit-box geometry's default sphere.
+    mesh.computeBoundingSphere();
   }, [voxelData]);
 
   return (
@@ -421,7 +425,7 @@ function FloatingVoxels({ mapWidth, mapHeight }: { mapWidth: number; mapHeight: 
   });
 
   return (
-    <instancedMesh ref={meshRef} args={[undefined, undefined, COUNT]}>
+    <instancedMesh ref={meshRef} args={[undefined, undefined, COUNT]} frustumCulled={false}>
       <boxGeometry args={[1, 1, 1]} />
       <meshStandardMaterial
         color="#4aeadc"


### PR DESCRIPTION
## Summary
Improved frustum culling performance and accuracy for the tower defense voxel rendering system by computing correct bounding spheres and disabling frustum culling where appropriate.

## Key Changes
- **VoxelBackgroundStage**: Added `computeBoundingSphere()` call to ensure the instanced mesh uses the actual spatial extent of the voxel data for frustum culling instead of relying on the default unit-box geometry's bounding sphere
- **FloatingVoxels**: Disabled frustum culling (`frustumCulled={false}`) on the instanced mesh to prevent incorrect culling of floating voxel particles

## Implementation Details
The first change ensures that when the voxel background is rendered with instancing, the Three.js frustum culling algorithm uses accurate bounds based on the actual geometry extent rather than the default sphere from the unit box geometry. This prevents unnecessary culling or rendering of off-screen geometry.

The second change disables frustum culling for floating voxels, which are likely animated particles that move dynamically and may have unpredictable bounds that don't align well with standard culling heuristics.

https://claude.ai/code/session_018Yf3ua7CDpGg2zmT1yACEz