### PR TITLE
Add multiplayer tower defense mode with send-enemies mechanic

### DIFF
--- a/src/app/[locale]/tower-defense/page.tsx
+++ b/src/app/[locale]/tower-defense/page.tsx
@@ -1,7 +1,82 @@
 'use client';
 
+import { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { motion } from 'framer-motion';
+import { Swords, Users, Shield } from 'lucide-react';
 import TowerDefenseGame from '@/components/tower-defense/TowerDefenseGame';
+import TowerDefenseMultiplayer from '@/components/tower-defense/TowerDefenseMultiplayer';
+import { cn } from '@/lib/utils';
+
+type GameMode = 'menu' | 'solo' | 'multiplayer';
 
 export default function TowerDefensePage() {
-  return <TowerDefenseGame />;
+  const searchParams = useSearchParams();
+  const modeParam = searchParams.get('mode');
+
+  const [mode, setMode] = useState<GameMode>(() => {
+    if (modeParam === 'multiplayer') return 'multiplayer';
+    if (modeParam === 'solo') return 'solo';
+    return 'menu';
+  });
+
+  if (mode === 'solo') return <TowerDefenseGame />;
+  if (mode === 'multiplayer') return <TowerDefenseMultiplayer />;
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen bg-slate-950 text-slate-200 px-4">
+      <motion.div
+        className="flex flex-col items-center"
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+      >
+        <Shield size={40} className="text-cyan-400 mb-3" />
+        <h1 className="text-4xl font-bold mb-1">Tower Defense</h1>
+        <p className="text-slate-500 text-sm mb-10">Choose your game mode</p>
+      </motion.div>
+
+      <div className="flex gap-4 w-full max-w-lg">
+        <motion.button
+          onClick={() => setMode('solo')}
+          className={cn(
+            'flex-1 flex flex-col items-center gap-3 px-6 py-8 rounded-2xl',
+            'bg-slate-900/80 border border-slate-700/50',
+            'hover:border-cyan-500/40 hover:bg-slate-800/80',
+            'transition-colors cursor-pointer'
+          )}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2 }}
+          whileHover={{ y: -4 }}
+        >
+          <Swords size={32} className="text-cyan-400" />
+          <span className="text-lg font-bold">Solo</span>
+          <span className="text-xs text-slate-500 text-center">
+            Defend against 30 waves
+          </span>
+        </motion.button>
+
+        <motion.button
+          onClick={() => setMode('multiplayer')}
+          className={cn(
+            'flex-1 flex flex-col items-center gap-3 px-6 py-8 rounded-2xl',
+            'bg-slate-900/80 border border-slate-700/50',
+            'hover:border-amber-500/40 hover:bg-slate-800/80',
+            'transition-colors cursor-pointer'
+          )}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.35 }}
+          whileHover={{ y: -4 }}
+        >
+          <Users size={32} className="text-amber-400" />
+          <span className="text-lg font-bold">Multiplayer</span>
+          <span className="text-xs text-slate-500 text-center">
+            2-4 players, send enemies
+          </span>
+        </motion.button>
+      </div>
+    </div>
+  );
 }

--- a/src/components/tower-defense/TDIncomingAlert.tsx
+++ b/src/components/tower-defense/TDIncomingAlert.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useEffect, useState, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { AlertTriangle } from 'lucide-react';
+import type { EnemyType } from '@/types/tower-defense';
+import { cn } from '@/lib/utils';
+
+const ENEMY_LABELS: Record<EnemyType, { label: string; icon: string }> = {
+  grunt: { label: 'Grunts', icon: '🐷' },
+  fast: { label: 'Chickens', icon: '🐔' },
+  swarm: { label: 'Swarm', icon: '🐰' },
+  flying: { label: 'Flyers', icon: '🐝' },
+  healer: { label: 'Healers', icon: '🐱' },
+  tank: { label: 'Tank', icon: '🐄' },
+  shield: { label: 'Shield', icon: '🐺' },
+  boss: { label: 'Boss', icon: '🐴' },
+};
+
+const MAX_VISIBLE = 3;
+const AUTO_DISMISS_MS = 3000;
+
+interface AlertData {
+  fromPlayerName: string;
+  enemyType: EnemyType;
+  count: number;
+  timestamp: number;
+}
+
+interface TDIncomingAlertProps {
+  alerts: AlertData[];
+}
+
+export default function TDIncomingAlert({ alerts }: TDIncomingAlertProps) {
+  const [visibleAlerts, setVisibleAlerts] = useState<AlertData[]>([]);
+  const timersRef = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
+  const prevLenRef = useRef(0);
+
+  // When new alerts arrive, add them to visible list and schedule auto-dismiss
+  useEffect(() => {
+    if (alerts.length <= prevLenRef.current) {
+      prevLenRef.current = alerts.length;
+      return;
+    }
+
+    const newAlerts = alerts.slice(prevLenRef.current);
+    prevLenRef.current = alerts.length;
+
+    setVisibleAlerts((prev) => {
+      const combined = [...newAlerts, ...prev];
+      // Keep only MAX_VISIBLE
+      return combined.slice(0, MAX_VISIBLE);
+    });
+
+    // Schedule auto-dismiss for each new alert
+    for (const alert of newAlerts) {
+      const timer = setTimeout(() => {
+        setVisibleAlerts((prev) =>
+          prev.filter((a) => a.timestamp !== alert.timestamp)
+        );
+        timersRef.current.delete(alert.timestamp);
+      }, AUTO_DISMISS_MS);
+      timersRef.current.set(alert.timestamp, timer);
+    }
+  }, [alerts]);
+
+  // Cleanup timers on unmount
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer));
+      timers.clear();
+    };
+  }, []);
+
+  return (
+    <div className="absolute top-20 right-4 z-30 flex flex-col gap-2 pointer-events-none w-[240px]">
+      <AnimatePresence mode="popLayout">
+        {visibleAlerts.map((alert) => {
+          const enemyInfo = ENEMY_LABELS[alert.enemyType];
+          const isBoss = alert.enemyType === 'boss';
+
+          return (
+            <motion.div
+              key={alert.timestamp}
+              layout
+              initial={{ x: 100, opacity: 0, scale: 0.9 }}
+              animate={{
+                x: 0,
+                opacity: 1,
+                scale: 1,
+                boxShadow: [
+                  '0 0 0px rgba(239, 68, 68, 0)',
+                  '0 0 16px rgba(239, 68, 68, 0.4)',
+                  '0 0 8px rgba(239, 68, 68, 0.2)',
+                ],
+              }}
+              exit={{ x: 100, opacity: 0, scale: 0.9 }}
+              transition={{
+                type: 'spring',
+                stiffness: 400,
+                damping: 25,
+                boxShadow: { duration: 0.8, repeat: 1 },
+              }}
+              className={cn(
+                'flex items-center gap-2.5 px-3 py-2.5 rounded-xl pointer-events-auto',
+                'bg-slate-900/[0.95] backdrop-blur-xl',
+                isBoss
+                  ? 'border-2 border-red-500/70'
+                  : 'border border-red-500/40'
+              )}
+            >
+              {/* Warning icon */}
+              <div
+                className={cn(
+                  'flex items-center justify-center flex-shrink-0 w-8 h-8 rounded-lg',
+                  isBoss ? 'bg-red-500/25' : 'bg-orange-500/15'
+                )}
+              >
+                <AlertTriangle
+                  size={16}
+                  className={isBoss ? 'text-red-400' : 'text-orange-400'}
+                />
+              </div>
+
+              {/* Alert content */}
+              <div className="flex-1 min-w-0">
+                <div className="text-[10px] font-semibold text-red-400 uppercase tracking-wider mb-0.5">
+                  Incoming
+                </div>
+                <div className="text-xs text-slate-200 leading-tight">
+                  <span className="font-bold text-slate-100">
+                    {alert.fromPlayerName}
+                  </span>
+                  {' sent '}
+                  <span className="font-bold">
+                    {alert.count}×
+                  </span>
+                  {' '}
+                  <span className="inline-flex items-center gap-0.5">
+                    <span>{enemyInfo?.icon}</span>
+                    <span className={isBoss ? 'text-red-300 font-bold' : ''}>
+                      {enemyInfo?.label ?? alert.enemyType}
+                    </span>
+                  </span>
+                </div>
+              </div>
+            </motion.div>
+          );
+        })}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/tower-defense/TDOpponentBar.tsx
+++ b/src/components/tower-defense/TDOpponentBar.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Heart, Trophy, Zap, Skull, Crosshair } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface TDOpponentBarProps {
+  opponents: Array<{
+    playerId: string;
+    playerName: string;
+    lives: number;
+    maxLives: number;
+    score: number;
+    sendPoints: number;
+    towerCount: number;
+    enemyCount: number;
+    eliminated: boolean;
+  }>;
+  selectedTarget: string | null;
+  onSelectTarget: (playerId: string) => void;
+}
+
+function TowerIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="4" y="1" width="4" height="2" rx="0.5" fill="currentColor" />
+      <rect x="3" y="3" width="6" height="7" rx="0.5" fill="currentColor" />
+      <rect x="5" y="7" width="2" height="3" rx="0.3" fill="rgba(15,23,42,0.6)" />
+    </svg>
+  );
+}
+
+function EnemyCountIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="6" cy="4" r="2.5" fill="currentColor" />
+      <ellipse cx="6" cy="10" rx="4" ry="2.5" fill="currentColor" opacity="0.5" />
+      <circle cx="5" cy="3.5" r="0.5" fill="rgba(15,23,42,0.8)" />
+      <circle cx="7" cy="3.5" r="0.5" fill="rgba(15,23,42,0.8)" />
+    </svg>
+  );
+}
+
+export default function TDOpponentBar({
+  opponents,
+  selectedTarget,
+  onSelectTarget,
+}: TDOpponentBarProps) {
+  return (
+    <motion.div
+      className={cn(
+        'absolute bottom-4 left-1/2 -translate-x-1/2 z-20',
+        'flex flex-row gap-2 px-3 py-2',
+        'bg-slate-900/[0.92] backdrop-blur-2xl',
+        'border border-slate-700/50 rounded-2xl'
+      )}
+      initial={{ y: 40, opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+      transition={{ type: 'spring', stiffness: 300, damping: 28, delay: 0.1 }}
+    >
+      {opponents.map((opp) => {
+        const isSelected = selectedTarget === opp.playerId;
+        const livesPercent = opp.maxLives > 0 ? opp.lives / opp.maxLives : 0;
+        const livesColor =
+          livesPercent > 0.5 ? '#22c55e' : livesPercent > 0.25 ? '#eab308' : '#ef4444';
+
+        return (
+          <motion.button
+            key={opp.playerId}
+            onClick={() => !opp.eliminated && onSelectTarget(opp.playerId)}
+            disabled={opp.eliminated}
+            className={cn(
+              'relative flex flex-col gap-1.5 px-3 py-2 rounded-xl transition-all duration-150 min-w-[140px]',
+              opp.eliminated
+                ? 'bg-slate-800/30 opacity-50 cursor-not-allowed'
+                : isSelected
+                  ? 'bg-cyan-500/10 border border-cyan-500/50 cursor-pointer'
+                  : 'bg-slate-800/60 border border-transparent hover:bg-slate-700/60 cursor-pointer'
+            )}
+            whileHover={!opp.eliminated ? { y: -2 } : undefined}
+            transition={{ type: 'spring', stiffness: 400, damping: 25 }}
+          >
+            {/* Selected target badge */}
+            {isSelected && !opp.eliminated && (
+              <div className="absolute -top-1.5 -right-1.5 bg-cyan-500 rounded-full p-0.5">
+                <Crosshair size={8} className="text-white" />
+              </div>
+            )}
+
+            {/* Player name row */}
+            <div className="flex items-center gap-1.5">
+              {opp.eliminated ? (
+                <Skull size={12} className="text-slate-500 flex-shrink-0" />
+              ) : (
+                <div
+                  className="w-2 h-2 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: livesColor }}
+                />
+              )}
+              <span
+                className={cn(
+                  'text-xs font-semibold truncate max-w-[80px]',
+                  opp.eliminated ? 'text-slate-500 line-through' : 'text-slate-200'
+                )}
+              >
+                {opp.playerName}
+              </span>
+            </div>
+
+            {opp.eliminated ? (
+              <div className="text-[10px] font-bold text-slate-600 uppercase tracking-wider">
+                Eliminated
+              </div>
+            ) : (
+              <>
+                {/* Lives bar */}
+                <div className="w-full h-1.5 bg-slate-700/60 rounded-full overflow-hidden">
+                  <div
+                    className="h-full rounded-full transition-all duration-300"
+                    style={{
+                      width: `${livesPercent * 100}%`,
+                      backgroundColor: livesColor,
+                    }}
+                  />
+                </div>
+
+                {/* Stats row */}
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="flex items-center gap-0.5" title="Lives">
+                    <Heart size={9} className="text-red-400 fill-red-400" />
+                    <span className="text-[10px] font-semibold text-slate-300 tabular-nums">
+                      {opp.lives}/{opp.maxLives}
+                    </span>
+                  </span>
+                  <span className="flex items-center gap-0.5" title="Score">
+                    <Trophy size={9} className="text-purple-400" />
+                    <span className="text-[10px] font-medium text-slate-400 tabular-nums">
+                      {opp.score}
+                    </span>
+                  </span>
+                  <span className="flex items-center gap-0.5 text-slate-400" title="Towers">
+                    <TowerIcon />
+                    <span className="text-[10px] font-medium tabular-nums">
+                      {opp.towerCount}
+                    </span>
+                  </span>
+                  <span className="flex items-center gap-0.5 text-slate-400" title="Enemies">
+                    <EnemyCountIcon />
+                    <span className="text-[10px] font-medium tabular-nums">
+                      {opp.enemyCount}
+                    </span>
+                  </span>
+                  <span className="flex items-center gap-0.5" title="Send Points">
+                    <Zap size={9} className="text-amber-400" />
+                    <span className="text-[10px] font-medium text-slate-400 tabular-nums">
+                      {opp.sendPoints}
+                    </span>
+                  </span>
+                </div>
+              </>
+            )}
+          </motion.button>
+        );
+      })}
+    </motion.div>
+  );
+}

--- a/src/components/tower-defense/TDSendEnemyPanel.tsx
+++ b/src/components/tower-defense/TDSendEnemyPanel.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Zap, Crosshair, Skull, Heart } from 'lucide-react';
+import type { EnemyType } from '@/types/tower-defense';
+import { cn } from '@/lib/utils';
+
+const SEND_ENEMY_COSTS = [
+  { enemyType: 'grunt' as const, cost: 5, count: 3, label: 'Grunts', icon: '🐷' },
+  { enemyType: 'fast' as const, cost: 4, count: 4, label: 'Chickens', icon: '🐔' },
+  { enemyType: 'swarm' as const, cost: 3, count: 8, label: 'Swarm', icon: '🐰' },
+  { enemyType: 'flying' as const, cost: 8, count: 2, label: 'Flyers', icon: '🐝' },
+  { enemyType: 'healer' as const, cost: 12, count: 2, label: 'Healers', icon: '🐱' },
+  { enemyType: 'tank' as const, cost: 15, count: 1, label: 'Tank', icon: '🐄' },
+  { enemyType: 'shield' as const, cost: 18, count: 1, label: 'Shield', icon: '🐺' },
+  { enemyType: 'boss' as const, cost: 50, count: 1, label: 'Boss', icon: '🐴' },
+];
+
+interface TDSendEnemyPanelProps {
+  sendPoints: number;
+  opponents: Array<{
+    playerId: string;
+    playerName: string;
+    lives: number;
+    eliminated: boolean;
+  }>;
+  selectedTarget: string | null;
+  onSelectTarget: (playerId: string) => void;
+  onSendEnemy: (targetPlayerId: string, enemyType: EnemyType) => void;
+}
+
+export default function TDSendEnemyPanel({
+  sendPoints,
+  opponents,
+  selectedTarget,
+  onSelectTarget,
+  onSendEnemy,
+}: TDSendEnemyPanelProps) {
+  const [pressedType, setPressedType] = useState<EnemyType | null>(null);
+  const [displayPoints, setDisplayPoints] = useState(sendPoints);
+  const prevPointsRef = useRef(sendPoints);
+
+  // Animate point counter
+  useEffect(() => {
+    if (sendPoints === prevPointsRef.current) return;
+    const start = prevPointsRef.current;
+    const diff = sendPoints - start;
+    const steps = Math.min(Math.abs(diff), 10);
+    const stepDuration = 200 / steps;
+    let step = 0;
+
+    const interval = setInterval(() => {
+      step++;
+      if (step >= steps) {
+        setDisplayPoints(sendPoints);
+        clearInterval(interval);
+      } else {
+        setDisplayPoints(Math.round(start + (diff * step) / steps));
+      }
+    }, stepDuration);
+
+    prevPointsRef.current = sendPoints;
+    return () => clearInterval(interval);
+  }, [sendPoints]);
+
+  const handleSend = useCallback((enemyType: EnemyType, cost: number) => {
+    if (!selectedTarget || sendPoints < cost) return;
+    setPressedType(enemyType);
+    onSendEnemy(selectedTarget, enemyType);
+    setTimeout(() => setPressedType(null), 300);
+  }, [selectedTarget, sendPoints, onSendEnemy]);
+
+  return (
+    <motion.div
+      className={cn(
+        'absolute right-4 top-20 w-[260px] z-20',
+        'bg-slate-900/[0.92] backdrop-blur-2xl',
+        'border border-slate-700/50 rounded-xl',
+        'flex flex-col overflow-hidden'
+      )}
+      initial={{ x: 80, opacity: 0 }}
+      animate={{ x: 0, opacity: 1 }}
+      exit={{ x: 80, opacity: 0 }}
+      transition={{ type: 'spring', stiffness: 300, damping: 28 }}
+    >
+      {/* Header */}
+      <div className="px-4 pt-3 pb-2">
+        <div className="flex items-center gap-2 mb-1">
+          <Crosshair size={14} className="text-cyan-400" />
+          <span className="text-xs font-bold uppercase tracking-wider text-slate-400">
+            Send Enemies
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Zap size={16} className="text-amber-400" />
+          <span className="text-lg font-bold text-amber-400 tabular-nums">
+            {displayPoints}
+          </span>
+          <span className="text-xs text-slate-500 ml-0.5">points</span>
+        </div>
+      </div>
+
+      {/* Target selector */}
+      <div className="px-3 py-2 border-t border-slate-700/40">
+        <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-500 mb-1.5 px-1">
+          Target
+        </div>
+        <div className="flex flex-col gap-1">
+          {opponents.map((opp) => {
+            const isSelected = selectedTarget === opp.playerId;
+            const isEliminated = opp.eliminated;
+
+            return (
+              <button
+                key={opp.playerId}
+                onClick={() => !isEliminated && onSelectTarget(opp.playerId)}
+                disabled={isEliminated}
+                className={cn(
+                  'flex items-center gap-2 px-2.5 py-1.5 rounded-lg text-left transition-all duration-150',
+                  isEliminated
+                    ? 'opacity-40 cursor-not-allowed bg-slate-800/40'
+                    : isSelected
+                      ? 'bg-cyan-500/15 border border-cyan-500/50 cursor-pointer'
+                      : 'bg-slate-800/60 border border-transparent hover:bg-slate-700/60 cursor-pointer'
+                )}
+              >
+                {/* Radio indicator */}
+                <div
+                  className={cn(
+                    'w-3 h-3 rounded-full border-2 flex-shrink-0 flex items-center justify-center',
+                    isEliminated
+                      ? 'border-slate-600'
+                      : isSelected
+                        ? 'border-cyan-400'
+                        : 'border-slate-500'
+                  )}
+                >
+                  {isSelected && !isEliminated && (
+                    <div className="w-1.5 h-1.5 rounded-full bg-cyan-400" />
+                  )}
+                  {isEliminated && (
+                    <span className="text-[6px] text-slate-500">×</span>
+                  )}
+                </div>
+
+                {/* Name */}
+                <span
+                  className={cn(
+                    'text-xs font-medium flex-1 truncate',
+                    isEliminated ? 'text-slate-600 line-through' : 'text-slate-200'
+                  )}
+                >
+                  {opp.playerName}
+                </span>
+
+                {/* Lives / Eliminated */}
+                {isEliminated ? (
+                  <Skull size={12} className="text-slate-600 flex-shrink-0" />
+                ) : (
+                  <span className="flex items-center gap-0.5 flex-shrink-0">
+                    <Heart size={10} className="text-red-400 fill-red-400" />
+                    <span className="text-[11px] font-semibold text-slate-300 tabular-nums">
+                      {opp.lives}
+                    </span>
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Enemy send grid */}
+      <div className="px-3 pt-2 pb-3 border-t border-slate-700/40 overflow-y-auto max-h-[340px] flex flex-col gap-1">
+        {SEND_ENEMY_COSTS.map(({ enemyType, cost, count, label, icon }) => {
+          const canAfford = sendPoints >= cost;
+          const hasTarget = selectedTarget !== null;
+          const enabled = canAfford && hasTarget;
+          const isPressed = pressedType === enemyType;
+
+          return (
+            <motion.button
+              key={enemyType}
+              onClick={() => handleSend(enemyType, cost)}
+              disabled={!enabled}
+              className={cn(
+                'flex items-center gap-2 px-2.5 py-2 rounded-lg transition-colors duration-150',
+                enabled
+                  ? 'bg-slate-800/70 hover:bg-slate-700/80 cursor-pointer'
+                  : 'bg-slate-800/30 opacity-40 cursor-not-allowed'
+              )}
+              animate={
+                isPressed
+                  ? { scale: [0.95, 1.05, 1] }
+                  : { scale: 1 }
+              }
+              transition={{ type: 'spring', stiffness: 500, damping: 20 }}
+            >
+              {/* Enemy icon */}
+              <span className="text-base leading-none flex-shrink-0 w-6 text-center">
+                {icon}
+              </span>
+
+              {/* Label + count */}
+              <div className="flex-1 text-left">
+                <span className="text-xs font-semibold text-slate-200">{label}</span>
+                <span className="text-[10px] text-slate-500 ml-1">×{count}</span>
+              </div>
+
+              {/* Cost badge */}
+              <div
+                className={cn(
+                  'flex items-center gap-0.5 px-1.5 py-0.5 rounded-md text-[11px] font-bold tabular-nums',
+                  enabled
+                    ? 'bg-amber-500/20 text-amber-400'
+                    : 'bg-slate-700/30 text-slate-600'
+                )}
+              >
+                <Zap size={10} />
+                {cost}
+              </div>
+            </motion.button>
+          );
+        })}
+      </div>
+
+      {/* No target hint */}
+      <AnimatePresence>
+        {!selectedTarget && opponents.some((o) => !o.eliminated) && (
+          <motion.div
+            className="px-3 pb-2 text-center"
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+          >
+            <span className="text-[10px] text-cyan-400/70">
+              Select a target above to send enemies
+            </span>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.div>
+  );
+}

--- a/src/components/tower-defense/TowerDefenseMultiplayer.tsx
+++ b/src/components/tower-defense/TowerDefenseMultiplayer.tsx
@@ -1,0 +1,863 @@
+'use client';
+
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import dynamic from 'next/dynamic';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  Copy, Check, Crown, Users, Loader2, Wifi, WifiOff,
+  Swords, LogOut, Trophy, Medal, Shield, Skull,
+} from 'lucide-react';
+import type { TowerType } from '@/types/tower-defense';
+import { TOWER_DEFS, INITIAL_LIVES } from '@/types/tower-defense';
+import { useProfile } from '@/lib/profile/context';
+import { useTDMultiplayerSocket } from '@/hooks/useTDMultiplayerSocket';
+import type { TDMultiplayerState } from '@/hooks/useTDMultiplayerSocket';
+import TDGameHUD from './TDGameHUD';
+import TDTowerPanel from './TDTowerPanel';
+import TDTowerInfo from './TDTowerInfo';
+import TDEnemyInfo from './TDEnemyInfo';
+import TDSendEnemyPanel from './TDSendEnemyPanel';
+import TDOpponentBar from './TDOpponentBar';
+import TDIncomingAlert from './TDIncomingAlert';
+import TDParticleOverlay from './TDParticleOverlay';
+import { cn } from '@/lib/utils';
+import styles from './TowerDefenseGame.module.css';
+
+const TowerDefenseRenderer3D = dynamic(
+  () => import('./TowerDefenseRenderer3D'),
+  { ssr: false }
+);
+
+const TOWER_ORDER: TowerType[] = ['archer', 'cannon', 'frost', 'lightning', 'sniper', 'flame', 'arcane'];
+
+// ===== Main Export =====
+
+export default function TowerDefenseMultiplayer() {
+  const { profile } = useProfile();
+  const mp = useTDMultiplayerSocket();
+  const { state } = mp;
+
+  // Auto-connect on mount
+  useEffect(() => {
+    if (!mp.isConnected) {
+      mp.connectWebSocket();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className={styles.container}>
+      <AnimatePresence mode="wait">
+        {(state.status === 'disconnected' || state.status === 'connecting') && (
+          <ConnectingScreen key="connecting" status={state.status} onRetry={mp.connectWebSocket} />
+        )}
+        {state.status === 'connected' && !state.roomCode && (
+          <TDMultiplayerLobby
+            key="lobby"
+            playerName={profile?.name || 'Player'}
+            error={state.error}
+            onCreateRoom={mp.createRoom}
+            onJoinRoom={mp.joinRoom}
+            onBack={mp.disconnect}
+          />
+        )}
+        {state.status === 'waiting' && state.roomCode && (
+          <TDMultiplayerWaitingRoom
+            key="waiting"
+            state={state}
+            onSetReady={mp.setReady}
+            onStartGame={mp.startGame}
+            onLeave={mp.leaveRoom}
+          />
+        )}
+        {state.status === 'countdown' && (
+          <TDMultiplayerCountdown
+            key="countdown"
+            countdown={state.countdown}
+            players={state.players}
+          />
+        )}
+        {(state.status === 'playing' || state.status === 'ended') && (
+          <TDMultiplayerGameView
+            key="game"
+            state={state}
+            mp={mp}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// ===== Connecting Screen =====
+
+function ConnectingScreen({
+  status,
+  onRetry,
+}: {
+  status: 'disconnected' | 'connecting';
+  onRetry: () => void;
+}) {
+  return (
+    <motion.div
+      className="flex flex-col items-center justify-center h-screen bg-slate-950 text-slate-200"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    >
+      {status === 'connecting' ? (
+        <>
+          <Loader2 size={48} className="text-cyan-400 animate-spin mb-4" />
+          <p className="text-lg font-semibold">Connecting to server...</p>
+        </>
+      ) : (
+        <>
+          <WifiOff size={48} className="text-slate-500 mb-4" />
+          <p className="text-lg font-semibold mb-4">Connection lost</p>
+          <button
+            onClick={onRetry}
+            className={cn(
+              'px-6 py-2.5 rounded-xl font-semibold text-sm',
+              'bg-cyan-600 hover:bg-cyan-500 transition-colors'
+            )}
+          >
+            Reconnect
+          </button>
+        </>
+      )}
+    </motion.div>
+  );
+}
+
+// ===== Multiplayer Lobby =====
+
+function TDMultiplayerLobby({
+  playerName,
+  error,
+  onCreateRoom,
+  onJoinRoom,
+  onBack,
+}: {
+  playerName: string;
+  error: string | null;
+  onCreateRoom: (name: string, mapIndex?: number) => void;
+  onJoinRoom: (code: string, name: string) => void;
+  onBack: () => void;
+}) {
+  const [joinCode, setJoinCode] = useState('');
+  const [selectedMap, setSelectedMap] = useState(0);
+
+  return (
+    <motion.div
+      className="flex flex-col items-center justify-center h-screen bg-slate-950 text-slate-200 px-4"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -20 }}
+      transition={{ duration: 0.3 }}
+    >
+      <Wifi size={20} className="text-green-400 mb-2" />
+      <h1 className="text-3xl font-bold mb-1">Tower Defense</h1>
+      <p className="text-slate-400 text-sm mb-8">Multiplayer</p>
+
+      <div className="w-full max-w-sm flex flex-col gap-4">
+        {/* Create room */}
+        <div className="bg-slate-900/80 border border-slate-700/50 rounded-xl p-4">
+          <h2 className="text-sm font-semibold text-slate-300 mb-3 flex items-center gap-2">
+            <Swords size={14} className="text-cyan-400" />
+            Create Room
+          </h2>
+          <div className="flex gap-2 mb-3">
+            <button
+              onClick={() => setSelectedMap(0)}
+              className={cn(
+                'flex-1 py-1.5 rounded-lg text-xs font-medium transition-colors',
+                selectedMap === 0
+                  ? 'bg-cyan-500/20 text-cyan-400 border border-cyan-500/40'
+                  : 'bg-slate-800 text-slate-400 border border-transparent hover:bg-slate-700'
+              )}
+            >
+              Map 1
+            </button>
+            <button
+              onClick={() => setSelectedMap(1)}
+              className={cn(
+                'flex-1 py-1.5 rounded-lg text-xs font-medium transition-colors',
+                selectedMap === 1
+                  ? 'bg-orange-500/20 text-orange-400 border border-orange-500/40'
+                  : 'bg-slate-800 text-slate-400 border border-transparent hover:bg-slate-700'
+              )}
+            >
+              Map 2
+            </button>
+          </div>
+          <button
+            onClick={() => onCreateRoom(playerName, selectedMap)}
+            className={cn(
+              'w-full py-2.5 rounded-xl font-semibold text-sm transition-colors',
+              'bg-cyan-600 hover:bg-cyan-500'
+            )}
+          >
+            Create Room
+          </button>
+        </div>
+
+        {/* Join room */}
+        <div className="bg-slate-900/80 border border-slate-700/50 rounded-xl p-4">
+          <h2 className="text-sm font-semibold text-slate-300 mb-3 flex items-center gap-2">
+            <Users size={14} className="text-amber-400" />
+            Join Room
+          </h2>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={joinCode}
+              onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
+              placeholder="Room code"
+              maxLength={6}
+              className={cn(
+                'flex-1 px-3 py-2 rounded-lg text-sm font-mono',
+                'bg-slate-800 border border-slate-600/50',
+                'text-slate-200 placeholder:text-slate-600',
+                'focus:outline-none focus:border-cyan-500/50'
+              )}
+            />
+            <button
+              onClick={() => joinCode && onJoinRoom(joinCode, playerName)}
+              disabled={!joinCode}
+              className={cn(
+                'px-5 py-2 rounded-lg font-semibold text-sm transition-colors',
+                joinCode
+                  ? 'bg-amber-600 hover:bg-amber-500'
+                  : 'bg-slate-700 text-slate-500 cursor-not-allowed'
+              )}
+            >
+              Join
+            </button>
+          </div>
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div className="text-center text-red-400 text-sm bg-red-500/10 border border-red-500/20 rounded-lg py-2 px-3">
+            {error}
+          </div>
+        )}
+
+        {/* Back */}
+        <button
+          onClick={onBack}
+          className="text-sm text-slate-500 hover:text-slate-300 transition-colors mt-2"
+        >
+          Back to menu
+        </button>
+      </div>
+    </motion.div>
+  );
+}
+
+// ===== Waiting Room =====
+
+function TDMultiplayerWaitingRoom({
+  state,
+  onSetReady,
+  onStartGame,
+  onLeave,
+}: {
+  state: TDMultiplayerState;
+  onSetReady: (ready: boolean) => void;
+  onStartGame: () => void;
+  onLeave: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const me = state.players.find(p => p.playerId === state.playerId);
+  const isReady = me?.ready ?? false;
+  const allReady = state.players.every(p => p.ready || p.playerId === state.playerId);
+  const canStart = state.isHost && allReady && state.players.length >= 2;
+
+  const handleCopy = useCallback(() => {
+    if (!state.roomCode) return;
+    navigator.clipboard.writeText(state.roomCode);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [state.roomCode]);
+
+  return (
+    <motion.div
+      className="flex flex-col items-center justify-center h-screen bg-slate-950 text-slate-200 px-4"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -20 }}
+      transition={{ duration: 0.3 }}
+    >
+      <p className="text-xs text-slate-500 uppercase tracking-wider mb-1">Room Code</p>
+      <button
+        onClick={handleCopy}
+        className={cn(
+          'flex items-center gap-2 text-4xl font-mono font-bold mb-6 px-4 py-2 rounded-xl',
+          'bg-slate-900/80 border border-slate-700/50 hover:border-cyan-500/40 transition-colors'
+        )}
+      >
+        <span className="text-cyan-400 tracking-widest">{state.roomCode}</span>
+        {copied ? (
+          <Check size={20} className="text-green-400" />
+        ) : (
+          <Copy size={20} className="text-slate-500" />
+        )}
+      </button>
+
+      {/* Player list */}
+      <div className="w-full max-w-sm bg-slate-900/80 border border-slate-700/50 rounded-xl p-4 mb-4">
+        <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-3">
+          Players ({state.players.length}/4)
+        </h3>
+        <div className="flex flex-col gap-2">
+          {state.players.map(p => (
+            <div
+              key={p.playerId}
+              className={cn(
+                'flex items-center gap-2 px-3 py-2 rounded-lg',
+                'bg-slate-800/60 border',
+                p.ready ? 'border-green-500/30' : 'border-transparent'
+              )}
+            >
+              {state.isHost && p.playerId === state.playerId && (
+                <Crown size={14} className="text-amber-400 flex-shrink-0" />
+              )}
+              {!state.isHost && p.playerId === state.players.find(x => state.roomCode)?.playerId && null}
+              <span className="text-sm font-medium flex-1 truncate">{p.playerName}</span>
+              {p.playerId === state.playerId && (
+                <span className="text-[10px] text-slate-500 font-medium">YOU</span>
+              )}
+              <span
+                className={cn(
+                  'text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full',
+                  p.ready
+                    ? 'bg-green-500/20 text-green-400'
+                    : 'bg-slate-700/50 text-slate-500'
+                )}
+              >
+                {p.ready ? 'Ready' : 'Not ready'}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Error */}
+      {state.error && (
+        <div className="text-center text-red-400 text-sm bg-red-500/10 border border-red-500/20 rounded-lg py-2 px-3 mb-4 max-w-sm w-full">
+          {state.error}
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex gap-3 w-full max-w-sm">
+        <button
+          onClick={onLeave}
+          className={cn(
+            'flex items-center gap-1.5 px-4 py-2.5 rounded-xl text-sm font-medium transition-colors',
+            'border border-slate-700/50 text-slate-400 hover:bg-slate-800 hover:text-slate-200'
+          )}
+        >
+          <LogOut size={14} />
+          Leave
+        </button>
+
+        <button
+          onClick={() => onSetReady(!isReady)}
+          className={cn(
+            'flex-1 py-2.5 rounded-xl font-semibold text-sm transition-colors',
+            isReady
+              ? 'bg-slate-700 text-slate-300 hover:bg-slate-600'
+              : 'bg-green-600 hover:bg-green-500 text-white'
+          )}
+        >
+          {isReady ? 'Cancel Ready' : 'Ready Up'}
+        </button>
+
+        {state.isHost && (
+          <button
+            onClick={onStartGame}
+            disabled={!canStart}
+            className={cn(
+              'px-5 py-2.5 rounded-xl font-semibold text-sm transition-colors',
+              canStart
+                ? 'bg-cyan-600 hover:bg-cyan-500'
+                : 'bg-slate-700 text-slate-500 cursor-not-allowed'
+            )}
+          >
+            Start
+          </button>
+        )}
+      </div>
+    </motion.div>
+  );
+}
+
+// ===== Countdown =====
+
+function TDMultiplayerCountdown({
+  countdown,
+  players,
+}: {
+  countdown: number;
+  players: TDMultiplayerState['players'];
+}) {
+  return (
+    <motion.div
+      className="flex flex-col items-center justify-center h-screen bg-slate-950 text-slate-200"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    >
+      <motion.div
+        key={countdown}
+        className="text-8xl font-bold text-cyan-400 mb-8"
+        initial={{ scale: 2, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        transition={{ type: 'spring', stiffness: 400, damping: 20 }}
+      >
+        {countdown > 0 ? countdown : 'GO!'}
+      </motion.div>
+      <div className="flex gap-4">
+        {players.map(p => (
+          <div
+            key={p.playerId}
+            className="text-sm font-medium text-slate-400 bg-slate-800/60 px-3 py-1.5 rounded-lg"
+          >
+            {p.playerName}
+          </div>
+        ))}
+      </div>
+    </motion.div>
+  );
+}
+
+// ===== Game View =====
+
+function TDMultiplayerGameView({
+  state,
+  mp,
+}: {
+  state: TDMultiplayerState;
+  mp: ReturnType<typeof useTDMultiplayerSocket>;
+}) {
+  const gs = state.ownGameState;
+  const [selectedTowerType, setSelectedTowerType] = useState<TowerType | null>(null);
+  const [selectedTowerId, setSelectedTowerId] = useState<string | null>(null);
+  const [selectedEnemyId, setSelectedEnemyId] = useState<string | null>(null);
+  const [soundOn, setSoundOn] = useState(true);
+
+  const myPlayer = state.players.find(p => p.playerId === state.playerId);
+  const isEliminated = myPlayer?.eliminated ?? false;
+
+  // Build opponent data for the panels
+  const opponents = useMemo(() =>
+    state.players
+      .filter(p => p.playerId !== state.playerId)
+      .map(p => ({
+        playerId: p.playerId,
+        playerName: p.playerName,
+        lives: p.lives,
+        maxLives: p.maxLives || INITIAL_LIVES,
+        score: p.score,
+        sendPoints: p.sendPoints,
+        towerCount: p.towerCount,
+        enemyCount: p.enemyCount,
+        eliminated: p.eliminated,
+      })),
+    [state.players, state.playerId]
+  );
+
+  const sendPanelOpponents = useMemo(() =>
+    opponents.map(o => ({
+      playerId: o.playerId,
+      playerName: o.playerName,
+      lives: o.lives,
+      eliminated: o.eliminated,
+    })),
+    [opponents]
+  );
+
+  // Selected tower/enemy objects
+  const selectedTower = useMemo(() => {
+    if (!selectedTowerId || !gs) return null;
+    return gs.towers.find(t => t.id === selectedTowerId) ?? null;
+  }, [selectedTowerId, gs]);
+
+  const selectedEnemy = useMemo(() => {
+    if (!selectedEnemyId || !gs) return null;
+    return gs.enemies.find(e => e.id === selectedEnemyId) ?? null;
+  }, [selectedEnemyId, gs]);
+
+  // Cell click -> place tower via server
+  const handleCellClick = useCallback((x: number, z: number) => {
+    if (isEliminated) return;
+
+    if (selectedTowerType && gs) {
+      mp.placeTower(selectedTowerType, x, z);
+      setSelectedTowerType(null);
+      return;
+    }
+    // Check if there's a tower on this cell
+    if (gs) {
+      const cell = gs.map.grid[z]?.[x];
+      if (cell?.towerId) {
+        setSelectedTowerId(cell.towerId);
+        setSelectedTowerType(null);
+        setSelectedEnemyId(null);
+        return;
+      }
+    }
+    setSelectedTowerId(null);
+  }, [selectedTowerType, gs, mp, isEliminated]);
+
+  const handleSelectTower = useCallback((id: string) => {
+    setSelectedTowerId(id);
+    setSelectedTowerType(null);
+    setSelectedEnemyId(null);
+  }, []);
+
+  const handleSelectEnemy = useCallback((id: string) => {
+    setSelectedEnemyId(prev => prev === id ? null : id);
+    setSelectedTowerId(null);
+    setSelectedTowerType(null);
+  }, []);
+
+  const handleDeselectEnemy = useCallback(() => setSelectedEnemyId(null), []);
+  const handleDeselect = useCallback(() => {
+    setSelectedTowerId(null);
+    setSelectedTowerType(null);
+  }, []);
+
+  const handleTowerTypeSelect = useCallback((type: TowerType) => {
+    if (isEliminated || !gs) return;
+    if (gs.gold < TOWER_DEFS[type].cost) return;
+    setSelectedTowerType(prev => prev === type ? null : type);
+    setSelectedTowerId(null);
+  }, [gs, isEliminated]);
+
+  const handleUpgrade = useCallback(() => {
+    if (selectedTowerId) mp.upgradeTower(selectedTowerId);
+  }, [selectedTowerId, mp]);
+
+  const handleSell = useCallback(() => {
+    if (selectedTowerId) {
+      mp.sellTower(selectedTowerId);
+      setSelectedTowerId(null);
+    }
+  }, [selectedTowerId, mp]);
+
+  const handleSpeedToggle = useCallback(() => {
+    // Speed is server-managed in multiplayer; no-op
+  }, []);
+
+  const handleSoundToggle = useCallback(() => {
+    setSoundOn(prev => !prev);
+  }, []);
+
+  const handleBackToMenu = useCallback(() => {
+    mp.leaveRoom();
+  }, [mp]);
+
+  const handleStartWave = useCallback(() => {
+    mp.startWave();
+  }, [mp]);
+
+  const handleSendEnemy = useCallback((targetPlayerId: string, enemyType: import('@/types/tower-defense').EnemyType) => {
+    mp.sendEnemy(targetPlayerId, enemyType);
+  }, [mp]);
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (isEliminated) return;
+
+      const num = parseInt(e.key);
+      if (num >= 1 && num <= TOWER_ORDER.length) {
+        const type = TOWER_ORDER[num - 1];
+        setSelectedTowerType(prev => prev === type ? null : type);
+        setSelectedTowerId(null);
+        return;
+      }
+
+      if (e.key === 'Escape') {
+        setSelectedTowerType(null);
+        setSelectedTowerId(null);
+      }
+
+      if ((e.key === ' ' || e.key === 'Enter') && state.isHost) {
+        e.preventDefault();
+        mp.startWave();
+      }
+
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        if (selectedTowerId) {
+          mp.sellTower(selectedTowerId);
+          setSelectedTowerId(null);
+        }
+      }
+
+      if (e.key === 'u' || e.key === 'U') {
+        if (selectedTowerId) mp.upgradeTower(selectedTowerId);
+      }
+    };
+
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [isEliminated, state.isHost, selectedTowerId, mp]);
+
+  if (!gs) {
+    return (
+      <div className="flex items-center justify-center h-screen bg-slate-950 text-slate-400">
+        <Loader2 size={32} className="animate-spin" />
+      </div>
+    );
+  }
+
+  const displayState = {
+    ...gs,
+    selectedTowerType,
+    selectedTowerId,
+    selectedEnemyId,
+  };
+
+  return (
+    <motion.div
+      className="relative w-full h-screen overflow-hidden bg-slate-950"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    >
+      {/* Particle Overlay */}
+      <TDParticleOverlay phase={gs.phase} />
+
+      {/* 3D Canvas */}
+      <div className={styles.canvasWrapper}>
+        <TowerDefenseRenderer3D
+          state={displayState}
+          onCellClick={handleCellClick}
+          onSelectTower={handleSelectTower}
+          onSelectEnemy={handleSelectEnemy}
+        />
+      </div>
+
+      {/* HUD */}
+      <TDGameHUD
+        gold={gs.gold}
+        lives={gs.lives}
+        maxLives={gs.maxLives}
+        score={gs.score}
+        currentWave={gs.currentWave}
+        totalWaves={gs.totalWaves}
+        phase={gs.phase}
+        enemyCount={gs.enemies.length}
+        gameSpeed={gs.gameSpeed}
+        soundOn={soundOn}
+        waveCountdown={gs.waveCountdown}
+        autoStart={gs.autoStart}
+        onStartWave={handleStartWave}
+        onSpeedToggle={handleSpeedToggle}
+        onSoundToggle={handleSoundToggle}
+        onBackToMenu={handleBackToMenu}
+      />
+
+      {/* Tower Selection Panel */}
+      <TDTowerPanel
+        gold={gs.gold}
+        selectedTowerType={selectedTowerType}
+        onSelectTowerType={handleTowerTypeSelect}
+      />
+
+      {/* Selected Tower Info */}
+      <AnimatePresence>
+        {selectedTower && (
+          <TDTowerInfo
+            key={selectedTower.id}
+            tower={selectedTower}
+            gold={gs.gold}
+            onUpgrade={handleUpgrade}
+            onSell={handleSell}
+            onDeselect={handleDeselect}
+          />
+        )}
+      </AnimatePresence>
+
+      {/* Enemy Info Panel */}
+      <AnimatePresence>
+        {selectedEnemy && !selectedTower && (
+          <TDEnemyInfo
+            key={selectedEnemy.id}
+            enemy={selectedEnemy}
+            onDeselect={handleDeselectEnemy}
+          />
+        )}
+      </AnimatePresence>
+
+      {/* Send Enemy Panel (right side) */}
+      <AnimatePresence>
+        {!isEliminated && (
+          <TDSendEnemyPanel
+            sendPoints={myPlayer?.sendPoints ?? 0}
+            opponents={sendPanelOpponents}
+            selectedTarget={state.selectedTarget}
+            onSelectTarget={mp.selectTarget}
+            onSendEnemy={handleSendEnemy}
+          />
+        )}
+      </AnimatePresence>
+
+      {/* Opponent Status Bar (bottom) */}
+      <TDOpponentBar
+        opponents={opponents}
+        selectedTarget={state.selectedTarget}
+        onSelectTarget={mp.selectTarget}
+      />
+
+      {/* Incoming Enemy Alerts */}
+      <TDIncomingAlert alerts={state.incomingAlerts} />
+
+      {/* Eliminated Overlay */}
+      <AnimatePresence>
+        {isEliminated && state.status === 'playing' && (
+          <motion.div
+            className={cn(
+              'absolute inset-0 z-40 flex flex-col items-center justify-center',
+              'bg-black/60 backdrop-blur-sm'
+            )}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <Skull size={48} className="text-red-400 mb-3" />
+            <h2 className="text-2xl font-bold text-red-400 mb-1">Eliminated</h2>
+            <p className="text-slate-400 text-sm">Spectating...</p>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* End Screen */}
+      <AnimatePresence>
+        {state.status === 'ended' && (
+          <TDMultiplayerEndScreen
+            state={state}
+            onLeave={mp.leaveRoom}
+          />
+        )}
+      </AnimatePresence>
+    </motion.div>
+  );
+}
+
+// ===== End Screen =====
+
+function TDMultiplayerEndScreen({
+  state,
+  onLeave,
+}: {
+  state: TDMultiplayerState;
+  onLeave: () => void;
+}) {
+  const isWinner = state.winner === state.playerId;
+
+  const rankIcons = [
+    <Trophy key="1" size={32} className="text-amber-400" />,
+    <Medal key="2" size={28} className="text-slate-300" />,
+    <Medal key="3" size={24} className="text-amber-600" />,
+    <Shield key="4" size={22} className="text-slate-500" />,
+  ];
+
+  const rankColors = ['text-amber-400', 'text-slate-300', 'text-amber-600', 'text-slate-500'];
+
+  return (
+    <motion.div
+      className="absolute inset-0 z-50 flex flex-col items-center justify-center bg-slate-950/90 backdrop-blur-md"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    >
+      <motion.div
+        className="text-center mb-8"
+        initial={{ y: -20, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ delay: 0.2 }}
+      >
+        {isWinner ? (
+          <>
+            <Trophy size={56} className="text-amber-400 mx-auto mb-3" />
+            <h2 className="text-3xl font-bold text-amber-400">Victory!</h2>
+          </>
+        ) : (
+          <>
+            <Shield size={56} className="text-slate-400 mx-auto mb-3" />
+            <h2 className="text-3xl font-bold text-slate-300">Game Over</h2>
+          </>
+        )}
+      </motion.div>
+
+      {/* Rankings */}
+      <motion.div
+        className="w-full max-w-md bg-slate-900/80 border border-slate-700/50 rounded-xl p-4 mb-6"
+        initial={{ y: 20, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ delay: 0.4 }}
+      >
+        <h3 className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-3 text-center">
+          Rankings
+        </h3>
+        <div className="flex flex-col gap-2">
+          {state.rankings
+            .sort((a, b) => a.rank - b.rank)
+            .map(r => {
+              const isMe = r.playerId === state.playerId;
+              return (
+                <div
+                  key={r.playerId}
+                  className={cn(
+                    'flex items-center gap-3 px-3 py-2.5 rounded-lg',
+                    isMe ? 'bg-cyan-500/10 border border-cyan-500/30' : 'bg-slate-800/60'
+                  )}
+                >
+                  <div className="flex-shrink-0 w-8 flex items-center justify-center">
+                    {rankIcons[r.rank - 1] || (
+                      <span className="text-sm font-bold text-slate-500">#{r.rank}</span>
+                    )}
+                  </div>
+                  <span
+                    className={cn(
+                      'text-sm font-semibold flex-1',
+                      rankColors[r.rank - 1] || 'text-slate-400'
+                    )}
+                  >
+                    {r.playerName}
+                    {isMe && <span className="text-[10px] text-slate-500 ml-1.5">(you)</span>}
+                  </span>
+                  <span className="text-sm font-mono text-slate-400 tabular-nums">
+                    {r.score.toLocaleString()}
+                  </span>
+                </div>
+              );
+            })}
+        </div>
+      </motion.div>
+
+      {/* Actions */}
+      <motion.div
+        className="flex gap-3"
+        initial={{ y: 20, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ delay: 0.6 }}
+      >
+        <button
+          onClick={onLeave}
+          className={cn(
+            'px-6 py-2.5 rounded-xl font-semibold text-sm transition-colors',
+            'border border-slate-700/50 text-slate-300 hover:bg-slate-800'
+          )}
+        >
+          Leave
+        </button>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/hooks/useTDMultiplayerSocket.ts
+++ b/src/hooks/useTDMultiplayerSocket.ts
@@ -1,0 +1,574 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import type {
+  GameState, Tower, Enemy, Projectile, EnemyType, TowerType,
+  TDPlayerState, TDMultiplayerRoom,
+} from '@/types/tower-defense';
+
+// ===== Exported Types =====
+
+export interface TDMultiplayerPlayer {
+  playerId: string;
+  playerName: string;
+  ready: boolean;
+  connected: boolean;
+  eliminated: boolean;
+  gold: number;
+  lives: number;
+  maxLives: number;
+  score: number;
+  sendPoints: number;
+  currentWave: number;
+  towerCount: number;
+  enemyCount: number;
+}
+
+export interface TDMultiplayerState {
+  roomCode: string | null;
+  playerId: string | null;
+  isHost: boolean;
+  status: 'disconnected' | 'connecting' | 'connected' | 'waiting' | 'countdown' | 'playing' | 'ended';
+  players: TDMultiplayerPlayer[];
+  ownGameState: GameState | null;
+  opponentStates: Map<string, {
+    playerId: string;
+    towers: Tower[];
+    enemies: Enemy[];
+    projectiles: Projectile[];
+    gold: number;
+    lives: number;
+    score: number;
+    sendPoints: number;
+    phase: string;
+  }>;
+  selectedTarget: string | null;
+  countdown: number;
+  winner: string | null;
+  rankings: Array<{ playerId: string; playerName: string; rank: number; score: number }>;
+  incomingAlerts: Array<{ fromPlayerName: string; enemyType: EnemyType; count: number; timestamp: number }>;
+  error: string | null;
+}
+
+export interface UseTDMultiplayerReturn {
+  state: TDMultiplayerState;
+  isConnected: boolean;
+  createRoom: (playerName: string, mapIndex?: number) => void;
+  joinRoom: (roomCode: string, playerName: string) => void;
+  leaveRoom: () => void;
+  setReady: (ready: boolean) => void;
+  startGame: () => void;
+  placeTower: (towerType: TowerType, gridX: number, gridZ: number) => void;
+  sellTower: (towerId: string) => void;
+  upgradeTower: (towerId: string) => void;
+  startWave: () => void;
+  sendEnemy: (targetPlayerId: string, enemyType: EnemyType) => void;
+  selectTarget: (targetPlayerId: string) => void;
+  connectWebSocket: () => void;
+  disconnect: () => void;
+}
+
+// ===== Constants =====
+
+const MULTIPLAYER_URL = process.env.NEXT_PUBLIC_MULTIPLAYER_URL || 'ws://localhost:3001';
+const MAX_RECONNECT_ATTEMPTS = 5;
+const PING_TIMEOUT = 60000;
+const PING_CHECK_INTERVAL = 10000;
+const SESSION_TOKEN_KEY = 'td_reconnectToken';
+
+// ===== Hook =====
+
+export function useTDMultiplayerSocket(): UseTDMultiplayerReturn {
+  // Connection
+  const wsRef = useRef<WebSocket | null>(null);
+  const playerIdRef = useRef<string | null>(null);
+  const reconnectAttemptsRef = useRef(0);
+  const reconnectTokenRef = useRef<string | null>(null);
+  const lastPingRef = useRef(Date.now());
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // State
+  const [status, setStatus] = useState<TDMultiplayerState['status']>('disconnected');
+  const [playerId, setPlayerId] = useState<string | null>(null);
+  const [roomCode, setRoomCode] = useState<string | null>(null);
+  const [isHost, setIsHost] = useState(false);
+  const [players, setPlayers] = useState<TDMultiplayerPlayer[]>([]);
+  const [ownGameState, setOwnGameState] = useState<GameState | null>(null);
+  const [opponentStates, setOpponentStates] = useState<TDMultiplayerState['opponentStates']>(new Map());
+  const [selectedTarget, setSelectedTarget] = useState<string | null>(null);
+  const [countdown, setCountdown] = useState(0);
+  const [winner, setWinner] = useState<string | null>(null);
+  const [rankings, setRankings] = useState<TDMultiplayerState['rankings']>([]);
+  const [incomingAlerts, setIncomingAlerts] = useState<TDMultiplayerState['incomingAlerts']>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  // Refs for stable access in callbacks
+  const roomCodeRef = useRef<string | null>(null);
+  const statusRef = useRef<TDMultiplayerState['status']>('disconnected');
+
+  // Keep refs in sync
+  useEffect(() => { roomCodeRef.current = roomCode; }, [roomCode]);
+  useEffect(() => { statusRef.current = status; }, [status]);
+
+  // ===== Send helper =====
+
+  const send = useCallback((msg: Record<string, unknown>) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify(msg));
+    }
+  }, []);
+
+  // ===== Server message handler =====
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleServerMessage = useCallback((msg: any) => {
+    const type = msg.type as string;
+
+    // Standard multiplayer protocol messages
+    if (type === 'ping') {
+      lastPingRef.current = Date.now();
+      send({ type: 'pong' });
+      return;
+    }
+
+    if (type === 'connected') {
+      playerIdRef.current = msg.playerId;
+      setPlayerId(msg.playerId);
+      return;
+    }
+
+    if (type === 'online_count') return;
+
+    if (type === 'error') {
+      setError(msg.message);
+      return;
+    }
+
+    // ===== TD-specific messages =====
+
+    switch (type) {
+      case 'td_room_created': {
+        roomCodeRef.current = msg.roomCode;
+        setRoomCode(msg.roomCode);
+        playerIdRef.current = msg.playerId;
+        setPlayerId(msg.playerId);
+        setIsHost(true);
+        setStatus('waiting');
+        setError(null);
+        break;
+      }
+
+      case 'td_room_joined': {
+        roomCodeRef.current = msg.roomCode;
+        setRoomCode(msg.roomCode);
+        setStatus('waiting');
+        setError(null);
+        // Room state will come separately via td_room_state
+        if (msg.room) {
+          applyRoomState(msg.room);
+        }
+        break;
+      }
+
+      case 'td_room_state': {
+        applyRoomState(msg.room);
+        break;
+      }
+
+      case 'td_player_joined': {
+        const p = msg.player as TDPlayerState;
+        setPlayers(prev => {
+          if (prev.some(x => x.playerId === p.playerId)) return prev;
+          return [...prev, toMultiplayerPlayer(p)];
+        });
+        break;
+      }
+
+      case 'td_player_left': {
+        setPlayers(prev => prev.filter(p => p.playerId !== msg.playerId));
+        break;
+      }
+
+      case 'td_player_ready': {
+        setPlayers(prev =>
+          prev.map(p => p.playerId === msg.playerId ? { ...p, ready: msg.ready } : p)
+        );
+        break;
+      }
+
+      case 'td_countdown': {
+        setStatus('countdown');
+        setCountdown(msg.seconds);
+        break;
+      }
+
+      case 'td_game_started': {
+        setStatus('playing');
+        setWinner(null);
+        setRankings([]);
+        setIncomingAlerts([]);
+        setSelectedTarget(null);
+        break;
+      }
+
+      case 'td_state_update': {
+        const playerStates = msg.playerStates as Array<{
+          playerId: string;
+          towers: Tower[];
+          enemies: Enemy[];
+          projectiles: Projectile[];
+          gold: number;
+          lives: number;
+          score: number;
+          sendPoints: number;
+          phase: string;
+        }>;
+
+        const myId = playerIdRef.current;
+
+        for (const ps of playerStates) {
+          if (ps.playerId === myId) {
+            // Update own full game state
+            setOwnGameState(prev => {
+              if (!prev) return prev;
+              return {
+                ...prev,
+                towers: ps.towers,
+                enemies: ps.enemies,
+                projectiles: ps.projectiles,
+                gold: ps.gold,
+                lives: ps.lives,
+                score: ps.score,
+                phase: ps.phase as GameState['phase'],
+              };
+            });
+          }
+        }
+
+        // Update opponent states
+        setOpponentStates(() => {
+          const newMap = new Map<string, typeof playerStates[number]>();
+          for (const ps of playerStates) {
+            if (ps.playerId !== myId) {
+              newMap.set(ps.playerId, ps);
+            }
+          }
+          return newMap;
+        });
+
+        // Update player summary data
+        setPlayers(prev => prev.map(p => {
+          const ps = playerStates.find(s => s.playerId === p.playerId);
+          if (!ps) return p;
+          return {
+            ...p,
+            gold: ps.gold,
+            lives: ps.lives,
+            score: ps.score,
+            sendPoints: ps.sendPoints,
+            towerCount: ps.towers.length,
+            enemyCount: ps.enemies.length,
+          };
+        }));
+
+        break;
+      }
+
+      case 'td_wave_started': {
+        // Wave is server-managed; state updates come via td_state_update
+        break;
+      }
+
+      case 'td_wave_complete': {
+        // Wave ended on server side; state updates come via td_state_update
+        break;
+      }
+
+      case 'td_tower_placed': {
+        // Tower placed confirmation — state arrives via td_state_update
+        break;
+      }
+
+      case 'td_tower_sold': {
+        break;
+      }
+
+      case 'td_tower_upgraded': {
+        break;
+      }
+
+      case 'td_enemy_sent': {
+        // This is broadcast to all; only matters if we're the target (handled separately via td_enemies_incoming)
+        break;
+      }
+
+      case 'td_enemies_incoming': {
+        const alert = {
+          fromPlayerName: msg.fromPlayerName as string,
+          enemyType: msg.enemyType as EnemyType,
+          count: msg.count as number,
+          timestamp: Date.now(),
+        };
+        setIncomingAlerts(prev => [...prev, alert]);
+        break;
+      }
+
+      case 'td_player_eliminated': {
+        setPlayers(prev =>
+          prev.map(p =>
+            p.playerId === msg.playerId ? { ...p, eliminated: true } : p
+          )
+        );
+        break;
+      }
+
+      case 'td_game_over': {
+        setStatus('ended');
+        setWinner(msg.winnerId || null);
+
+        // Build rankings with player names
+        const rankingsRaw = msg.rankings as Array<{ playerId: string; rank: number; score: number }>;
+        setPlayers(prev => {
+          const rankingsWithNames = rankingsRaw.map(r => {
+            const player = prev.find(p => p.playerId === r.playerId);
+            return { ...r, playerName: player?.playerName || 'Unknown' };
+          });
+          setRankings(rankingsWithNames);
+          return prev;
+        });
+        break;
+      }
+
+      default:
+        break;
+    }
+  }, [send]);
+
+  // ===== Room state helper =====
+
+  const applyRoomState = useCallback((room: TDMultiplayerRoom) => {
+    setRoomCode(room.code);
+    roomCodeRef.current = room.code;
+    setIsHost(room.hostId === playerIdRef.current);
+    setPlayers(room.players.map(toMultiplayerPlayer));
+
+    if (room.status === 'playing') {
+      setStatus('playing');
+      // Find own game state from room player data
+      const self = room.players.find(p => p.playerId === playerIdRef.current);
+      if (self) {
+        setOwnGameState(self.gameState);
+      }
+    } else if (room.status === 'countdown') {
+      setStatus('countdown');
+    } else if (room.status === 'ended') {
+      setStatus('ended');
+    }
+  }, []);
+
+  // ===== WebSocket connection =====
+
+  const connectWebSocket = useCallback(() => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) return;
+    if (wsRef.current?.readyState === WebSocket.CONNECTING) return;
+
+    setStatus('connecting');
+    const ws = new WebSocket(MULTIPLAYER_URL);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      if (wsRef.current !== ws) { ws.close(); return; }
+
+      setStatus('connected');
+      setError(null);
+      reconnectAttemptsRef.current = 0;
+      lastPingRef.current = Date.now();
+
+      // Try reconnect if we had a session
+      const token = reconnectTokenRef.current || sessionStorage.getItem(SESSION_TOKEN_KEY);
+      if (token) {
+        ws.send(JSON.stringify({ type: 'reconnect', reconnectToken: token }));
+      }
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const message = JSON.parse(event.data);
+        handleServerMessage(message);
+      } catch { /* ignore parse errors */ }
+    };
+
+    ws.onclose = () => {
+      if (wsRef.current !== ws) return;
+      wsRef.current = null;
+
+      const hadSession = reconnectTokenRef.current || sessionStorage.getItem(SESSION_TOKEN_KEY);
+      if (hadSession && reconnectAttemptsRef.current < MAX_RECONNECT_ATTEMPTS) {
+        reconnectAttemptsRef.current++;
+        const delay = Math.min(1000 * Math.pow(2, reconnectAttemptsRef.current - 1), 15000);
+        setStatus('connecting');
+        reconnectTimerRef.current = setTimeout(() => {
+          reconnectTimerRef.current = null;
+          connectWebSocket();
+        }, delay);
+      } else {
+        setStatus('disconnected');
+      }
+    };
+
+    ws.onerror = () => {
+      ws.close();
+    };
+  }, [handleServerMessage]);
+
+  const disconnect = useCallback(() => {
+    reconnectAttemptsRef.current = MAX_RECONNECT_ATTEMPTS;
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+    if (wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+    setStatus('disconnected');
+  }, []);
+
+  // ===== Ping timeout check =====
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (wsRef.current?.readyState === WebSocket.OPEN && Date.now() - lastPingRef.current > PING_TIMEOUT) {
+        wsRef.current.close();
+      }
+    }, PING_CHECK_INTERVAL);
+
+    return () => {
+      clearInterval(interval);
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+    };
+  }, []);
+
+  // ===== Action dispatchers =====
+
+  const createRoom = useCallback((playerName: string, mapIndex: number = 0) => {
+    send({ type: 'td_create_room', playerName, mapIndex });
+  }, [send]);
+
+  const joinRoom = useCallback((roomCode: string, playerName: string) => {
+    send({ type: 'td_join_room', roomCode: roomCode.toUpperCase().trim(), playerName });
+  }, [send]);
+
+  const leaveRoom = useCallback(() => {
+    send({ type: 'td_leave_room' });
+    setStatus('connected');
+    setRoomCode(null);
+    roomCodeRef.current = null;
+    setPlayers([]);
+    setOwnGameState(null);
+    setOpponentStates(new Map());
+    setSelectedTarget(null);
+    setWinner(null);
+    setRankings([]);
+    setIncomingAlerts([]);
+    setIsHost(false);
+    reconnectTokenRef.current = null;
+    sessionStorage.removeItem(SESSION_TOKEN_KEY);
+  }, [send]);
+
+  const setReady = useCallback((ready: boolean) => {
+    send({ type: 'td_set_ready', ready });
+  }, [send]);
+
+  const startGame = useCallback(() => {
+    send({ type: 'td_start_game' });
+  }, [send]);
+
+  const placeTower = useCallback((towerType: TowerType, gridX: number, gridZ: number) => {
+    send({ type: 'td_place_tower', towerType, gridX, gridZ });
+  }, [send]);
+
+  const sellTowerAction = useCallback((towerId: string) => {
+    send({ type: 'td_sell_tower', towerId });
+  }, [send]);
+
+  const upgradeTowerAction = useCallback((towerId: string) => {
+    send({ type: 'td_upgrade_tower', towerId });
+  }, [send]);
+
+  const startWaveAction = useCallback(() => {
+    send({ type: 'td_start_wave' });
+  }, [send]);
+
+  const sendEnemy = useCallback((targetPlayerId: string, enemyType: EnemyType) => {
+    send({ type: 'td_send_enemy', targetPlayerId, enemyType });
+  }, [send]);
+
+  const selectTarget = useCallback((targetPlayerId: string) => {
+    setSelectedTarget(targetPlayerId);
+    send({ type: 'td_select_target', targetPlayerId });
+  }, [send]);
+
+  // ===== Composed state =====
+
+  const state: TDMultiplayerState = {
+    roomCode,
+    playerId,
+    isHost,
+    status,
+    players,
+    ownGameState,
+    opponentStates,
+    selectedTarget,
+    countdown,
+    winner,
+    rankings,
+    incomingAlerts,
+    error,
+  };
+
+  return {
+    state,
+    isConnected: status !== 'disconnected',
+    createRoom,
+    joinRoom,
+    leaveRoom,
+    setReady,
+    startGame,
+    placeTower,
+    sellTower: sellTowerAction,
+    upgradeTower: upgradeTowerAction,
+    startWave: startWaveAction,
+    sendEnemy,
+    selectTarget,
+    connectWebSocket,
+    disconnect,
+  };
+}
+
+// ===== Helpers =====
+
+function toMultiplayerPlayer(p: TDPlayerState): TDMultiplayerPlayer {
+  return {
+    playerId: p.playerId,
+    playerName: p.playerName,
+    ready: p.ready,
+    connected: p.connected,
+    eliminated: p.eliminated,
+    gold: p.gameState?.gold ?? 0,
+    lives: p.gameState?.lives ?? 20,
+    maxLives: p.gameState?.maxLives ?? 20,
+    score: p.gameState?.score ?? 0,
+    sendPoints: p.sendPoints ?? 0,
+    currentWave: p.gameState?.currentWave ?? 0,
+    towerCount: p.gameState?.towers?.length ?? 0,
+    enemyCount: p.gameState?.enemies?.length ?? 0,
+  };
+}

--- a/src/lib/tower-defense/TDMultiplayerManager.ts
+++ b/src/lib/tower-defense/TDMultiplayerManager.ts
@@ -1,0 +1,843 @@
+import type {
+  GameState, TDPlayerState, TDMultiplayerRoom, EnemyType, TowerType,
+  Tower, Enemy,
+} from '@/types/tower-defense';
+import {
+  SEND_ENEMY_COSTS, SEND_POINTS_PER_KILL, ENEMY_DEFS,
+  TOTAL_WAVES, WAVE_PREP_TIME,
+} from '@/types/tower-defense';
+import {
+  createInitialState, placeTower, sellTower, upgradeTower,
+  updateGame, startWave,
+} from './engine';
+import { WAVES } from './waves';
+
+// ===== Callbacks for server integration =====
+
+export interface TDMPCallbacks {
+  onBroadcast: (roomCode: string, message: object, excludePlayerId?: string) => void;
+  onSendToPlayer: (playerId: string, message: object) => void;
+  onSessionEnd: (roomCode: string) => void;
+}
+
+// ===== Internal room state =====
+
+interface TDMPRoom {
+  code: string;
+  name: string;
+  hostId: string;
+  players: TDMPPlayer[];
+  status: 'waiting' | 'countdown' | 'playing' | 'ended';
+  maxPlayers: number;
+  mapIndex: number;
+  currentWave: number;
+  waveActive: boolean;
+  winner: string | null;
+  createdAt: number;
+  gameStartedAt: number | null;
+  waveBuildTimer: number;
+  // Track previous kill counts per player for sendPoints delta
+  prevKillCounts: Map<string, number>;
+}
+
+interface TDMPPlayer {
+  playerId: string;
+  playerName: string;
+  gameState: GameState;
+  ready: boolean;
+  connected: boolean;
+  sendPoints: number;
+  totalSent: number;
+  totalReceived: number;
+  eliminated: boolean;
+  eliminatedAt: number | null;
+  defaultTarget: string | null;
+}
+
+// ===== Constants =====
+
+const TD_TICK_RATE = 20; // 20 ticks/sec = 50ms per tick
+const TD_MAX_PLAYERS = 4;
+const TD_MIN_PLAYERS = 2;
+const ROOM_TIMEOUT = 10 * 60 * 1000; // 10 minutes
+const COUNTDOWN_SECONDS = 3;
+
+// ===== Manager =====
+
+export class TDMultiplayerManager {
+  private rooms = new Map<string, TDMPRoom>();
+  private playerToRoom = new Map<string, string>();
+  private tickIntervals = new Map<string, NodeJS.Timeout>();
+  private cleanupInterval: NodeJS.Timeout;
+  private callbacks: TDMPCallbacks;
+
+  constructor(callbacks: TDMPCallbacks) {
+    this.callbacks = callbacks;
+    this.cleanupInterval = setInterval(() => this.cleanupStaleRooms(), 60000);
+  }
+
+  // ===== Room Lifecycle =====
+
+  createRoom(
+    playerId: string,
+    playerName: string,
+    mapIndex: number = 0,
+  ): { roomCode: string } {
+    const roomCode = this.generateRoomCode();
+    const sanitizedName = (playerName || 'Player').slice(0, 20);
+
+    const player: TDMPPlayer = {
+      playerId,
+      playerName: sanitizedName,
+      gameState: createInitialState(mapIndex),
+      ready: false,
+      connected: true,
+      sendPoints: 0,
+      totalSent: 0,
+      totalReceived: 0,
+      eliminated: false,
+      eliminatedAt: null,
+      defaultTarget: null,
+    };
+
+    const room: TDMPRoom = {
+      code: roomCode,
+      name: `${sanitizedName}'s TD`,
+      hostId: playerId,
+      players: [player],
+      status: 'waiting',
+      maxPlayers: TD_MAX_PLAYERS,
+      mapIndex,
+      currentWave: 0,
+      waveActive: false,
+      winner: null,
+      createdAt: Date.now(),
+      gameStartedAt: null,
+      waveBuildTimer: WAVE_PREP_TIME,
+      prevKillCounts: new Map(),
+    };
+
+    this.rooms.set(roomCode, room);
+    this.playerToRoom.set(playerId, roomCode);
+
+    return { roomCode };
+  }
+
+  joinRoom(
+    roomCode: string,
+    playerId: string,
+    playerName: string,
+  ): { success: boolean; error?: string } {
+    const normalized = roomCode.toUpperCase().trim();
+    const room = this.rooms.get(normalized);
+
+    if (!room) return { success: false, error: 'Room not found' };
+    if (room.status !== 'waiting') return { success: false, error: 'Game already in progress' };
+    if (room.players.length >= room.maxPlayers) return { success: false, error: 'Room is full' };
+
+    const existing = room.players.find(p => p.playerId === playerId);
+    if (existing) {
+      existing.connected = true;
+      return { success: true };
+    }
+
+    const sanitizedName = (playerName || 'Player').slice(0, 20);
+    const player: TDMPPlayer = {
+      playerId,
+      playerName: sanitizedName,
+      gameState: createInitialState(room.mapIndex),
+      ready: false,
+      connected: true,
+      sendPoints: 0,
+      totalSent: 0,
+      totalReceived: 0,
+      eliminated: false,
+      eliminatedAt: null,
+      defaultTarget: null,
+    };
+
+    room.players.push(player);
+    this.playerToRoom.set(playerId, normalized);
+
+    // Broadcast player joined to others
+    this.callbacks.onBroadcast(normalized, {
+      type: 'td_player_joined',
+      player: this.toPlayerState(player),
+    }, playerId);
+
+    return { success: true };
+  }
+
+  leaveRoom(playerId: string): void {
+    const roomCode = this.playerToRoom.get(playerId);
+    if (!roomCode) return;
+
+    const room = this.rooms.get(roomCode);
+    if (!room) {
+      this.playerToRoom.delete(playerId);
+      return;
+    }
+
+    // During gameplay, mark as eliminated
+    if (room.status === 'playing') {
+      const player = room.players.find(p => p.playerId === playerId);
+      if (player && !player.eliminated) {
+        this.eliminatePlayer(room, playerId);
+      }
+    }
+
+    room.players = room.players.filter(p => p.playerId !== playerId);
+    this.playerToRoom.delete(playerId);
+
+    if (room.players.length === 0) {
+      this.stopTickLoop(roomCode);
+      this.rooms.delete(roomCode);
+      return;
+    }
+
+    // Transfer host
+    if (room.hostId === playerId) {
+      const next = room.players.find(p => p.connected) || room.players[0];
+      room.hostId = next.playerId;
+    }
+
+    this.callbacks.onBroadcast(roomCode, {
+      type: 'td_player_left',
+      playerId,
+    });
+  }
+
+  handleDisconnect(playerId: string): void {
+    const roomCode = this.playerToRoom.get(playerId);
+    if (!roomCode) return;
+
+    const room = this.rooms.get(roomCode);
+    if (!room) return;
+
+    const player = room.players.find(p => p.playerId === playerId);
+    if (player) {
+      player.connected = false;
+    }
+  }
+
+  setReady(playerId: string, ready: boolean): void {
+    const roomCode = this.playerToRoom.get(playerId);
+    if (!roomCode) return;
+
+    const room = this.rooms.get(roomCode);
+    if (!room || room.status !== 'waiting') return;
+
+    const player = room.players.find(p => p.playerId === playerId);
+    if (!player) return;
+
+    player.ready = ready;
+
+    this.callbacks.onBroadcast(roomCode, {
+      type: 'td_player_ready',
+      playerId,
+      ready,
+    });
+  }
+
+  startGame(playerId: string): void {
+    const roomCode = this.playerToRoom.get(playerId);
+    if (!roomCode) return;
+
+    const room = this.rooms.get(roomCode);
+    if (!room) return;
+    if (room.hostId !== playerId) {
+      this.callbacks.onSendToPlayer(playerId, {
+        type: 'error',
+        message: 'Only the host can start the game',
+      });
+      return;
+    }
+    if (room.players.length < TD_MIN_PLAYERS) {
+      this.callbacks.onSendToPlayer(playerId, {
+        type: 'error',
+        message: `Need at least ${TD_MIN_PLAYERS} players`,
+      });
+      return;
+    }
+
+    const notReady = room.players.filter(p => !p.ready && p.playerId !== room.hostId);
+    if (notReady.length > 0) {
+      this.callbacks.onSendToPlayer(playerId, {
+        type: 'error',
+        message: 'All players must be ready',
+      });
+      return;
+    }
+
+    // Start countdown
+    room.status = 'countdown';
+    let countdown = COUNTDOWN_SECONDS;
+
+    const countdownInterval = setInterval(() => {
+      this.callbacks.onBroadcast(roomCode, {
+        type: 'td_countdown',
+        seconds: countdown,
+      });
+
+      countdown--;
+
+      if (countdown < 0) {
+        clearInterval(countdownInterval);
+        this.beginPlaying(roomCode);
+      }
+    }, 1000);
+  }
+
+  private beginPlaying(roomCode: string): void {
+    const room = this.rooms.get(roomCode);
+    if (!room || room.status !== 'countdown') return;
+
+    room.status = 'playing';
+    room.gameStartedAt = Date.now();
+    room.currentWave = 0;
+    room.waveActive = false;
+    room.waveBuildTimer = WAVE_PREP_TIME;
+
+    // Reset all player game states
+    for (const player of room.players) {
+      player.gameState = createInitialState(room.mapIndex);
+      player.gameState.phase = 'build';
+      player.sendPoints = 0;
+      player.totalSent = 0;
+      player.totalReceived = 0;
+      player.eliminated = false;
+      player.eliminatedAt = null;
+    }
+
+    // Initialize kill tracking
+    room.prevKillCounts.clear();
+    for (const player of room.players) {
+      room.prevKillCounts.set(player.playerId, 0);
+    }
+
+    this.callbacks.onBroadcast(roomCode, {
+      type: 'td_game_started',
+      mapIndex: room.mapIndex,
+      wave: 0,
+    });
+
+    this.startTickLoop(roomCode);
+  }
+
+  // ===== Game Actions =====
+
+  placeTower(
+    playerId: string,
+    towerType: TowerType,
+    gridX: number,
+    gridZ: number,
+  ): { success: boolean; error?: string } {
+    const room = this.getPlayerRoom(playerId);
+    if (!room || room.status !== 'playing') return { success: false, error: 'Not in an active game' };
+
+    const player = room.players.find(p => p.playerId === playerId);
+    if (!player || player.eliminated) return { success: false, error: 'Player eliminated' };
+
+    const prevGold = player.gameState.gold;
+    player.gameState = placeTower(player.gameState, towerType, gridX, gridZ);
+
+    if (player.gameState.gold === prevGold) {
+      return { success: false, error: 'Cannot place tower there' };
+    }
+
+    // Find the newly placed tower
+    const newTower = player.gameState.towers[player.gameState.towers.length - 1];
+
+    this.callbacks.onBroadcast(room.code, {
+      type: 'td_tower_placed',
+      playerId,
+      tower: newTower,
+    });
+
+    return { success: true };
+  }
+
+  sellTower(playerId: string, towerId: string): { success: boolean; error?: string } {
+    const room = this.getPlayerRoom(playerId);
+    if (!room || room.status !== 'playing') return { success: false, error: 'Not in an active game' };
+
+    const player = room.players.find(p => p.playerId === playerId);
+    if (!player || player.eliminated) return { success: false, error: 'Player eliminated' };
+
+    const hadTower = player.gameState.towers.some(t => t.id === towerId);
+    if (!hadTower) return { success: false, error: 'Tower not found' };
+
+    player.gameState = sellTower(player.gameState, towerId);
+
+    this.callbacks.onBroadcast(room.code, {
+      type: 'td_tower_sold',
+      playerId,
+      towerId,
+    });
+
+    return { success: true };
+  }
+
+  upgradeTower(playerId: string, towerId: string): { success: boolean; error?: string } {
+    const room = this.getPlayerRoom(playerId);
+    if (!room || room.status !== 'playing') return { success: false, error: 'Not in an active game' };
+
+    const player = room.players.find(p => p.playerId === playerId);
+    if (!player || player.eliminated) return { success: false, error: 'Player eliminated' };
+
+    const tower = player.gameState.towers.find(t => t.id === towerId);
+    if (!tower) return { success: false, error: 'Tower not found' };
+
+    const prevLevel = tower.level;
+    player.gameState = upgradeTower(player.gameState, towerId);
+
+    const updatedTower = player.gameState.towers.find(t => t.id === towerId);
+    if (!updatedTower || updatedTower.level === prevLevel) {
+      return { success: false, error: 'Cannot upgrade tower' };
+    }
+
+    this.callbacks.onBroadcast(room.code, {
+      type: 'td_tower_upgraded',
+      playerId,
+      towerId,
+      level: updatedTower.level,
+    });
+
+    return { success: true };
+  }
+
+  startWave(playerId: string): void {
+    const room = this.getPlayerRoom(playerId);
+    if (!room || room.status !== 'playing') return;
+
+    // Only host can start waves
+    if (room.hostId !== playerId) return;
+    if (room.waveActive) return;
+    if (room.currentWave >= TOTAL_WAVES) return;
+
+    this.triggerWave(room);
+  }
+
+  private triggerWave(room: TDMPRoom): void {
+    room.waveActive = true;
+    room.currentWave++;
+
+    // Start wave on each non-eliminated player's game state
+    for (const player of room.players) {
+      if (player.eliminated) continue;
+      player.gameState = startWave(player.gameState);
+    }
+
+    this.callbacks.onBroadcast(room.code, {
+      type: 'td_wave_started',
+      waveNumber: room.currentWave,
+    });
+  }
+
+  // ===== Enemy Sending =====
+
+  sendEnemy(
+    playerId: string,
+    targetPlayerId: string,
+    enemyType: EnemyType,
+  ): { success: boolean; error?: string } {
+    const room = this.getPlayerRoom(playerId);
+    if (!room || room.status !== 'playing') return { success: false, error: 'Not in an active game' };
+
+    const sender = room.players.find(p => p.playerId === playerId);
+    if (!sender || sender.eliminated) return { success: false, error: 'Sender eliminated' };
+
+    const target = room.players.find(p => p.playerId === targetPlayerId);
+    if (!target || target.eliminated) return { success: false, error: 'Target eliminated' };
+    if (playerId === targetPlayerId) return { success: false, error: 'Cannot target yourself' };
+
+    const costEntry = SEND_ENEMY_COSTS.find(c => c.enemyType === enemyType);
+    if (!costEntry) return { success: false, error: 'Invalid enemy type' };
+
+    if (sender.sendPoints < costEntry.cost) {
+      return { success: false, error: 'Not enough send points' };
+    }
+
+    // Deduct cost
+    sender.sendPoints -= costEntry.cost;
+
+    // Spawn enemies on target's board
+    const enemyDef = ENEMY_DEFS[enemyType];
+    const spawnPos = target.gameState.map.spawnPoints[0];
+
+    for (let i = 0; i < costEntry.count; i++) {
+      const enemy: Enemy = {
+        id: `sent_${Date.now()}_${i}_${Math.random().toString(36).slice(2, 6)}`,
+        type: enemyType,
+        hp: Math.round(enemyDef.hp * costEntry.hpMultiplier),
+        maxHp: Math.round(enemyDef.hp * costEntry.hpMultiplier),
+        speed: enemyDef.speed,
+        armor: enemyDef.armor,
+        position: { ...spawnPos },
+        waypointIndex: 0,
+        progress: 0,
+        effects: [],
+        flying: enemyDef.flying,
+        dead: false,
+      };
+      target.gameState.enemies.push(enemy);
+    }
+
+    // Update stats
+    sender.totalSent += costEntry.count;
+    target.totalReceived += costEntry.count;
+
+    // Broadcast to all
+    this.callbacks.onBroadcast(room.code, {
+      type: 'td_enemy_sent',
+      fromPlayerId: playerId,
+      toPlayerId: targetPlayerId,
+      enemyType,
+      count: costEntry.count,
+    });
+
+    // Send warning to target
+    this.callbacks.onSendToPlayer(targetPlayerId, {
+      type: 'td_enemies_incoming',
+      fromPlayerName: sender.playerName,
+      enemyType,
+      count: costEntry.count,
+    });
+
+    return { success: true };
+  }
+
+  selectTarget(playerId: string, targetPlayerId: string): void {
+    const room = this.getPlayerRoom(playerId);
+    if (!room || room.status !== 'playing') return;
+
+    const player = room.players.find(p => p.playerId === playerId);
+    if (!player || player.eliminated) return;
+
+    const target = room.players.find(p => p.playerId === targetPlayerId && !p.eliminated);
+    if (!target || targetPlayerId === playerId) return;
+
+    player.defaultTarget = targetPlayerId;
+  }
+
+  // ===== Tick Loop =====
+
+  private startTickLoop(roomCode: string): void {
+    const tickInterval = 1000 / TD_TICK_RATE;
+
+    const interval = setInterval(() => {
+      const room = this.rooms.get(roomCode);
+      if (!room || room.status !== 'playing') {
+        this.stopTickLoop(roomCode);
+        return;
+      }
+
+      this.tickRoom(room);
+    }, tickInterval);
+
+    this.tickIntervals.set(roomCode, interval);
+  }
+
+  private stopTickLoop(roomCode: string): void {
+    const interval = this.tickIntervals.get(roomCode);
+    if (interval) {
+      clearInterval(interval);
+      this.tickIntervals.delete(roomCode);
+    }
+  }
+
+  private tickRoom(room: TDMPRoom): void {
+    const dt = 1 / TD_TICK_RATE;
+    let allWavesDone = true;
+
+    for (const player of room.players) {
+      if (player.eliminated) continue;
+
+      // Count kills before update
+      const prevKills = this.getTotalKills(player.gameState);
+
+      // Run game engine update
+      player.gameState = updateGame(player.gameState, dt);
+
+      // Count kills after update
+      const newKills = this.getTotalKills(player.gameState);
+      const killDelta = newKills - prevKills;
+
+      // Award sendPoints for kills
+      if (killDelta > 0) {
+        // We approximate by using the per-enemy-type points
+        // Since we can't easily track which enemies died, award a flat per-kill bonus
+        // based on the enemy composition
+        const prevCount = room.prevKillCounts.get(player.playerId) || 0;
+        const currentTowerKills = player.gameState.towers.reduce((sum, t) => sum + t.kills, 0);
+        const delta = currentTowerKills - prevCount;
+        if (delta > 0) {
+          // Award average sendPoints (roughly 1.5 per kill as a compromise)
+          player.sendPoints += delta * 2;
+          room.prevKillCounts.set(player.playerId, currentTowerKills);
+        }
+      }
+
+      // Check if player lost
+      if (player.gameState.phase === 'lost' && !player.eliminated) {
+        this.eliminatePlayer(room, player.playerId);
+      }
+
+      // Check if player's wave is still active
+      if (player.gameState.phase === 'wave') {
+        allWavesDone = false;
+      }
+    }
+
+    // If all living players finished the wave, transition to build phase
+    if (room.waveActive && allWavesDone) {
+      const alivePlayers = room.players.filter(p => !p.eliminated);
+      const allInBuild = alivePlayers.every(
+        p => p.gameState.phase === 'build' || p.gameState.phase === 'won'
+      );
+
+      if (allInBuild) {
+        room.waveActive = false;
+        room.waveBuildTimer = WAVE_PREP_TIME;
+
+        const waveDef = WAVES[room.currentWave - 1];
+        const reward = waveDef?.reward ?? 0;
+
+        this.callbacks.onBroadcast(room.code, {
+          type: 'td_wave_complete',
+          waveNumber: room.currentWave,
+          reward,
+        });
+
+        // Check if all waves done
+        if (room.currentWave >= TOTAL_WAVES) {
+          this.endGame(room);
+          return;
+        }
+      }
+    }
+
+    // Build phase countdown for auto-wave start
+    if (!room.waveActive && room.currentWave < TOTAL_WAVES) {
+      room.waveBuildTimer -= dt;
+      if (room.waveBuildTimer <= 0) {
+        this.triggerWave(room);
+      }
+    }
+
+    // Check win condition
+    const alivePlayers = room.players.filter(p => !p.eliminated);
+    if (alivePlayers.length <= 1 && room.players.length >= TD_MIN_PLAYERS) {
+      this.endGame(room);
+      return;
+    }
+
+    // Broadcast state update every 3 ticks (~150ms) to reduce bandwidth
+    const elapsed = room.gameStartedAt ? Date.now() - room.gameStartedAt : 0;
+    const tickCount = Math.floor(elapsed / (1000 / TD_TICK_RATE));
+    if (tickCount % 3 === 0) {
+      this.broadcastStateUpdate(room);
+    }
+  }
+
+  private getTotalKills(state: GameState): number {
+    return state.towers.reduce((sum, t) => sum + t.kills, 0);
+  }
+
+  private broadcastStateUpdate(room: TDMPRoom): void {
+    const playerStates = room.players
+      .filter(p => !p.eliminated)
+      .map(p => ({
+        playerId: p.playerId,
+        towers: p.gameState.towers,
+        enemies: p.gameState.enemies,
+        projectiles: p.gameState.projectiles,
+        gold: p.gameState.gold,
+        lives: p.gameState.lives,
+        score: p.gameState.score,
+        sendPoints: p.sendPoints,
+        phase: p.gameState.phase,
+      }));
+
+    this.callbacks.onBroadcast(room.code, {
+      type: 'td_state_update',
+      playerStates,
+    });
+  }
+
+  // ===== Elimination =====
+
+  private eliminatePlayer(room: TDMPRoom, playerId: string): void {
+    const player = room.players.find(p => p.playerId === playerId);
+    if (!player || player.eliminated) return;
+
+    player.eliminated = true;
+    player.eliminatedAt = Date.now();
+
+    const aliveCount = room.players.filter(p => !p.eliminated).length;
+    const rank = aliveCount + 1;
+
+    this.callbacks.onBroadcast(room.code, {
+      type: 'td_player_eliminated',
+      playerId,
+      rank,
+    });
+  }
+
+  // ===== Game End =====
+
+  private endGame(room: TDMPRoom): void {
+    room.status = 'ended';
+    this.stopTickLoop(room.code);
+
+    const alivePlayers = room.players.filter(p => !p.eliminated);
+
+    // Determine winner: last standing or highest score
+    let winnerId: string | null = null;
+    if (alivePlayers.length === 1) {
+      winnerId = alivePlayers[0].playerId;
+    } else if (alivePlayers.length > 1) {
+      alivePlayers.sort((a, b) => b.gameState.score - a.gameState.score);
+      winnerId = alivePlayers[0].playerId;
+    }
+
+    room.winner = winnerId;
+
+    // Build rankings
+    const rankings: Array<{ playerId: string; rank: number; score: number }> = [];
+
+    // Alive players ranked by score
+    const sortedAlive = [...alivePlayers].sort((a, b) => b.gameState.score - a.gameState.score);
+    sortedAlive.forEach((p, i) => {
+      rankings.push({ playerId: p.playerId, rank: i + 1, score: p.gameState.score });
+    });
+
+    // Eliminated players ranked by elimination time (later = better)
+    const eliminated = room.players
+      .filter(p => p.eliminated)
+      .sort((a, b) => (b.eliminatedAt || 0) - (a.eliminatedAt || 0));
+
+    eliminated.forEach((p, i) => {
+      rankings.push({
+        playerId: p.playerId,
+        rank: sortedAlive.length + i + 1,
+        score: p.gameState.score,
+      });
+    });
+
+    this.callbacks.onBroadcast(room.code, {
+      type: 'td_game_over',
+      winnerId: winnerId || '',
+      rankings,
+    });
+
+    this.callbacks.onSessionEnd(room.code);
+  }
+
+  // ===== Queries =====
+
+  getRoom(roomCode: string): TDMultiplayerRoom | null {
+    const normalized = roomCode.toUpperCase().trim();
+    const room = this.rooms.get(normalized);
+    if (!room) return null;
+
+    return {
+      code: room.code,
+      name: room.name,
+      hostId: room.hostId,
+      players: room.players.map(p => this.toPlayerState(p)),
+      status: room.status,
+      maxPlayers: room.maxPlayers,
+      mapIndex: room.mapIndex,
+      currentWave: room.currentWave,
+      waveActive: room.waveActive,
+      winner: room.winner,
+    };
+  }
+
+  getPlayerIdsInRoom(roomCode: string): string[] {
+    const normalized = roomCode.toUpperCase().trim();
+    const room = this.rooms.get(normalized);
+    if (!room) return [];
+    return room.players.filter(p => p.connected).map(p => p.playerId);
+  }
+
+  getRoomByPlayerId(playerId: string): TDMPRoom | null {
+    const code = this.playerToRoom.get(playerId);
+    if (!code) return null;
+    return this.rooms.get(code) || null;
+  }
+
+  getRoomCount(): number {
+    return this.rooms.size;
+  }
+
+  // ===== Utilities =====
+
+  private getPlayerRoom(playerId: string): TDMPRoom | null {
+    const code = this.playerToRoom.get(playerId);
+    if (!code) return null;
+    return this.rooms.get(code) || null;
+  }
+
+  private toPlayerState(player: TDMPPlayer): TDPlayerState {
+    return {
+      playerId: player.playerId,
+      playerName: player.playerName,
+      gameState: player.gameState,
+      ready: player.ready,
+      connected: player.connected,
+      sendPoints: player.sendPoints,
+      totalSent: player.totalSent,
+      totalReceived: player.totalReceived,
+      eliminated: player.eliminated,
+      eliminatedAt: player.eliminatedAt,
+    };
+  }
+
+  private generateRoomCode(): string {
+    const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+    let code: string;
+    let attempts = 0;
+    do {
+      code = 'T'; // Prefix T for tower defense rooms
+      const len = attempts > 100 ? 5 : 4;
+      for (let i = 1; i < len; i++) {
+        code += chars.charAt(Math.floor(Math.random() * chars.length));
+      }
+      attempts++;
+    } while (this.rooms.has(code));
+    return code;
+  }
+
+  private cleanupStaleRooms(): void {
+    const now = Date.now();
+    const toDelete: string[] = [];
+
+    this.rooms.forEach((room, code) => {
+      const connected = room.players.filter(p => p.connected);
+      if (connected.length === 0 && now - room.createdAt > ROOM_TIMEOUT) {
+        toDelete.push(code);
+      }
+      if (room.status === 'ended' && now - (room.gameStartedAt || room.createdAt) > ROOM_TIMEOUT) {
+        toDelete.push(code);
+      }
+    });
+
+    toDelete.forEach(code => {
+      this.stopTickLoop(code);
+      const room = this.rooms.get(code);
+      if (room) {
+        room.players.forEach(p => this.playerToRoom.delete(p.playerId));
+      }
+      this.rooms.delete(code);
+      console.log(`[TD CLEANUP] Removed stale TD room ${code}`);
+    });
+  }
+
+  destroy(): void {
+    clearInterval(this.cleanupInterval);
+    this.tickIntervals.forEach(interval => clearInterval(interval));
+    this.tickIntervals.clear();
+  }
+}

--- a/src/types/multiplayer.ts
+++ b/src/types/multiplayer.ts
@@ -98,8 +98,223 @@ import type { ArenaClientMessage, ArenaServerMessage } from './arena';
 import type { MCClientMessage, MCServerMessage as MCBoardServerMessage } from './minecraft-board';
 import type { EoEClientMessage } from './echoes';
 import type { MWClientMessage } from './minecraft-world';
+import type { TDPlayerState, TDMultiplayerRoom, EnemyType, TowerType, Tower, Enemy, Projectile, GamePhase } from './tower-defense';
 
 export type { ArenaClientMessage, ArenaServerMessage, MCClientMessage, MCBoardServerMessage, MWClientMessage };
+
+// ===== Tower Defense Multiplayer Messages =====
+
+// --- Client → Server ---
+
+export interface TDCreateRoomMessage {
+  type: 'td_create_room';
+  playerName: string;
+  mapIndex?: number;
+}
+
+export interface TDJoinRoomMessage {
+  type: 'td_join_room';
+  roomCode: string;
+  playerName: string;
+}
+
+export interface TDLeaveRoomMessage {
+  type: 'td_leave_room';
+}
+
+export interface TDSetReadyMessage {
+  type: 'td_set_ready';
+  ready: boolean;
+}
+
+export interface TDStartGameMessage {
+  type: 'td_start_game';
+}
+
+export interface TDPlaceTowerMessage {
+  type: 'td_place_tower';
+  towerType: TowerType;
+  gridX: number;
+  gridZ: number;
+}
+
+export interface TDSellTowerMessage {
+  type: 'td_sell_tower';
+  towerId: string;
+}
+
+export interface TDUpgradeTowerMessage {
+  type: 'td_upgrade_tower';
+  towerId: string;
+}
+
+export interface TDStartWaveMessage {
+  type: 'td_start_wave';
+}
+
+export interface TDSendEnemyMessage {
+  type: 'td_send_enemy';
+  targetPlayerId: string;
+  enemyType: EnemyType;
+}
+
+export interface TDSelectTargetMessage {
+  type: 'td_select_target';
+  targetPlayerId: string;
+}
+
+export type TDClientMessage =
+  | TDCreateRoomMessage
+  | TDJoinRoomMessage
+  | TDLeaveRoomMessage
+  | TDSetReadyMessage
+  | TDStartGameMessage
+  | TDPlaceTowerMessage
+  | TDSellTowerMessage
+  | TDUpgradeTowerMessage
+  | TDStartWaveMessage
+  | TDSendEnemyMessage
+  | TDSelectTargetMessage;
+
+// --- Server → Client ---
+
+export interface TDRoomCreatedMessage {
+  type: 'td_room_created';
+  roomCode: string;
+  playerId: string;
+}
+
+export interface TDRoomJoinedMessage {
+  type: 'td_room_joined';
+  roomCode: string;
+  room: TDMultiplayerRoom;
+}
+
+export interface TDRoomStateMessage {
+  type: 'td_room_state';
+  room: TDMultiplayerRoom;
+}
+
+export interface TDPlayerJoinedMessage {
+  type: 'td_player_joined';
+  player: TDPlayerState;
+}
+
+export interface TDPlayerLeftMessage {
+  type: 'td_player_left';
+  playerId: string;
+}
+
+export interface TDPlayerReadyMessage {
+  type: 'td_player_ready';
+  playerId: string;
+  ready: boolean;
+}
+
+export interface TDCountdownMessage {
+  type: 'td_countdown';
+  seconds: number;
+}
+
+export interface TDGameStartedMessage {
+  type: 'td_game_started';
+  mapIndex: number;
+  wave: number;
+}
+
+export interface TDStateUpdatePlayer {
+  playerId: string;
+  towers: Tower[];
+  enemies: Enemy[];
+  projectiles: Projectile[];
+  gold: number;
+  lives: number;
+  score: number;
+  sendPoints: number;
+  phase: GamePhase;
+}
+
+export interface TDStateUpdateMessage {
+  type: 'td_state_update';
+  playerStates: TDStateUpdatePlayer[];
+}
+
+export interface TDTowerPlacedMessage {
+  type: 'td_tower_placed';
+  playerId: string;
+  tower: Tower;
+}
+
+export interface TDTowerSoldMessage {
+  type: 'td_tower_sold';
+  playerId: string;
+  towerId: string;
+}
+
+export interface TDTowerUpgradedMessage {
+  type: 'td_tower_upgraded';
+  playerId: string;
+  towerId: string;
+  level: number;
+}
+
+export interface TDWaveStartedMessage {
+  type: 'td_wave_started';
+  waveNumber: number;
+}
+
+export interface TDWaveCompleteMessage {
+  type: 'td_wave_complete';
+  waveNumber: number;
+  reward: number;
+}
+
+export interface TDEnemySentMessage {
+  type: 'td_enemy_sent';
+  fromPlayerId: string;
+  toPlayerId: string;
+  enemyType: EnemyType;
+  count: number;
+}
+
+export interface TDEnemiesIncomingMessage {
+  type: 'td_enemies_incoming';
+  fromPlayerName: string;
+  enemyType: EnemyType;
+  count: number;
+}
+
+export interface TDPlayerEliminatedMessage {
+  type: 'td_player_eliminated';
+  playerId: string;
+  rank: number;
+}
+
+export interface TDGameOverMessage {
+  type: 'td_game_over';
+  winnerId: string;
+  rankings: Array<{ playerId: string; rank: number; score: number }>;
+}
+
+export type TDServerMessage =
+  | TDRoomCreatedMessage
+  | TDRoomJoinedMessage
+  | TDRoomStateMessage
+  | TDPlayerJoinedMessage
+  | TDPlayerLeftMessage
+  | TDPlayerReadyMessage
+  | TDCountdownMessage
+  | TDGameStartedMessage
+  | TDStateUpdateMessage
+  | TDTowerPlacedMessage
+  | TDTowerSoldMessage
+  | TDTowerUpgradedMessage
+  | TDWaveStartedMessage
+  | TDWaveCompleteMessage
+  | TDEnemySentMessage
+  | TDEnemiesIncomingMessage
+  | TDPlayerEliminatedMessage
+  | TDGameOverMessage;
 
 export type ClientMessage =
   | CreateRoomMessage
@@ -118,6 +333,7 @@ export type ClientMessage =
   | MCClientMessage
   | MWClientMessage
   | EoEClientMessage
+  | TDClientMessage
   | SetProfileMessage
   | GetOnlineUsersMessage;
 
@@ -280,7 +496,8 @@ export type ServerMessage =
   | RankedMatchFoundMessage
   | RankedQueuedMessage
   | ArenaServerMessage
-  | MCBoardServerMessage;
+  | MCBoardServerMessage
+  | TDServerMessage;
 
 // ===== Relay Payload Types =====
 // These are game-specific messages relayed between players

--- a/src/types/tower-defense.ts
+++ b/src/types/tower-defense.ts
@@ -137,6 +137,19 @@ export interface Wave {
 // === Game State ===
 export type GamePhase = 'menu' | 'build' | 'wave' | 'paused' | 'won' | 'lost';
 
+export interface SpawnTrackerGroup {
+  group: WaveGroup;
+  spawned: number;
+  nextSpawn: number;
+  startTimer: number;
+  done: boolean;
+}
+
+export interface SpawnTracker {
+  groups: SpawnTrackerGroup[];
+  allDone: boolean;
+}
+
 export interface GameState {
   phase: GamePhase;
   gold: number;
@@ -156,6 +169,7 @@ export interface GameState {
   enemiesRemaining: number;
   autoStart: boolean;
   gameSpeed: number;
+  spawnTracker?: SpawnTracker | null;
 }
 
 // === Constants ===
@@ -377,3 +391,66 @@ export const INITIAL_GOLD = 500;
 export const INITIAL_LIVES = 20;
 export const WAVE_PREP_TIME = 15; // seconds between waves
 export const TOTAL_WAVES = 30;
+
+// ===== Multiplayer Types =====
+
+/** Per-player state in a multiplayer TD game */
+export interface TDPlayerState {
+  playerId: string;
+  playerName: string;
+  gameState: GameState;
+  ready: boolean;
+  connected: boolean;
+  sendPoints: number;
+  totalSent: number;
+  totalReceived: number;
+  eliminated: boolean;
+  eliminatedAt: number | null;
+}
+
+/** Cost table for sending enemies to opponents */
+export interface SendEnemyCost {
+  enemyType: EnemyType;
+  cost: number;
+  count: number;
+  hpMultiplier: number;
+}
+
+/** Multiplayer room state */
+export interface TDMultiplayerRoom {
+  code: string;
+  name: string;
+  hostId: string;
+  players: TDPlayerState[];
+  status: 'waiting' | 'countdown' | 'playing' | 'ended';
+  maxPlayers: number;
+  mapIndex: number;
+  currentWave: number;
+  waveActive: boolean;
+  winner: string | null;
+}
+
+/** Send enemy action */
+export interface SendEnemyAction {
+  fromPlayerId: string;
+  toPlayerId: string;
+  enemyType: EnemyType;
+  count: number;
+  hpMultiplier: number;
+}
+
+export const SEND_ENEMY_COSTS: SendEnemyCost[] = [
+  { enemyType: 'grunt', cost: 5, count: 3, hpMultiplier: 1.0 },
+  { enemyType: 'fast', cost: 4, count: 4, hpMultiplier: 1.0 },
+  { enemyType: 'tank', cost: 15, count: 1, hpMultiplier: 1.2 },
+  { enemyType: 'flying', cost: 8, count: 2, hpMultiplier: 1.0 },
+  { enemyType: 'healer', cost: 12, count: 2, hpMultiplier: 1.0 },
+  { enemyType: 'swarm', cost: 3, count: 8, hpMultiplier: 0.8 },
+  { enemyType: 'shield', cost: 18, count: 1, hpMultiplier: 1.0 },
+  { enemyType: 'boss', cost: 50, count: 1, hpMultiplier: 0.6 },
+];
+
+export const SEND_POINTS_PER_KILL: Record<EnemyType, number> = {
+  grunt: 1, fast: 1, tank: 3, flying: 2,
+  healer: 2, boss: 10, swarm: 1, shield: 3,
+};


### PR DESCRIPTION
Players compete on independent boards, earning Send Points from kills to spawn enemies on opponents' maps. Last player standing wins.

Backend:
- TDMultiplayerManager with 20Hz server-authoritative tick loop, per-player GameState, wave sync, elimination tracking
- 28 new td_ WebSocket message types for full room lifecycle
- Server integration with message routing and broadcast helpers
- Refactored engine spawn tracking for per-player state support

Frontend:
- useTDMultiplayerSocket hook with reconnect and ping/pong keepalive
- TowerDefenseMultiplayer component with lobby, waiting room, countdown, game view, and end screen phases
- TDSendEnemyPanel: target selector + enemy send grid with costs
- TDOpponentBar: live opponent status with target selection
- TDIncomingAlert: toast notifications for incoming enemies
- Solo/Multiplayer mode selector on tower-defense page