### PR TITLE
Migrate ESLint to flat config, clean up debug logs and stale files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": [
-    "next/core-web-vitals",
-    "next/typescript"
-  ]
-}

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ next-env.d.ts
 /public/sitemap.xml
 /public/sitemap-*.xml
 
+# daily workflow docs (local session aids)
+DAILY-SESSION-GUIDE.md
+DAILY-WORKFLOW.md
+
 # claude-worker
 claude-worker.ps1
 claude-launcher.ps1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-**azuretier.net** (package name: `azuret.net`) is a full-stack gaming platform built with Next.js 16 and TypeScript. It features multiplayer rhythm/battle games (Rhythmia) with ranked matchmaking, a 9-player arena mode, a Minecraft-style board game, an advancements (achievements) system, loyalty rewards, profile customization with skin theming, interactive stories, a wiki, and WebGL/Three.js visual effects. The site is internationalized with next-intl, supporting Japanese (default), English, Thai, Spanish, and French locales.
+**azuretier.net** (package name: `azuret.net`) is a full-stack gaming platform built with Next.js 16 and TypeScript. It is designed as an open, personalizable space — every player can customize their profile, skin, and theme to make the experience their own, and the platform is built to be publicly shareable so players can feature and showcase it. It features multiplayer rhythm/battle games (Rhythmia) with ranked matchmaking, a 9-player arena mode, a Minecraft-style board game, an advancements (achievements) system, loyalty rewards, profile customization with skin theming, interactive stories, a wiki, and WebGL/Three.js visual effects. The site is internationalized with next-intl, supporting Japanese (default), English, Thai, Spanish, and French locales.
 
 ## Tech Stack
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { defineConfig, globalIgnores } from 'eslint/config'
+import nextVitals from 'eslint-config-next/core-web-vitals'
+import nextTs from 'eslint-config-next/typescript'
+
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  globalIgnores([
+    '.next/**',
+    'out/**',
+    'build/**',
+    'next-env.d.ts',
+  ]),
+])
+
+export default eslintConfig

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -36,7 +36,6 @@ const nextConfig = {
       }
     ];
   },
-  turbopack: {},
   webpack(config, { isServer }) {
     config.module.rules.push({
       test: /\.(glsl|vs|fs|vert|frag)$/,

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "@types/react-dom": "^18",
         "@types/three": "^0.179.0",
         "eslint": "^9.39.1",
-        "eslint-config-next": "16.0.8",
+        "eslint-config-next": "^16.1.6",
         "postcss": "^8",
         "raw-loader": "^4.0.2",
         "tailwindcss": "^3.4.1",
@@ -2604,9 +2604,9 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.0.8",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.0.8.tgz",
-      "integrity": "sha512-1miV0qXDcLUaOdHridVPCh4i39ElRIAraseVIbb3BEqyZ5ol9sPyjTP/GNTPV5rBxqxjF6/vv5zQTVbhiNaLqA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.6.tgz",
+      "integrity": "sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8425,13 +8425,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.0.8",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.0.8.tgz",
-      "integrity": "sha512-8J5cOAboXIV3f8OD6BOyj7Fik6n/as7J4MboiUSExWruf/lCu1OPR3ZVSdnta6WhzebrmAATEmNSBZsLWA6kbg==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.6.tgz",
+      "integrity": "sha512-vKq40io2B0XtkkNDYyleATwblNt8xuh3FWp8SpSz3pt7P01OkBFlKsJZ2mWt5WsCySlDQLckb1zMY9yE9Qy0LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.0.8",
+        "@next/eslint-plugin-next": "16.1.6",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "azuret.net",
   "version": "0.1.0",
+  "description": "An open, personalizable gaming platform where every player can customize their experience and publicly feature and showcase the platform as their own.",
   "private": true,
   "scripts": {
     "dev": "ts-node --project tsconfig.server.json server.ts",
     "build": "next build",
     "postbuild": "next-sitemap",
     "start": "ts-node --project tsconfig.server.json server.ts",
-    "lint": "next lint",
+    "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
     "multiplayer": "ts-node --project tsconfig.server.json multiplayer-server.ts"
@@ -88,7 +89,7 @@
     "@types/react-dom": "^18",
     "@types/three": "^0.179.0",
     "eslint": "^9.39.1",
-    "eslint-config-next": "16.0.8",
+    "eslint-config-next": "^16.1.6",
     "postcss": "^8",
     "raw-loader": "^4.0.2",
     "tailwindcss": "^3.4.1",

--- a/src/lib/arena/ArenaManager.ts
+++ b/src/lib/arena/ArenaManager.ts
@@ -900,7 +900,6 @@ export class ArenaRoomManager {
         room.players.forEach(p => this.playerToRoom.delete(p.id));
       }
       this.rooms.delete(code);
-      console.log(`[ARENA CLEANUP] Removed stale arena ${code}`);
     });
   }
 

--- a/src/lib/minecraft-switch/MinecraftSwitchManager.ts
+++ b/src/lib/minecraft-switch/MinecraftSwitchManager.ts
@@ -368,7 +368,6 @@ export class MinecraftSwitchManager {
       this.gameTick(roomCode);
     }, TICK_INTERVAL);
 
-    console.log(`[MCS] Game loop started for room ${roomCode} at ${MS_CONFIG.TICK_RATE} tps`);
   }
 
   private stopGameLoop(roomCode: string): void {
@@ -377,7 +376,6 @@ export class MinecraftSwitchManager {
 
     clearInterval(room.gameLoopInterval);
     room.gameLoopInterval = null;
-    console.log(`[MCS] Game loop stopped for room ${roomCode}`);
   }
 
   private gameTick(roomCode: string): void {
@@ -1245,7 +1243,6 @@ export class MinecraftSwitchManager {
           this.playerToRoom.delete(p.id);
         }
         this.rooms.delete(code);
-        console.log(`[MCS] Cleaned up stale room ${code}`);
       }
     }
   }

--- a/src/lib/minecraft-world/MinecraftWorldManager.ts
+++ b/src/lib/minecraft-world/MinecraftWorldManager.ts
@@ -431,7 +431,6 @@ export class MinecraftWorldManager {
           this.playerToRoom.delete(p.id);
         }
         this.rooms.delete(code);
-        console.log(`[MW] Cleaned up stale room ${code}`);
       }
     }
   }

--- a/src/lib/multiplayer/RoomManager.ts
+++ b/src/lib/multiplayer/RoomManager.ts
@@ -45,7 +45,6 @@ export class MultiplayerRoomManager {
         room.players.forEach(p => this.playerToRoom.delete(p.id));
       }
       this.rooms.delete(code);
-      console.log(`[CLEANUP] Removed stale room ${code}`);
     });
   }
 

--- a/src/lib/tower-defense/TDMultiplayerManager.ts
+++ b/src/lib/tower-defense/TDMultiplayerManager.ts
@@ -831,7 +831,6 @@ export class TDMultiplayerManager {
         room.players.forEach(p => this.playerToRoom.delete(p.playerId));
       }
       this.rooms.delete(code);
-      console.log(`[TD CLEANUP] Removed stale TD room ${code}`);
     });
   }
 


### PR DESCRIPTION
## Summary
- **ESLint migration**: Migrated from `next lint` (removed in Next.js 16) to ESLint flat config (`eslint.config.mjs`), updated `eslint-config-next` to latest, changed lint script to `eslint .`
- **Debug log cleanup**: Removed 7 leftover `console.log` calls from 5 server manager files (ArenaManager, RoomManager, MinecraftWorldManager, TDMultiplayerManager, MinecraftSwitchManager)
- **Project description**: Added personalization and public showcase philosophy to CLAUDE.md and package.json — the platform is designed as an open, personalizable space where every player can customize and feature it as their own
- **Housekeeping**: Gitignored daily workflow docs, fixed duplicate `turbopack` key in next.config.mjs, closed PR #433 (stale, conflicting)

## Test plan
- [x] `npm run lint` runs successfully (was broken before, now works)
- [x] No functional code changes — only removed debug logs and config migration
- [ ] Verify `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)