### PR TITLE
Integrate rich TD mechanics into Rhythmia's Galaxy ring

### DIFF
--- a/src/components/rhythmia/tetris/components/GalaxyBoard.tsx
+++ b/src/components/rhythmia/tetris/components/GalaxyBoard.tsx
@@ -121,7 +121,7 @@ export const GalaxyBoard = React.memo(function GalaxyBoard({
         />
     );
 
-    if (!galaxyActive || waveNumber <= 0) {
+    if (waveNumber <= 0) {
         return boardElement;
     }
 

--- a/src/components/rhythmia/tetris/components/GalaxyBoard.tsx
+++ b/src/components/rhythmia/tetris/components/GalaxyBoard.tsx
@@ -11,6 +11,8 @@ interface GalaxyBoardProps {
     // Galaxy TD state
     galaxyActive: boolean;
     waveNumber: number;
+    gold?: number;
+    lives?: number;
 
     // Board props (pass-through)
     board: BoardType;
@@ -53,6 +55,8 @@ interface GalaxyBoardProps {
 export const GalaxyBoard = React.memo(function GalaxyBoard({
     galaxyActive,
     waveNumber,
+    gold,
+    lives,
     board,
     currentPiece,
     boardBeat,
@@ -123,7 +127,11 @@ export const GalaxyBoard = React.memo(function GalaxyBoard({
 
     return (
         <div className={galaxyStyles.galaxyContainer}>
-            <div className={galaxyStyles.waveLabel}>WAVE {waveNumber}</div>
+            <div className={galaxyStyles.waveLabel}>
+                WAVE {waveNumber}
+                {gold !== undefined && <span>{' '}&middot; {gold}G</span>}
+                {lives !== undefined && <span>{' '}&middot; {lives}HP</span>}
+            </div>
             {boardElement}
         </div>
     );

--- a/src/components/rhythmia/tetris/components/GalaxyRing3D.tsx
+++ b/src/components/rhythmia/tetris/components/GalaxyRing3D.tsx
@@ -3,8 +3,13 @@
 import React, { useRef, useMemo, useEffect, useCallback } from 'react';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
-import type { TowerType, EnemyType, RingEnemy, RingTower, RingProjectile, TowerSlot, GalaxyGate, StatusEffect } from '../galaxy-types';
-import { ENEMY_DEFS } from '@/types/tower-defense';
+import type { TowerType, EnemyType, RingEnemy, RingTower, RingProjectile, TowerSlot, GalaxyGate } from '../galaxy-types';
+import { TOWER_DEFS, ENEMY_DEFS } from '@/types/tower-defense';
+import { createMobMesh, animateMob, disposeMobGroup, disposeSharedMobResources } from '../minecraft-mobs';
+import type { MobMeshData } from '../minecraft-mobs';
+import type { TDEnemyType } from '../types';
+import { createProjectileMesh, animateProjectile, disposeProjectileGroup, disposeSharedProjectileResources } from '@/components/tower-defense/td-projectiles';
+import type { ProjectileMeshData } from '@/components/tower-defense/td-projectiles';
 import {
     GALAXY_RING_DEPTH,
     GALAXY_TOP_WIDTH,
@@ -15,6 +20,42 @@ import {
     GALAXY_TOWERS_PER_SIDE_LR,
     GALAXY_GATE_POSITIONS,
 } from '../galaxy-constants';
+
+// ===== Tower-to-Minecraft-Mob mapping (same as TD page) =====
+const TOWER_MOB_MAP: Record<TowerType, TDEnemyType> = {
+    archer: 'skeleton',
+    cannon: 'magma_cube',
+    frost: 'slime',
+    lightning: 'enderman',
+    sniper: 'skeleton',
+    flame: 'zombie',
+    arcane: 'enderman',
+};
+
+// ===== Enemy-to-Animal-Mob mapping (same as TD page) =====
+const ENEMY_MOB_MAP: Record<EnemyType, TDEnemyType> = {
+    grunt: 'pig',
+    fast: 'chicken',
+    tank: 'cow',
+    flying: 'bee',
+    healer: 'cat',
+    boss: 'horse',
+    swarm: 'rabbit',
+    shield: 'wolf',
+};
+
+const ENEMY_MOB_SCALE: Record<EnemyType, number> = {
+    grunt: 0.28,
+    fast: 0.25,
+    tank: 0.32,
+    flying: 0.28,
+    healer: 0.28,
+    boss: 0.42,
+    swarm: 0.18,
+    shield: 0.32,
+};
+
+const TOWER_MOB_SCALE = 0.25;
 
 // ===== Grid dimensions =====
 const GRID_W = GALAXY_TOP_WIDTH;               // 16
@@ -27,35 +68,22 @@ const DEPTH = GALAXY_RING_DEPTH;                 // 3
 const CELL = 0.32;
 const CELL_GAP = 0.02;
 const BLOCK_H = 0.18;
-const ENEMY_SIZE = 0.28;
-const TOWER_SIZE = 0.22;
 const LERP_SPEED = 8;
 const SLOT_SIZE = 0.18;
 
 const ORIGIN_X = -(GRID_W - 1) * CELL * 0.5;
 const ORIGIN_Z = -(GRID_H - 1) * CELL * 0.5;
 
-// ===== Tower type colors =====
-const TOWER_TYPE_COLORS: Record<TowerType, { main: THREE.Color; accent: THREE.Color; glow: THREE.Color }> = {
-    archer:    { main: new THREE.Color('#4ade80'), accent: new THREE.Color('#22c55e'), glow: new THREE.Color('#66ff99') },
-    cannon:    { main: new THREE.Color('#f97316'), accent: new THREE.Color('#ea580c'), glow: new THREE.Color('#ff9944') },
-    frost:     { main: new THREE.Color('#38bdf8'), accent: new THREE.Color('#0ea5e9'), glow: new THREE.Color('#66ddff') },
-    lightning: { main: new THREE.Color('#a78bfa'), accent: new THREE.Color('#8b5cf6'), glow: new THREE.Color('#bb99ff') },
-    sniper:    { main: new THREE.Color('#f43f5e'), accent: new THREE.Color('#e11d48'), glow: new THREE.Color('#ff6688') },
-    flame:     { main: new THREE.Color('#ef4444'), accent: new THREE.Color('#dc2626'), glow: new THREE.Color('#ff6644') },
-    arcane:    { main: new THREE.Color('#c084fc'), accent: new THREE.Color('#a855f7'), glow: new THREE.Color('#dd99ff') },
+// ===== Tower type colors (for platforms and auras) =====
+const TOWER_TYPE_COLORS: Record<TowerType, { main: string; accent: string; glow: string }> = {
+    archer:    { main: '#4ade80', accent: '#22c55e', glow: '#66ff99' },
+    cannon:    { main: '#f97316', accent: '#ea580c', glow: '#ff9944' },
+    frost:     { main: '#38bdf8', accent: '#0ea5e9', glow: '#66ddff' },
+    lightning: { main: '#a78bfa', accent: '#8b5cf6', glow: '#bb99ff' },
+    sniper:    { main: '#f43f5e', accent: '#e11d48', glow: '#ff6688' },
+    flame:     { main: '#ef4444', accent: '#dc2626', glow: '#ff6644' },
+    arcane:    { main: '#c084fc', accent: '#a855f7', glow: '#dd99ff' },
 };
-
-// ===== Enemy type colors =====
-function getEnemyColor(type: EnemyType): THREE.Color {
-    const def = ENEMY_DEFS[type];
-    return new THREE.Color(def.color);
-}
-
-function getEnemyScale(type: EnemyType): number {
-    const def = ENEMY_DEFS[type];
-    return def.scale / 0.4; // normalized to base grunt scale
-}
 
 // ===== Path/Terrain colors =====
 const PATH_COLORS = [new THREE.Color('#3a6a4a'), new THREE.Color('#4a7a5a'), new THREE.Color('#3a5a4a'), new THREE.Color('#4a7a5a')];
@@ -340,7 +368,7 @@ function TerrainDecorations() {
 }
 
 // ===== HP Number Sprite =====
-function HPNumberSprite({ health, maxHealth }: { health: number; maxHealth: number }) {
+function HPNumberSprite({ health, maxHealth, yOffset }: { health: number; maxHealth: number; yOffset: number }) {
     const texture = useMemo(() => {
         const canvas = document.createElement('canvas');
         canvas.width = 64; canvas.height = 24;
@@ -360,21 +388,21 @@ function HPNumberSprite({ health, maxHealth }: { health: number; maxHealth: numb
     }, [health, maxHealth]);
     useEffect(() => () => { texture.dispose(); }, [texture]);
     return (
-        <sprite position={[0, ENEMY_SIZE * 2.15, 0]} scale={[0.38, 0.14, 1]}>
+        <sprite position={[0, yOffset + 0.12, 0]} scale={[0.38, 0.14, 1]}>
             <spriteMaterial map={texture} transparent depthTest={false} />
         </sprite>
     );
 }
 
 // ===== Enemy HP Bar =====
-function EnemyHPBar({ health, maxHealth }: { health: number; maxHealth: number }) {
+function EnemyHPBar({ health, maxHealth, yOffset }: { health: number; maxHealth: number; yOffset: number }) {
     const ratio = Math.max(0, health / maxHealth);
-    const barW = ENEMY_SIZE * 1.3;
+    const barW = 0.32;
     const barH = 0.035;
     const barColor = ratio > 0.5 ? '#44dd66' : ratio > 0.25 ? '#ddaa33' : '#dd3333';
     return (
-        <group position={[0, ENEMY_SIZE * 1.85, 0]}>
-            <HPNumberSprite health={health} maxHealth={maxHealth} />
+        <group position={[0, yOffset, 0]}>
+            <HPNumberSprite health={health} maxHealth={maxHealth} yOffset={0} />
             <mesh>
                 <planeGeometry args={[barW, barH]} />
                 <meshBasicMaterial color="#111111" transparent opacity={0.7} side={THREE.DoubleSide} />
@@ -387,41 +415,111 @@ function EnemyHPBar({ health, maxHealth }: { health: number; maxHealth: number }
     );
 }
 
-// ===== Pixelated Enemy with type-specific visuals =====
-function PixelEnemy({ pathPosition, enemyType, id, health, maxHealth, effects }: {
+// ===== Mob Enemy (Minecraft animal models) =====
+function MobEnemy({ pathPosition, enemyType, id, health, maxHealth, effects, flying }: {
     pathPosition: number;
     enemyType: EnemyType;
     id: string;
     health: number;
     maxHealth: number;
-    effects: StatusEffect[];
+    effects: { type: string }[];
+    flying: boolean;
 }) {
     const groupRef = useRef<THREE.Group>(null);
+    const mobRef = useRef<MobMeshData | null>(null);
     const smoothRef = useRef({ x: 0, z: 0, angle: 0, init: false });
+    const prevPosRef = useRef({ x: 0, z: 0 });
+    const facingAngleRef = useRef(0);
     const idHash = useMemo(() => hashString(id), [id]);
-    const baseColor = useMemo(() => getEnemyColor(enemyType), [enemyType]);
-    const scale = useMemo(() => getEnemyScale(enemyType), [enemyType]);
+    const mobType = ENEMY_MOB_MAP[enemyType];
+    const mobScale = ENEMY_MOB_SCALE[enemyType];
 
-    // Status effect tints
     const isSlow = effects.some(e => e.type === 'slow');
-    const isBurn = effects.some(e => e.type === 'burn');
-    const isStun = effects.some(e => e.type === 'stun');
+    const isBurning = effects.some(e => e.type === 'burn');
+    const isAmplified = effects.some(e => e.type === 'amplify');
+    const isStunned = effects.some(e => e.type === 'stun');
 
-    const bodyColor = useMemo(() => {
-        const c = baseColor.clone();
-        if (isSlow) c.lerp(new THREE.Color('#4488ff'), 0.4);
-        if (isBurn) c.lerp(new THREE.Color('#ff4422'), 0.3);
-        if (isStun) c.lerp(new THREE.Color('#ffff44'), 0.5);
-        return c;
-    }, [baseColor, isSlow, isBurn, isStun]);
+    const mobData = useMemo(() => {
+        const data = createMobMesh(mobType);
+        data.group.scale.setScalar(mobScale);
+        return data;
+    }, [mobType, mobScale]);
+
+    useEffect(() => {
+        mobRef.current = mobData;
+        return () => {
+            disposeMobGroup(mobData);
+            mobRef.current = null;
+        };
+    }, [mobData]);
+
+    // Store original material emissive values
+    const origEmissives = useRef<Map<THREE.Material, { color: number; intensity: number }>>(new Map());
+
+    useEffect(() => {
+        if (mobData.isGltf) return;
+        const map = new Map<THREE.Material, { color: number; intensity: number }>();
+        mobData.group.traverse((child: THREE.Object3D) => {
+            if (child instanceof THREE.Mesh) {
+                const mat = child.material;
+                if (mat instanceof THREE.MeshStandardMaterial) {
+                    if (!map.has(mat)) {
+                        map.set(mat, { color: mat.emissive.getHex(), intensity: mat.emissiveIntensity });
+                    }
+                }
+            }
+        });
+        origEmissives.current = map;
+    }, [mobData]);
+
+    // Apply status effect visuals
+    useEffect(() => {
+        if (mobData.isGltf) return;
+        let meshIndex = 0;
+        mobData.group.traverse((child: THREE.Object3D) => {
+            if (child instanceof THREE.Mesh) {
+                const mat = child.material;
+                if (mat instanceof THREE.MeshStandardMaterial) {
+                    if (isBurning) {
+                        if (meshIndex % 3 === 0) {
+                            mat.emissive.set(0xff4400);
+                            mat.emissiveIntensity = 0.7;
+                        } else if (meshIndex % 3 === 1) {
+                            mat.emissive.set(0xff6600);
+                            mat.emissiveIntensity = 0.25;
+                        } else {
+                            mat.emissive.set(0x331100);
+                            mat.emissiveIntensity = 0.15;
+                        }
+                    } else if (isSlow) {
+                        mat.emissive.set(0x38bdf8);
+                        mat.emissiveIntensity = 0.3;
+                    } else {
+                        const orig = origEmissives.current.get(mat);
+                        if (orig) {
+                            mat.emissive.set(orig.color);
+                            mat.emissiveIntensity = orig.intensity;
+                        } else {
+                            mat.emissive.set(0x000000);
+                            mat.emissiveIntensity = 0;
+                        }
+                    }
+                }
+                meshIndex++;
+            }
+        });
+    }, [mobData, isBurning, isSlow]);
 
     useFrame(({ clock }, delta) => {
         if (!groupRef.current) return;
         const target = pathToWorld(pathPosition);
-        const bobY = BLOCK_H * 0.5 + Math.sin(clock.elapsedTime * 2 + idHash) * 0.04;
+        const bobY = flying
+            ? BLOCK_H * 0.5 + 0.3 + Math.sin(clock.elapsedTime * 2 + idHash) * 0.08
+            : BLOCK_H * 0.5 + Math.sin(clock.elapsedTime * 4 + idHash) * 0.02;
         const s = smoothRef.current;
         if (!s.init) {
             s.x = target.x; s.z = target.z; s.angle = target.angle; s.init = true;
+            prevPosRef.current = { x: target.x, z: target.z };
         } else {
             const t = 1 - Math.exp(-LERP_SPEED * delta);
             s.x += (target.x - s.x) * t; s.z += (target.z - s.z) * t;
@@ -431,54 +529,172 @@ function PixelEnemy({ pathPosition, enemyType, id, health, maxHealth, effects }:
             s.angle += ad * t;
         }
         groupRef.current.position.set(s.x, bobY, s.z);
-        groupRef.current.rotation.y = s.angle;
+
+        // Face direction of movement
+        const dx = s.x - prevPosRef.current.x;
+        const dz = s.z - prevPosRef.current.z;
+        if (dx * dx + dz * dz > 0.000001) {
+            const targetAngle = Math.atan2(dx, dz) + Math.PI;
+            let angleDelta = targetAngle - facingAngleRef.current;
+            while (angleDelta > Math.PI) angleDelta -= Math.PI * 2;
+            while (angleDelta < -Math.PI) angleDelta += Math.PI * 2;
+            facingAngleRef.current += angleDelta * 0.25;
+        }
+        prevPosRef.current = { x: s.x, z: s.z };
+        groupRef.current.rotation.y = facingAngleRef.current;
+
+        // Animate mob limbs
+        if (mobRef.current) {
+            animateMob(mobRef.current, clock.elapsedTime, !isStunned);
+        }
     });
 
-    const headColor = useMemo(() => bodyColor.clone().multiplyScalar(1.15), [bodyColor]);
-    const feetColor = useMemo(() => bodyColor.clone().multiplyScalar(0.75), [bodyColor]);
-    const leftFootRef = useRef<THREE.Mesh>(null);
-    const rightFootRef = useRef<THREE.Mesh>(null);
+    const charHeight = mobData.height * mobScale;
 
-    useFrame(({ clock }) => {
-        if (!leftFootRef.current || !rightFootRef.current) return;
-        const w = Math.sin(clock.elapsedTime * 6 + idHash * 2);
-        leftFootRef.current.position.z = w * 0.04;
-        rightFootRef.current.position.z = -w * 0.04;
+    return (
+        <group ref={groupRef}>
+            <primitive object={mobData.group} />
+            <EnemyHPBar health={health} maxHealth={maxHealth} yOffset={charHeight + 0.05} />
+
+            {/* Shield aura (wolf) */}
+            {enemyType === 'shield' && (
+                <mesh position={[0, charHeight * 0.5, 0]}>
+                    <sphereGeometry args={[mobScale * 2.5, 12, 8]} />
+                    <meshStandardMaterial color="#60a5fa" transparent opacity={0.15} side={THREE.DoubleSide} />
+                </mesh>
+            )}
+
+            {/* Healer aura (cat) */}
+            {enemyType === 'healer' && (
+                <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.02, 0]}>
+                    <ringGeometry args={[0.15, 0.22, 16]} />
+                    <meshBasicMaterial color="#86efac" transparent opacity={0.15} side={THREE.DoubleSide} />
+                </mesh>
+            )}
+
+            {/* Amplify marker */}
+            {isAmplified && (
+                <group position={[0, charHeight * 0.5, 0]}>
+                    <mesh>
+                        <sphereGeometry args={[mobScale * 2, 8, 8]} />
+                        <meshStandardMaterial color="#c084fc" emissive="#9333ea" emissiveIntensity={0.6} transparent opacity={0.25} wireframe />
+                    </mesh>
+                </group>
+            )}
+
+            {/* Stun marker */}
+            {isStunned && (
+                <mesh position={[0, charHeight + 0.1, 0]}>
+                    <octahedronGeometry args={[0.06, 0]} />
+                    <meshStandardMaterial color="#fbbf24" emissive="#fbbf24" emissiveIntensity={1} />
+                </mesh>
+            )}
+        </group>
+    );
+}
+
+// ===== Tower Aura Effects =====
+
+// Magma tower (cannon) — pulsing orange aura ring
+function MagmaAuraRing({ radius }: { radius: number }) {
+    const pulseRef = useRef<THREE.Mesh>(null);
+    const ringRef = useRef<THREE.Mesh>(null);
+
+    useFrame((state) => {
+        const t = state.clock.elapsedTime;
+        if (pulseRef.current) {
+            const pulse = 0.85 + Math.sin(t * 3) * 0.15;
+            pulseRef.current.scale.set(pulse, pulse, 1);
+            const mat = pulseRef.current.material as THREE.MeshBasicMaterial;
+            mat.opacity = 0.1 + Math.sin(t * 3) * 0.05;
+        }
+        if (ringRef.current) {
+            ringRef.current.rotation.z = t * 0.5;
+        }
     });
 
     return (
-        <group ref={groupRef} scale={[scale, scale, scale]}>
-            <EnemyHPBar health={health} maxHealth={maxHealth} />
-            <mesh position={[0, ENEMY_SIZE * 0.5, 0]}>
-                <boxGeometry args={[ENEMY_SIZE, ENEMY_SIZE, ENEMY_SIZE * 0.8]} />
-                <meshStandardMaterial color={bodyColor} roughness={0.9} flatShading />
+        <group position={[0, 0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+            <mesh ref={pulseRef}>
+                <circleGeometry args={[radius, 24]} />
+                <meshBasicMaterial color="#ff6600" transparent opacity={0.1} side={THREE.DoubleSide} />
             </mesh>
-            <mesh position={[0, ENEMY_SIZE * 1.25, 0]}>
-                <boxGeometry args={[ENEMY_SIZE * 1.1, ENEMY_SIZE * 0.8, ENEMY_SIZE * 0.9]} />
-                <meshStandardMaterial color={headColor} roughness={0.85} flatShading />
+            <mesh ref={ringRef}>
+                <ringGeometry args={[radius * 0.5, radius * 0.55, 24]} />
+                <meshBasicMaterial color="#ff8800" transparent opacity={0.15} side={THREE.DoubleSide} />
             </mesh>
-            <mesh position={[-ENEMY_SIZE * 0.22, ENEMY_SIZE * 1.3, ENEMY_SIZE * 0.42]}>
-                <boxGeometry args={[ENEMY_SIZE * 0.15, ENEMY_SIZE * 0.12, ENEMY_SIZE * 0.08]} />
-                <meshStandardMaterial color="#111111" />
-            </mesh>
-            <mesh position={[ENEMY_SIZE * 0.22, ENEMY_SIZE * 1.3, ENEMY_SIZE * 0.42]}>
-                <boxGeometry args={[ENEMY_SIZE * 0.15, ENEMY_SIZE * 0.12, ENEMY_SIZE * 0.08]} />
-                <meshStandardMaterial color="#111111" />
-            </mesh>
-            <mesh ref={leftFootRef} position={[-ENEMY_SIZE * 0.2, 0, 0]}>
-                <boxGeometry args={[ENEMY_SIZE * 0.35, ENEMY_SIZE * 0.3, ENEMY_SIZE * 0.4]} />
-                <meshStandardMaterial color={feetColor} roughness={0.95} flatShading />
-            </mesh>
-            <mesh ref={rightFootRef} position={[ENEMY_SIZE * 0.2, 0, 0]}>
-                <boxGeometry args={[ENEMY_SIZE * 0.35, ENEMY_SIZE * 0.3, ENEMY_SIZE * 0.4]} />
-                <meshStandardMaterial color={feetColor} roughness={0.95} flatShading />
+            <mesh>
+                <ringGeometry args={[radius - 0.03, radius, 24]} />
+                <meshBasicMaterial color="#f97316" transparent opacity={0.25} side={THREE.DoubleSide} />
             </mesh>
         </group>
     );
 }
 
-// ===== Tower Aura =====
-function TowerAura({ active, color }: { active: boolean; color: THREE.Color }) {
+// Frost tower — radiating slow AoE ring
+function FrostAoERing({ radius }: { radius: number }) {
+    const pulseRef = useRef<THREE.Mesh>(null);
+    const ringRef = useRef<THREE.Mesh>(null);
+
+    useFrame((state) => {
+        const t = state.clock.elapsedTime;
+        if (pulseRef.current) {
+            const pulse = 0.9 + Math.sin(t * 2) * 0.1;
+            pulseRef.current.scale.set(pulse, pulse, 1);
+            const mat = pulseRef.current.material as THREE.MeshBasicMaterial;
+            mat.opacity = 0.08 + Math.sin(t * 2) * 0.04;
+        }
+        if (ringRef.current) {
+            ringRef.current.rotation.z = t * 0.3;
+        }
+    });
+
+    return (
+        <group position={[0, 0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+            <mesh ref={pulseRef}>
+                <circleGeometry args={[radius, 24]} />
+                <meshBasicMaterial color="#38bdf8" transparent opacity={0.08} side={THREE.DoubleSide} />
+            </mesh>
+            <mesh ref={ringRef}>
+                <ringGeometry args={[radius * 0.5, radius * 0.55, 24]} />
+                <meshBasicMaterial color="#7dd3fc" transparent opacity={0.12} side={THREE.DoubleSide} />
+            </mesh>
+            <mesh>
+                <ringGeometry args={[radius - 0.03, radius, 24]} />
+                <meshBasicMaterial color="#38bdf8" transparent opacity={0.2} side={THREE.DoubleSide} />
+            </mesh>
+        </group>
+    );
+}
+
+// Arcane tower — magical aura glow
+function ArcaneAuraGlow({ height }: { height: number }) {
+    const ringRef = useRef<THREE.Mesh>(null);
+
+    useFrame((state) => {
+        if (ringRef.current) {
+            ringRef.current.rotation.z = state.clock.elapsedTime * 0.8;
+            const mat = ringRef.current.material as THREE.MeshBasicMaterial;
+            mat.opacity = 0.15 + Math.sin(state.clock.elapsedTime * 2.5) * 0.08;
+        }
+    });
+
+    return (
+        <group position={[0, height * 0.5 + 0.05, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+            <mesh ref={ringRef}>
+                <ringGeometry args={[0.12, 0.18, 6]} />
+                <meshBasicMaterial color="#c084fc" transparent opacity={0.2} side={THREE.DoubleSide} />
+            </mesh>
+            <mesh>
+                <circleGeometry args={[0.1, 6]} />
+                <meshBasicMaterial color="#a855f7" transparent opacity={0.1} side={THREE.DoubleSide} />
+            </mesh>
+        </group>
+    );
+}
+
+// ===== Line-clear pulse aura =====
+function TowerAura({ active, color }: { active: boolean; color: string }) {
     const meshRef = useRef<THREE.Mesh>(null);
     const matRef = useRef<THREE.MeshBasicMaterial>(null);
     const scaleRef = useRef(0);
@@ -492,142 +708,30 @@ function TowerAura({ active, color }: { active: boolean; color: THREE.Color }) {
         meshRef.current.visible = s > 0.01;
     });
     return (
-        <mesh ref={meshRef} position={[0, TOWER_SIZE * 1.5, 0]} rotation={[-Math.PI / 2, 0, 0]} visible={false}>
-            <ringGeometry args={[TOWER_SIZE * 0.8, TOWER_SIZE * 2.2, 8]} />
+        <mesh ref={meshRef} position={[0, 0.15, 0]} rotation={[-Math.PI / 2, 0, 0]} visible={false}>
+            <ringGeometry args={[0.12, 0.3, 8]} />
             <meshBasicMaterial ref={matRef} color={color} transparent opacity={0} side={THREE.DoubleSide} />
         </mesh>
     );
 }
 
-// ===== Type-specific tower geometry =====
-function TowerBody({ type, level }: { type: TowerType; level: number }) {
-    const colors = TOWER_TYPE_COLORS[type];
-
-    // Common base
-    const base = (
-        <mesh position={[0, TOWER_SIZE * 0.35, 0]}>
-            <boxGeometry args={[TOWER_SIZE * 1.4, TOWER_SIZE * 0.7, TOWER_SIZE * 1.4]} />
-            <meshStandardMaterial color={colors.main} roughness={0.75} flatShading />
-        </mesh>
-    );
-
-    // Type-specific top
-    let top: React.ReactNode;
-    switch (type) {
-        case 'archer': // Tall narrow
-            top = (
-                <mesh position={[0, TOWER_SIZE * 1.5, 0]}>
-                    <boxGeometry args={[TOWER_SIZE * 0.6, TOWER_SIZE * 1.6, TOWER_SIZE * 0.6]} />
-                    <meshStandardMaterial color={colors.accent} roughness={0.65} flatShading />
-                </mesh>
-            );
-            break;
-        case 'cannon': // Squat wide
-            top = (
-                <mesh position={[0, TOWER_SIZE * 1.0, 0]}>
-                    <boxGeometry args={[TOWER_SIZE * 1.2, TOWER_SIZE * 0.8, TOWER_SIZE * 1.2]} />
-                    <meshStandardMaterial color={colors.accent} roughness={0.6} flatShading />
-                </mesh>
-            );
-            break;
-        case 'frost': // Crystal shape
-            top = (
-                <mesh position={[0, TOWER_SIZE * 1.3, 0]} rotation={[0, Math.PI / 4, 0]}>
-                    <boxGeometry args={[TOWER_SIZE * 0.8, TOWER_SIZE * 1.2, TOWER_SIZE * 0.8]} />
-                    <meshStandardMaterial color={colors.accent} roughness={0.3} metalness={0.3} flatShading />
-                </mesh>
-            );
-            break;
-        case 'lightning': // Tall spire
-            top = (
-                <mesh position={[0, TOWER_SIZE * 1.7, 0]}>
-                    <boxGeometry args={[TOWER_SIZE * 0.5, TOWER_SIZE * 2.0, TOWER_SIZE * 0.5]} />
-                    <meshStandardMaterial color={colors.accent} roughness={0.5} metalness={0.2} flatShading />
-                </mesh>
-            );
-            break;
-        case 'sniper': // Narrow tall
-            top = (
-                <mesh position={[0, TOWER_SIZE * 1.6, 0]}>
-                    <boxGeometry args={[TOWER_SIZE * 0.4, TOWER_SIZE * 1.8, TOWER_SIZE * 0.4]} />
-                    <meshStandardMaterial color={colors.accent} roughness={0.7} flatShading />
-                </mesh>
-            );
-            break;
-        case 'flame': // Flickering top
-            top = (
-                <>
-                    <mesh position={[0, TOWER_SIZE * 1.1, 0]}>
-                        <boxGeometry args={[TOWER_SIZE * 1.0, TOWER_SIZE * 1.0, TOWER_SIZE * 1.0]} />
-                        <meshStandardMaterial color={colors.accent} roughness={0.6} flatShading />
-                    </mesh>
-                    <mesh position={[0, TOWER_SIZE * 1.8, 0]}>
-                        <boxGeometry args={[TOWER_SIZE * 0.5, TOWER_SIZE * 0.5, TOWER_SIZE * 0.5]} />
-                        <meshStandardMaterial color="#ff8844" emissive="#ff4422" emissiveIntensity={1.5} roughness={0.2} flatShading />
-                    </mesh>
-                </>
-            );
-            break;
-        case 'arcane': // Floating orb
-            top = (
-                <>
-                    <mesh position={[0, TOWER_SIZE * 1.2, 0]}>
-                        <boxGeometry args={[TOWER_SIZE * 0.8, TOWER_SIZE * 1.0, TOWER_SIZE * 0.8]} />
-                        <meshStandardMaterial color={colors.accent} roughness={0.5} flatShading />
-                    </mesh>
-                    <mesh position={[0, TOWER_SIZE * 2.2, 0]}>
-                        <boxGeometry args={[TOWER_SIZE * 0.45, TOWER_SIZE * 0.45, TOWER_SIZE * 0.45]} />
-                        <meshStandardMaterial color={colors.glow} emissive={colors.glow} emissiveIntensity={2} roughness={0.2} flatShading />
-                    </mesh>
-                </>
-            );
-            break;
-    }
-
-    return (
-        <>
-            {base}
-            {top}
-            {/* Crown for leveled towers */}
-            <mesh position={[0, TOWER_SIZE * 2.8, 0]}>
-                <boxGeometry args={[TOWER_SIZE * 1.2, TOWER_SIZE * 0.25, TOWER_SIZE * 1.2]} />
-                <meshStandardMaterial color={colors.accent} roughness={0.7} flatShading />
-            </mesh>
-            {/* Glow tip */}
-            <mesh position={[0, TOWER_SIZE * 3.2, 0]}>
-                <boxGeometry args={[TOWER_SIZE * 0.35, TOWER_SIZE * 0.4, TOWER_SIZE * 0.35]} />
-                <meshStandardMaterial color={colors.glow} emissive={colors.glow} emissiveIntensity={1.5} roughness={0.2} flatShading />
-            </mesh>
-            <pointLight position={[0, TOWER_SIZE * 3.4, 0]} color={colors.glow} intensity={0.5} distance={1.5} />
-            {level > 1 && (
-                <mesh position={[0, TOWER_SIZE * 3.0, 0]}>
-                    <boxGeometry args={[TOWER_SIZE * 1.0, TOWER_SIZE * 0.12, TOWER_SIZE * 1.0]} />
-                    <meshStandardMaterial color="#ffcc44" emissive="#ffcc44" emissiveIntensity={0.3} roughness={0.5} flatShading />
-                </mesh>
-            )}
-            {level > 2 && (
-                <mesh position={[0, TOWER_SIZE * 3.15, 0]}>
-                    <boxGeometry args={[TOWER_SIZE * 0.8, TOWER_SIZE * 0.08, TOWER_SIZE * 0.8]} />
-                    <meshStandardMaterial color="#ff8844" emissive="#ff8844" emissiveIntensity={0.5} roughness={0.5} flatShading />
-                </mesh>
-            )}
-        </>
-    );
-}
-
-// ===== Tower Mesh =====
-function GridTower({ tower, isSelected, lineClearPulse, onClick }: {
+// ===== Tower Mesh with Minecraft mob model =====
+function MobTower({ tower, isSelected, lineClearPulse, onClick }: {
     tower: RingTower;
     isSelected: boolean;
     lineClearPulse: boolean;
     onClick: (id: string) => void;
 }) {
     const groupRef = useRef<THREE.Group>(null);
+    const mobWrapperRef = useRef<THREE.Group>(null);
+    const mobRef = useRef<MobMeshData | null>(null);
+    const facingAngleRef = useRef(0);
     const colors = TOWER_TYPE_COLORS[tower.type];
+    const def = TOWER_DEFS[tower.type];
+    const mobType = TOWER_MOB_MAP[tower.type];
+    const isStackable = tower.type === 'cannon' || tower.type === 'frost';
 
-    // The slot stores the per-side index; use tower.side + slot local index for positioning
     const localIndex = useMemo(() => {
-        // Slots ordered: top(10), bottom(10), left(20), right(20)
         let idx = tower.slotIndex;
         const tb = GALAXY_TOWERS_PER_SIDE_TB;
         const lr = GALAXY_TOWERS_PER_SIDE_LR;
@@ -642,14 +746,48 @@ function GridTower({ tower, isSelected, lineClearPulse, onClick }: {
 
     const towerPos = useMemo(() => towerToWorld(tower.side, localIndex), [tower.side, localIndex]);
 
+    // Create mob mesh (stackable mobs grow with level)
+    const mobData = useMemo(() => {
+        const data = isStackable
+            ? createMobMesh(mobType, { segments: tower.level })
+            : createMobMesh(mobType);
+        data.group.scale.setScalar(TOWER_MOB_SCALE);
+        return data;
+    }, [mobType, isStackable, tower.level]);
+
+    useEffect(() => {
+        mobRef.current = mobData;
+        return () => {
+            disposeMobGroup(mobData);
+            mobRef.current = null;
+        };
+    }, [mobData]);
+
     useFrame(({ clock }) => {
         if (!groupRef.current) return;
         groupRef.current.position.set(towerPos.x, BLOCK_H * 0.5, towerPos.z);
-        groupRef.current.rotation.y = towerPos.angle;
+
         if (isSelected) {
             groupRef.current.scale.setScalar(1 + Math.sin(clock.elapsedTime * 4) * 0.08);
         } else {
             groupRef.current.scale.setScalar(1);
+        }
+
+        // Face toward target (use path angle as base, target override when attacking)
+        if (mobWrapperRef.current && tower.targetId) {
+            // When targeting, rotate mob to face the path direction
+            const targetAngle = towerPos.angle + Math.PI;
+            let delta = targetAngle - facingAngleRef.current;
+            while (delta > Math.PI) delta -= Math.PI * 2;
+            while (delta < -Math.PI) delta += Math.PI * 2;
+            facingAngleRef.current += delta * 0.15;
+            mobWrapperRef.current.rotation.y = facingAngleRef.current;
+        }
+
+        // Idle animation (slime types don't bounce on the tower stage)
+        if (mobRef.current) {
+            const slimeTower = tower.type === 'cannon' || tower.type === 'frost';
+            animateMob(mobRef.current, clock.elapsedTime, !slimeTower);
         }
     });
 
@@ -658,13 +796,65 @@ function GridTower({ tower, isSelected, lineClearPulse, onClick }: {
         onClick(tower.id);
     }, [tower.id, onClick]);
 
+    const charHeight = mobData.height * TOWER_MOB_SCALE;
+    // Convert ring-engine range (path-fraction) to approximate 3D radius
+    const towerRange = (def.range / 72) * GALAXY_PATH_LENGTH * CELL * 0.15;
+
     return (
         <group ref={groupRef} onPointerDown={handleClick}>
             <TowerAura active={lineClearPulse} color={colors.glow} />
-            <TowerBody type={tower.type} level={tower.level} />
+
+            {/* Platform base */}
+            <mesh position={[0, 0.03, 0]} castShadow>
+                <cylinderGeometry args={[0.16, 0.19, 0.06, 8]} />
+                <meshStandardMaterial color={colors.main} roughness={0.35} metalness={0.35} />
+            </mesh>
+            {/* Platform accent ring */}
+            <mesh position={[0, 0.005, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+                <ringGeometry args={[0.16, 0.21, 12]} />
+                <meshStandardMaterial
+                    color={colors.accent}
+                    emissive={colors.accent}
+                    emissiveIntensity={0.6}
+                    transparent opacity={0.5}
+                    side={THREE.DoubleSide}
+                />
+            </mesh>
+
+            {/* Minecraft mob model */}
+            <group ref={mobWrapperRef} position={[0, 0.06, 0]}>
+                <primitive object={mobData.group} />
+            </group>
+
+            {/* Level indicators */}
+            {tower.level > 1 && (
+                <mesh position={[0, 0.065, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+                    <ringGeometry args={[0.14, 0.17, 8]} />
+                    <meshStandardMaterial color="#ffcc44" emissive="#ffcc44" emissiveIntensity={0.3} transparent opacity={0.7} side={THREE.DoubleSide} />
+                </mesh>
+            )}
+            {tower.level > 2 && (
+                <mesh position={[0, 0.07, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+                    <ringGeometry args={[0.11, 0.14, 8]} />
+                    <meshStandardMaterial color="#ff8844" emissive="#ff8844" emissiveIntensity={0.5} transparent opacity={0.7} side={THREE.DoubleSide} />
+                </mesh>
+            )}
+
+            {/* Type-specific auras */}
+            {tower.type === 'cannon' && <MagmaAuraRing radius={towerRange} />}
+            {tower.type === 'frost' && <FrostAoERing radius={towerRange} />}
+            {tower.type === 'arcane' && <ArcaneAuraGlow height={charHeight} />}
+            {tower.type === 'lightning' && (
+                <pointLight position={[0, charHeight * 0.5 + 0.06, 0]} color="#a78bfa" intensity={1.5} distance={1} decay={2} />
+            )}
+            {tower.type === 'flame' && (
+                <pointLight position={[0, charHeight * 0.3 + 0.06, 0]} color="#ef4444" intensity={1.0} distance={0.8} decay={2} />
+            )}
+
+            {/* Selection ring */}
             {isSelected && (
                 <mesh position={[0, 0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
-                    <ringGeometry args={[TOWER_SIZE * 1.5, TOWER_SIZE * 2.0, 16]} />
+                    <ringGeometry args={[0.2, 0.25, 16]} />
                     <meshBasicMaterial color="#ffffff" transparent opacity={0.3} side={THREE.DoubleSide} />
                 </mesh>
             )}
@@ -681,7 +871,6 @@ function TowerSlotMarker({ slot, highlighted, onSlotClick }: {
     const groupRef = useRef<THREE.Group>(null);
     const matRef = useRef<THREE.MeshStandardMaterial>(null);
 
-    // slot.index is the per-side local index
     const slotPos = useMemo(() => towerToWorld(slot.side, slot.index), [slot.side, slot.index]);
 
     useFrame(({ clock }) => {
@@ -725,40 +914,54 @@ function TowerSlotMarker({ slot, highlighted, onSlotClick }: {
     );
 }
 
-// ===== Projectile =====
+// ===== Projectile (Minecraft-themed) =====
 function RingProjectile3D({ projectile }: { projectile: RingProjectile }) {
     const groupRef = useRef<THREE.Group>(null);
+    const projRef = useRef<ProjectileMeshData | null>(null);
     const smoothRef = useRef({ x: 0, z: 0, init: false });
-    const colors = TOWER_TYPE_COLORS[projectile.towerType];
+    const prevPos = useRef(new THREE.Vector3());
+    const velocity = useRef(new THREE.Vector3());
 
-    useFrame((_, delta) => {
-        if (!groupRef.current) return;
+    const projData = useMemo(() => {
+        return createProjectileMesh(projectile.towerType);
+    }, [projectile.towerType]);
+
+    useEffect(() => {
+        projRef.current = projData;
+        return () => {
+            disposeProjectileGroup(projData);
+            projRef.current = null;
+        };
+    }, [projData]);
+
+    useFrame((state, delta) => {
+        if (!groupRef.current || !projRef.current) return;
         const target = pathToWorld(projectile.pathFraction);
-        const y = BLOCK_H * 0.5 + TOWER_SIZE * 2;
+        const y = BLOCK_H * 0.5 + 0.25;
         const s = smoothRef.current;
         if (!s.init) {
             s.x = target.x; s.z = target.z; s.init = true;
+            prevPos.current.set(target.x, y, target.z);
         } else {
             const t = 1 - Math.exp(-LERP_SPEED * 2 * delta);
             s.x += (target.x - s.x) * t;
             s.z += (target.z - s.z) * t;
         }
         groupRef.current.position.set(s.x, y, s.z);
+
+        // Compute velocity for arrow orientation
+        velocity.current.set(s.x - prevPos.current.x, 0, s.z - prevPos.current.z);
+        if (velocity.current.lengthSq() > 0.0001) {
+            velocity.current.normalize();
+        }
+        prevPos.current.set(s.x, y, s.z);
+
+        animateProjectile(projRef.current, state.clock.elapsedTime, velocity.current);
     });
 
     return (
         <group ref={groupRef}>
-            <mesh>
-                <boxGeometry args={[0.06, 0.06, 0.06]} />
-                <meshStandardMaterial
-                    color={colors.glow}
-                    emissive={colors.glow}
-                    emissiveIntensity={3}
-                    roughness={0.2}
-                    flatShading
-                />
-            </mesh>
-            <pointLight color={colors.glow} intensity={0.3} distance={0.8} />
+            <primitive object={projData.group} />
         </group>
     );
 }
@@ -802,6 +1005,17 @@ function GateMarkers({ gates }: { gates: GalaxyGate[] }) {
     );
 }
 
+// ===== Cleanup shared resources on unmount =====
+function SharedResourceCleanup() {
+    useEffect(() => {
+        return () => {
+            disposeSharedMobResources();
+            disposeSharedProjectileResources();
+        };
+    }, []);
+    return null;
+}
+
 // ===== Main 3D Scene =====
 function GalaxyRingScene({
     enemies,
@@ -829,6 +1043,7 @@ function GalaxyRingScene({
     return (
         <>
             <PixelFilterSetup />
+            <SharedResourceCleanup />
             <ambientLight intensity={0.7} color="#ccccff" />
             <directionalLight position={[5, 10, 5]} intensity={0.9} color="#ffffff" />
             <directionalLight position={[-4, 6, -6]} intensity={0.25} color="#8888cc" />
@@ -851,9 +1066,9 @@ function GalaxyRingScene({
                     />
                 ))}
 
-                {/* Placed towers */}
+                {/* Placed towers (Minecraft mob models) */}
                 {towers.map(tower => (
-                    <GridTower
+                    <MobTower
                         key={tower.id}
                         tower={tower}
                         isSelected={tower.id === selectedTowerId}
@@ -862,9 +1077,9 @@ function GalaxyRingScene({
                     />
                 ))}
 
-                {/* Enemies */}
+                {/* Enemies (Minecraft animal mob models) */}
                 {enemies.filter(e => !e.dead).map(enemy => (
-                    <PixelEnemy
+                    <MobEnemy
                         key={enemy.id}
                         pathPosition={enemy.pathFraction}
                         enemyType={enemy.type}
@@ -872,10 +1087,11 @@ function GalaxyRingScene({
                         health={enemy.hp}
                         maxHealth={enemy.maxHp}
                         effects={enemy.effects}
+                        flying={enemy.flying}
                     />
                 ))}
 
-                {/* Projectiles */}
+                {/* Projectiles (Minecraft-themed: arrows, cobwebs, TNT, etc.) */}
                 {projectiles.map(proj => (
                     <RingProjectile3D key={proj.id} projectile={proj} />
                 ))}

--- a/src/components/rhythmia/tetris/components/GalaxyRing3D.tsx
+++ b/src/components/rhythmia/tetris/components/GalaxyRing3D.tsx
@@ -904,8 +904,15 @@ function TowerSlotMarker({ slot, highlighted, onSlotClick }: {
         onSlotClick(globalIndex);
     }, [globalIndex, onSlotClick]);
 
+    const HIT_SIZE = 0.4; // Larger invisible hitbox for reliable raycasting
     return (
-        <group ref={groupRef} onPointerDown={handleClick}>
+        <group ref={groupRef}>
+            {/* Invisible larger hitbox for click detection */}
+            <mesh position={[0, SLOT_SIZE * 0.5 + 0.05, 0]} onPointerDown={handleClick}>
+                <boxGeometry args={[HIT_SIZE, HIT_SIZE, HIT_SIZE]} />
+                <meshBasicMaterial visible={false} />
+            </mesh>
+            {/* Visible slot marker */}
             <mesh position={[0, SLOT_SIZE * 0.5, 0]}>
                 <boxGeometry args={[SLOT_SIZE, SLOT_SIZE * 0.3, SLOT_SIZE]} />
                 <meshStandardMaterial ref={matRef} color={SLOT_COLOR_EMPTY} transparent opacity={0.15} roughness={0.8} flatShading />

--- a/src/components/rhythmia/tetris/components/GalaxyRing3D.tsx
+++ b/src/components/rhythmia/tetris/components/GalaxyRing3D.tsx
@@ -1,23 +1,22 @@
 'use client';
 
-import React, { useRef, useMemo, useEffect } from 'react';
+import React, { useRef, useMemo, useEffect, useCallback } from 'react';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
-import type { GalaxyRingEnemy, GalaxyTower, GalaxyGate } from '../galaxy-types';
+import type { TowerType, EnemyType, RingEnemy, RingTower, RingProjectile, TowerSlot, GalaxyGate, StatusEffect } from '../galaxy-types';
+import { ENEMY_DEFS } from '@/types/tower-defense';
 import {
     GALAXY_RING_DEPTH,
     GALAXY_TOP_WIDTH,
     GALAXY_SIDE_HEIGHT,
     GALAXY_PATH_LENGTH,
     GALAXY_SIDE_BOUNDARIES,
-    GALAXY_GATE_POSITIONS,
     GALAXY_TOWERS_PER_SIDE_TB,
     GALAXY_TOWERS_PER_SIDE_LR,
+    GALAXY_GATE_POSITIONS,
 } from '../galaxy-constants';
 
 // ===== Grid dimensions =====
-// Board = 10 wide × 20 tall.  Ring = 3 cells deep on each side.
-// Total grid = 16 wide × 26 tall.  Center 10×20 is the board (empty).
 const GRID_W = GALAXY_TOP_WIDTH;               // 16
 const GRID_H = GALAXY_SIDE_HEIGHT + 2 * GALAXY_RING_DEPTH; // 26
 const BOARD_W = GRID_W - 2 * GALAXY_RING_DEPTH; // 10
@@ -25,51 +24,51 @@ const BOARD_H = GALAXY_SIDE_HEIGHT;              // 20
 const DEPTH = GALAXY_RING_DEPTH;                 // 3
 
 // ===== 3D sizing =====
-const CELL = 0.32;                  // World units per grid cell
-const CELL_GAP = 0.02;             // Gap between cells
-const BLOCK_H = 0.18;              // Terrain block height
+const CELL = 0.32;
+const CELL_GAP = 0.02;
+const BLOCK_H = 0.18;
 const ENEMY_SIZE = 0.28;
 const TOWER_SIZE = 0.22;
 const LERP_SPEED = 8;
+const SLOT_SIZE = 0.18;
 
-// Precomputed grid origin — center the grid at world origin
 const ORIGIN_X = -(GRID_W - 1) * CELL * 0.5;
 const ORIGIN_Z = -(GRID_H - 1) * CELL * 0.5;
 
-// ===== Color palettes =====
-const ENEMY_COLORS = [
-    new THREE.Color('#88cc88'),
-    new THREE.Color('#7799bb'),
-    new THREE.Color('#bb9977'),
-    new THREE.Color('#aa88cc'),
-    new THREE.Color('#ccaa77'),
-];
+// ===== Tower type colors =====
+const TOWER_TYPE_COLORS: Record<TowerType, { main: THREE.Color; accent: THREE.Color; glow: THREE.Color }> = {
+    archer:    { main: new THREE.Color('#4ade80'), accent: new THREE.Color('#22c55e'), glow: new THREE.Color('#66ff99') },
+    cannon:    { main: new THREE.Color('#f97316'), accent: new THREE.Color('#ea580c'), glow: new THREE.Color('#ff9944') },
+    frost:     { main: new THREE.Color('#38bdf8'), accent: new THREE.Color('#0ea5e9'), glow: new THREE.Color('#66ddff') },
+    lightning: { main: new THREE.Color('#a78bfa'), accent: new THREE.Color('#8b5cf6'), glow: new THREE.Color('#bb99ff') },
+    sniper:    { main: new THREE.Color('#f43f5e'), accent: new THREE.Color('#e11d48'), glow: new THREE.Color('#ff6688') },
+    flame:     { main: new THREE.Color('#ef4444'), accent: new THREE.Color('#dc2626'), glow: new THREE.Color('#ff6644') },
+    arcane:    { main: new THREE.Color('#c084fc'), accent: new THREE.Color('#a855f7'), glow: new THREE.Color('#dd99ff') },
+};
 
-const PATH_COLORS = [
-    new THREE.Color('#3a6a4a'),
-    new THREE.Color('#4a7a5a'),
-    new THREE.Color('#3a5a4a'),
-    new THREE.Color('#4a7a5a'),
-];
-const TOWER_LAYER_COLORS = [
-    new THREE.Color('#4a3a6a'),
-    new THREE.Color('#5a4a7a'),
-    new THREE.Color('#3a2a5a'),
-];
-const BUFFER_COLORS = [
-    new THREE.Color('#2a1a4a'),
-    new THREE.Color('#3a2a5a'),
-];
+// ===== Enemy type colors =====
+function getEnemyColor(type: EnemyType): THREE.Color {
+    const def = ENEMY_DEFS[type];
+    return new THREE.Color(def.color);
+}
+
+function getEnemyScale(type: EnemyType): number {
+    const def = ENEMY_DEFS[type];
+    return def.scale / 0.4; // normalized to base grunt scale
+}
+
+// ===== Path/Terrain colors =====
+const PATH_COLORS = [new THREE.Color('#3a6a4a'), new THREE.Color('#4a7a5a'), new THREE.Color('#3a5a4a'), new THREE.Color('#4a7a5a')];
+const TOWER_LAYER_COLORS = [new THREE.Color('#4a3a6a'), new THREE.Color('#5a4a7a'), new THREE.Color('#3a2a5a')];
+const BUFFER_COLORS = [new THREE.Color('#2a1a4a'), new THREE.Color('#3a2a5a')];
 const CORNER_COLOR = new THREE.Color('#1a1030');
-const GATE_COLOR_FULL = new THREE.Color('#44ff88');
-
-const TOWER_COLOR_IDLE = new THREE.Color('#6655aa');
-const TOWER_COLOR_CHARGED = new THREE.Color('#aa88ff');
-const TOWER_GLOW_COLOR = new THREE.Color('#00ccff');
+const SLOT_COLOR_EMPTY = new THREE.Color('#554488');
+const SLOT_COLOR_HIGHLIGHT = new THREE.Color('#8866dd');
 
 // ===== Pixel filter setup =====
 function PixelFilterSetup() {
     const { gl } = useThree();
+    // eslint-disable-next-line react-hooks/immutability
     useEffect(() => { gl.outputColorSpace = THREE.SRGBColorSpace; }, [gl]);
     return null;
 }
@@ -85,78 +84,49 @@ function getCellKind(col: number, row: number): CellKind {
     const inCenter = col >= DEPTH && col < DEPTH + BOARD_W && row >= DEPTH && row < DEPTH + BOARD_H;
 
     if (inCenter) return 'empty';
-
-    // Corners (3×3 blocks at each corner)
     if ((inTopStrip || inBottomStrip) && (inLeftStrip || inRightStrip)) return 'corner';
 
-    // Determine layer (distance from outer edge)
     let layer: number;
-    if (inTopStrip) {
-        layer = row;
-    } else if (inBottomStrip) {
-        layer = GRID_H - 1 - row;
-    } else if (inLeftStrip) {
-        layer = col;
-    } else if (inRightStrip) {
-        layer = GRID_W - 1 - col;
-    } else {
-        return 'empty';
-    }
+    if (inTopStrip) layer = row;
+    else if (inBottomStrip) layer = GRID_H - 1 - row;
+    else if (inLeftStrip) layer = col;
+    else if (inRightStrip) layer = GRID_W - 1 - col;
+    else return 'empty';
 
     if (layer === 0) return 'path';
     if (layer === 1) return 'tower';
     return 'buffer';
 }
 
-// ===== Path fraction (0-1) → 3D world position on the rectangular path =====
-// Clockwise: top (left→right), right (top→bottom), bottom (right→left), left (bottom→top)
+// ===== Path fraction → 3D world position =====
 function pathToWorld(pathPos: number): { x: number; z: number; angle: number } {
     const p = ((pathPos % 1.0) + 1.0) % 1.0;
-    const totalLen = GALAXY_PATH_LENGTH; // 72
-    const cellIdx = p * totalLen;
-
-    const topLen = GALAXY_TOP_WIDTH;     // 16
-    const rightLen = GALAXY_SIDE_HEIGHT; // 20
-    const bottomLen = GALAXY_TOP_WIDTH;  // 16
-    // leftLen = 20
+    const cellIdx = p * GALAXY_PATH_LENGTH;
+    const topLen = GALAXY_TOP_WIDTH;
+    const rightLen = GALAXY_SIDE_HEIGHT;
+    const bottomLen = GALAXY_TOP_WIDTH;
 
     let col: number, row: number, angle: number;
 
     if (cellIdx < topLen) {
-        // Top side: row=0, col goes left→right
         const t = cellIdx / topLen;
-        col = t * (GRID_W - 1);
-        row = 0;
-        angle = 0; // facing right
+        col = t * (GRID_W - 1); row = 0; angle = 0;
     } else if (cellIdx < topLen + rightLen) {
-        // Right side: col=GRID_W-1, row goes top→bottom
         const t = (cellIdx - topLen) / rightLen;
-        col = GRID_W - 1;
-        row = DEPTH + t * (BOARD_H - 1);
-        angle = -Math.PI / 2; // facing down
+        col = GRID_W - 1; row = DEPTH + t * (BOARD_H - 1); angle = -Math.PI / 2;
     } else if (cellIdx < topLen + rightLen + bottomLen) {
-        // Bottom side: row=GRID_H-1, col goes right→left
         const t = (cellIdx - topLen - rightLen) / bottomLen;
-        col = (GRID_W - 1) * (1 - t);
-        row = GRID_H - 1;
-        angle = Math.PI; // facing left
+        col = (GRID_W - 1) * (1 - t); row = GRID_H - 1; angle = Math.PI;
     } else {
-        // Left side: col=0, row goes bottom→top
         const leftStart = topLen + rightLen + bottomLen;
         const t = (cellIdx - leftStart) / GALAXY_SIDE_HEIGHT;
-        col = 0;
-        row = DEPTH + (BOARD_H - 1) * (1 - t);
-        angle = Math.PI / 2; // facing up
+        col = 0; row = DEPTH + (BOARD_H - 1) * (1 - t); angle = Math.PI / 2;
     }
 
-    return {
-        x: ORIGIN_X + col * CELL,
-        z: ORIGIN_Z + row * CELL,
-        angle,
-    };
+    return { x: ORIGIN_X + col * CELL, z: ORIGIN_Z + row * CELL, angle };
 }
 
-// ===== Tower position on the tower layer (1 cell inward from path) =====
+// ===== Tower position (1 cell inward from path) =====
 function towerToWorld(side: string, index: number): { x: number; z: number; angle: number } {
     const bounds = GALAXY_SIDE_BOUNDARIES[side as keyof typeof GALAXY_SIDE_BOUNDARIES];
     const count = (side === 'top' || side === 'bottom') ? GALAXY_TOWERS_PER_SIDE_TB : GALAXY_TOWERS_PER_SIDE_LR;
@@ -164,76 +134,48 @@ function towerToWorld(side: string, index: number): { x: number; z: number; angl
     const padding = (side === 'top' || side === 'bottom') ? sideLen * (DEPTH / GALAXY_TOP_WIDTH) : 0;
     const usable = sideLen - 2 * padding;
     const pathFrac = bounds.start + padding + (index + 0.5) * (usable / count);
-
-    // Get the path position, then offset inward by 1 cell
     const pathWorld = pathToWorld(pathFrac);
     let dx = 0, dz = 0;
-
-    if (side === 'top') { dz = CELL; }
-    else if (side === 'bottom') { dz = -CELL; }
-    else if (side === 'left') { dx = CELL; }
-    else { dx = -CELL; }
-
-    return {
-        x: pathWorld.x + dx,
-        z: pathWorld.z + dz,
-        angle: pathWorld.angle,
-    };
+    if (side === 'top') dz = CELL;
+    else if (side === 'bottom') dz = -CELL;
+    else if (side === 'left') dx = CELL;
+    else dx = -CELL;
+    return { x: pathWorld.x + dx, z: pathWorld.z + dz, angle: pathWorld.angle };
 }
 
-// ===== Terrain Grid — instanced mesh of all ring cells =====
+// ===== Terrain Grid =====
 function TerrainGrid() {
     const meshRef = useRef<THREE.InstancedMesh>(null);
-
     const { count, matrices, colors } = useMemo(() => {
         const rng = mulberry32(42);
         const cells: { x: number; z: number; color: THREE.Color; heightVar: number }[] = [];
-
         for (let row = 0; row < GRID_H; row++) {
             for (let col = 0; col < GRID_W; col++) {
                 const kind = getCellKind(col, row);
                 if (kind === 'empty') continue;
-
                 const wx = ORIGIN_X + col * CELL;
                 const wz = ORIGIN_Z + row * CELL;
                 const hv = (rng() - 0.5) * 0.04;
-
                 let color: THREE.Color;
                 switch (kind) {
-                    case 'path':
-                        color = PATH_COLORS[Math.floor(rng() * PATH_COLORS.length)];
-                        break;
-                    case 'tower':
-                        color = TOWER_LAYER_COLORS[Math.floor(rng() * TOWER_LAYER_COLORS.length)];
-                        break;
-                    case 'buffer':
-                        color = BUFFER_COLORS[Math.floor(rng() * BUFFER_COLORS.length)];
-                        break;
-                    case 'corner':
-                        color = CORNER_COLOR.clone();
-                        break;
-                    default:
-                        color = CORNER_COLOR.clone();
+                    case 'path': color = PATH_COLORS[Math.floor(rng() * PATH_COLORS.length)]; break;
+                    case 'tower': color = TOWER_LAYER_COLORS[Math.floor(rng() * TOWER_LAYER_COLORS.length)]; break;
+                    case 'buffer': color = BUFFER_COLORS[Math.floor(rng() * BUFFER_COLORS.length)]; break;
+                    default: color = CORNER_COLOR.clone();
                 }
-
                 cells.push({ x: wx, z: wz, color, heightVar: hv });
             }
         }
-
         const totalBlocks = cells.length;
         const mat = new Float32Array(totalBlocks * 16);
         const col = new Float32Array(totalBlocks * 3);
         const dummy = new THREE.Matrix4();
-
         for (let i = 0; i < totalBlocks; i++) {
             const c = cells[i];
             dummy.makeTranslation(c.x, c.heightVar, c.z);
             dummy.toArray(mat, i * 16);
-            col[i * 3] = c.color.r;
-            col[i * 3 + 1] = c.color.g;
-            col[i * 3 + 2] = c.color.b;
+            col[i * 3] = c.color.r; col[i * 3 + 1] = c.color.g; col[i * 3 + 2] = c.color.b;
         }
-
         return { count: totalBlocks, matrices: mat, colors: col };
     }, []);
 
@@ -250,7 +192,6 @@ function TerrainGrid() {
     }, [count, matrices, colors]);
 
     const blockSize = CELL - CELL_GAP;
-
     return (
         <instancedMesh ref={meshRef} args={[undefined, undefined, count]} castShadow={false} receiveShadow={false}>
             <boxGeometry args={[blockSize, BLOCK_H, blockSize]} />
@@ -259,10 +200,9 @@ function TerrainGrid() {
     );
 }
 
-// ===== Terrain underside — darker slab beneath the whole ring =====
+// ===== Terrain underside =====
 function TerrainUnderside() {
     const meshRef = useRef<THREE.InstancedMesh>(null);
-
     const { count, matrices } = useMemo(() => {
         const cells: { x: number; z: number }[] = [];
         for (let row = 0; row < GRID_H; row++) {
@@ -292,7 +232,6 @@ function TerrainUnderside() {
     }, [count, matrices]);
 
     const blockSize = CELL - CELL_GAP;
-
     return (
         <instancedMesh ref={meshRef} args={[undefined, undefined, count]}>
             <boxGeometry args={[blockSize, BLOCK_H * 0.5, blockSize]} />
@@ -301,12 +240,11 @@ function TerrainUnderside() {
     );
 }
 
-// ===== Ground plane with pixelated texture =====
+// ===== Ground plane =====
 function GroundPlane() {
     const texture = useMemo(() => {
         const canvas = document.createElement('canvas');
-        canvas.width = 16;
-        canvas.height = 16;
+        canvas.width = 16; canvas.height = 16;
         const ctx = canvas.getContext('2d')!;
         const rng = mulberry32(99);
         const cs = ['#0e0818', '#120c20', '#160e28', '#0e0a1a', '#100c1e'];
@@ -317,14 +255,10 @@ function GroundPlane() {
             }
         }
         const tex = new THREE.CanvasTexture(canvas);
-        tex.magFilter = THREE.NearestFilter;
-        tex.minFilter = THREE.NearestFilter;
-        tex.generateMipmaps = false;
+        tex.magFilter = THREE.NearestFilter; tex.minFilter = THREE.NearestFilter; tex.generateMipmaps = false;
         return tex;
     }, []);
-
     const size = Math.max(GRID_W, GRID_H) * CELL * 2;
-
     return (
         <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -BLOCK_H, 0]}>
             <planeGeometry args={[size, size]} />
@@ -333,7 +267,7 @@ function GroundPlane() {
     );
 }
 
-// ===== Path outline — thin rectangular loop marking the outer path =====
+// ===== Path outline =====
 function PathOutline() {
     const points = useMemo(() => {
         const y = BLOCK_H * 0.5 + 0.01;
@@ -341,16 +275,12 @@ function PathOutline() {
         const topZ = ORIGIN_Z - CELL * 0.5;
         const botZ = ORIGIN_Z + (GRID_H - 1) * CELL + CELL * 0.5;
         return [
-            new THREE.Vector3(-halfW, y, topZ),
-            new THREE.Vector3(halfW, y, topZ),
-            new THREE.Vector3(halfW, y, botZ),
-            new THREE.Vector3(-halfW, y, botZ),
+            new THREE.Vector3(-halfW, y, topZ), new THREE.Vector3(halfW, y, topZ),
+            new THREE.Vector3(halfW, y, botZ), new THREE.Vector3(-halfW, y, botZ),
             new THREE.Vector3(-halfW, y, topZ),
         ];
     }, []);
-
     const lineGeo = useMemo(() => new THREE.BufferGeometry().setFromPoints(points), [points]);
-
     return (
         <line>
             <bufferGeometry attach="geometry" {...lineGeo} />
@@ -359,47 +289,33 @@ function PathOutline() {
     );
 }
 
-// ===== Decorative crystals scattered on the ring =====
+// ===== Decorative crystals =====
 function TerrainDecorations() {
     const meshRef = useRef<THREE.InstancedMesh>(null);
-
     const { count, matrices, colors } = useMemo(() => {
         const rng = mulberry32(137);
         const decoCount = 30;
         const mat = new Float32Array(decoCount * 16);
         const col = new Float32Array(decoCount * 3);
         const dummy = new THREE.Matrix4();
-        const crystalColors = [
-            new THREE.Color('#8866cc'),
-            new THREE.Color('#66aacc'),
-            new THREE.Color('#aa77dd'),
-            new THREE.Color('#5588aa'),
-        ];
-
+        const crystalColors = [new THREE.Color('#8866cc'), new THREE.Color('#66aacc'), new THREE.Color('#aa77dd'), new THREE.Color('#5588aa')];
         let placed = 0;
         for (let attempt = 0; attempt < decoCount * 3 && placed < decoCount; attempt++) {
             const gCol = Math.floor(rng() * GRID_W);
             const gRow = Math.floor(rng() * GRID_H);
-            const kind = getCellKind(gCol, gRow);
-            if (kind === 'empty') continue;
-
+            if (getCellKind(gCol, gRow) === 'empty') continue;
             const scale = 0.03 + rng() * 0.06;
             const hScale = 0.5 + rng() * 2;
             const wx = ORIGIN_X + gCol * CELL + (rng() - 0.5) * CELL * 0.4;
             const wz = ORIGIN_Z + gRow * CELL + (rng() - 0.5) * CELL * 0.4;
-
             dummy.identity();
             dummy.makeTranslation(wx, BLOCK_H * 0.5 + scale * hScale * 0.5, wz);
             dummy.multiply(new THREE.Matrix4().makeScale(scale, scale * hScale, scale));
             dummy.toArray(mat, placed * 16);
-
             const c = crystalColors[Math.floor(rng() * crystalColors.length)];
-            col[placed * 3] = c.r;
-            col[placed * 3 + 1] = c.g;
-            col[placed * 3 + 2] = c.b;
+            col[placed * 3] = c.r; col[placed * 3 + 1] = c.g; col[placed * 3 + 2] = c.b;
             placed++;
         }
-
         return { count: placed, matrices: mat.slice(0, placed * 16), colors: col.slice(0, placed * 3) };
     }, []);
 
@@ -427,28 +343,22 @@ function TerrainDecorations() {
 function HPNumberSprite({ health, maxHealth }: { health: number; maxHealth: number }) {
     const texture = useMemo(() => {
         const canvas = document.createElement('canvas');
-        canvas.width = 64;
-        canvas.height = 24;
+        canvas.width = 64; canvas.height = 24;
         const ctx = canvas.getContext('2d')!;
         ctx.clearRect(0, 0, 64, 24);
         ctx.font = 'bold 18px monospace';
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        ctx.strokeStyle = '#000000';
-        ctx.lineWidth = 3;
-        ctx.strokeText(`${health}/${maxHealth}`, 32, 12);
+        ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+        ctx.strokeStyle = '#000000'; ctx.lineWidth = 3;
+        const txt = `${Math.ceil(health)}/${maxHealth}`;
+        ctx.strokeText(txt, 32, 12);
         const ratio = health / maxHealth;
         ctx.fillStyle = ratio > 0.5 ? '#44dd66' : ratio > 0.25 ? '#ddaa33' : '#dd3333';
-        ctx.fillText(`${health}/${maxHealth}`, 32, 12);
+        ctx.fillText(txt, 32, 12);
         const tex = new THREE.CanvasTexture(canvas);
-        tex.magFilter = THREE.NearestFilter;
-        tex.minFilter = THREE.NearestFilter;
-        tex.generateMipmaps = false;
+        tex.magFilter = THREE.NearestFilter; tex.minFilter = THREE.NearestFilter; tex.generateMipmaps = false;
         return tex;
     }, [health, maxHealth]);
-
     useEffect(() => () => { texture.dispose(); }, [texture]);
-
     return (
         <sprite position={[0, ENEMY_SIZE * 2.15, 0]} scale={[0.38, 0.14, 1]}>
             <spriteMaterial map={texture} transparent depthTest={false} />
@@ -462,7 +372,6 @@ function EnemyHPBar({ health, maxHealth }: { health: number; maxHealth: number }
     const barW = ENEMY_SIZE * 1.3;
     const barH = 0.035;
     const barColor = ratio > 0.5 ? '#44dd66' : ratio > 0.25 ? '#ddaa33' : '#dd3333';
-
     return (
         <group position={[0, ENEMY_SIZE * 1.85, 0]}>
             <HPNumberSprite health={health} maxHealth={maxHealth} />
@@ -478,55 +387,67 @@ function EnemyHPBar({ health, maxHealth }: { health: number; maxHealth: number }
     );
 }
 
-// ===== Pixelated Enemy with smooth movement =====
-function PixelEnemy({ pathPosition, index, health, maxHealth }: {
+// ===== Pixelated Enemy with type-specific visuals =====
+function PixelEnemy({ pathPosition, enemyType, id, health, maxHealth, effects }: {
     pathPosition: number;
-    index: number;
+    enemyType: EnemyType;
+    id: string;
     health: number;
     maxHealth: number;
+    effects: StatusEffect[];
 }) {
     const groupRef = useRef<THREE.Group>(null);
     const smoothRef = useRef({ x: 0, z: 0, angle: 0, init: false });
-    const color = useMemo(() => ENEMY_COLORS[index % ENEMY_COLORS.length], [index]);
+    const idHash = useMemo(() => hashString(id), [id]);
+    const baseColor = useMemo(() => getEnemyColor(enemyType), [enemyType]);
+    const scale = useMemo(() => getEnemyScale(enemyType), [enemyType]);
+
+    // Status effect tints
+    const isSlow = effects.some(e => e.type === 'slow');
+    const isBurn = effects.some(e => e.type === 'burn');
+    const isStun = effects.some(e => e.type === 'stun');
+
+    const bodyColor = useMemo(() => {
+        const c = baseColor.clone();
+        if (isSlow) c.lerp(new THREE.Color('#4488ff'), 0.4);
+        if (isBurn) c.lerp(new THREE.Color('#ff4422'), 0.3);
+        if (isStun) c.lerp(new THREE.Color('#ffff44'), 0.5);
+        return c;
+    }, [baseColor, isSlow, isBurn, isStun]);
 
     useFrame(({ clock }, delta) => {
         if (!groupRef.current) return;
         const target = pathToWorld(pathPosition);
-        const bobY = BLOCK_H * 0.5 + Math.sin(clock.elapsedTime * 2 + index) * 0.04;
-
+        const bobY = BLOCK_H * 0.5 + Math.sin(clock.elapsedTime * 2 + idHash) * 0.04;
         const s = smoothRef.current;
         if (!s.init) {
             s.x = target.x; s.z = target.z; s.angle = target.angle; s.init = true;
         } else {
             const t = 1 - Math.exp(-LERP_SPEED * delta);
-            s.x += (target.x - s.x) * t;
-            s.z += (target.z - s.z) * t;
+            s.x += (target.x - s.x) * t; s.z += (target.z - s.z) * t;
             let ad = target.angle - s.angle;
             if (ad > Math.PI) ad -= Math.PI * 2;
             if (ad < -Math.PI) ad += Math.PI * 2;
             s.angle += ad * t;
         }
-
         groupRef.current.position.set(s.x, bobY, s.z);
         groupRef.current.rotation.y = s.angle;
     });
 
-    const bodyColor = useMemo(() => color.clone(), [color]);
-    const headColor = useMemo(() => color.clone().multiplyScalar(1.15), [color]);
-    const feetColor = useMemo(() => color.clone().multiplyScalar(0.75), [color]);
-
+    const headColor = useMemo(() => bodyColor.clone().multiplyScalar(1.15), [bodyColor]);
+    const feetColor = useMemo(() => bodyColor.clone().multiplyScalar(0.75), [bodyColor]);
     const leftFootRef = useRef<THREE.Mesh>(null);
     const rightFootRef = useRef<THREE.Mesh>(null);
 
     useFrame(({ clock }) => {
         if (!leftFootRef.current || !rightFootRef.current) return;
-        const w = Math.sin(clock.elapsedTime * 6 + index * 2);
+        const w = Math.sin(clock.elapsedTime * 6 + idHash * 2);
         leftFootRef.current.position.z = w * 0.04;
         rightFootRef.current.position.z = -w * 0.04;
     });
 
     return (
-        <group ref={groupRef}>
+        <group ref={groupRef} scale={[scale, scale, scale]}>
             <EnemyHPBar health={health} maxHealth={maxHealth} />
             <mesh position={[0, ENEMY_SIZE * 0.5, 0]}>
                 <boxGeometry args={[ENEMY_SIZE, ENEMY_SIZE, ENEMY_SIZE * 0.8]} />
@@ -557,96 +478,287 @@ function PixelEnemy({ pathPosition, index, health, maxHealth }: {
 }
 
 // ===== Tower Aura =====
-function TowerAura({ active }: { active: boolean }) {
+function TowerAura({ active, color }: { active: boolean; color: THREE.Color }) {
     const meshRef = useRef<THREE.Mesh>(null);
     const matRef = useRef<THREE.MeshBasicMaterial>(null);
     const scaleRef = useRef(0);
-
     useFrame((_, delta) => {
         if (!meshRef.current || !matRef.current) return;
-        if (active && scaleRef.current < 1) {
-            scaleRef.current = Math.min(1, scaleRef.current + delta * 4);
-        } else if (!active && scaleRef.current > 0) {
-            scaleRef.current = Math.max(0, scaleRef.current - delta * 2);
-        }
+        if (active && scaleRef.current < 1) scaleRef.current = Math.min(1, scaleRef.current + delta * 4);
+        else if (!active && scaleRef.current > 0) scaleRef.current = Math.max(0, scaleRef.current - delta * 2);
         const s = scaleRef.current;
         meshRef.current.scale.set(1 + s * 0.8, 1, 1 + s * 0.8);
         matRef.current.opacity = (1 - s) * 0.6;
         meshRef.current.visible = s > 0.01;
     });
-
     return (
         <mesh ref={meshRef} position={[0, TOWER_SIZE * 1.5, 0]} rotation={[-Math.PI / 2, 0, 0]} visible={false}>
             <ringGeometry args={[TOWER_SIZE * 0.8, TOWER_SIZE * 2.2, 8]} />
-            <meshBasicMaterial ref={matRef} color={TOWER_GLOW_COLOR} transparent opacity={0} side={THREE.DoubleSide} />
+            <meshBasicMaterial ref={matRef} color={color} transparent opacity={0} side={THREE.DoubleSide} />
         </mesh>
     );
 }
 
+// ===== Type-specific tower geometry =====
+function TowerBody({ type, level }: { type: TowerType; level: number }) {
+    const colors = TOWER_TYPE_COLORS[type];
+
+    // Common base
+    const base = (
+        <mesh position={[0, TOWER_SIZE * 0.35, 0]}>
+            <boxGeometry args={[TOWER_SIZE * 1.4, TOWER_SIZE * 0.7, TOWER_SIZE * 1.4]} />
+            <meshStandardMaterial color={colors.main} roughness={0.75} flatShading />
+        </mesh>
+    );
+
+    // Type-specific top
+    let top: React.ReactNode;
+    switch (type) {
+        case 'archer': // Tall narrow
+            top = (
+                <mesh position={[0, TOWER_SIZE * 1.5, 0]}>
+                    <boxGeometry args={[TOWER_SIZE * 0.6, TOWER_SIZE * 1.6, TOWER_SIZE * 0.6]} />
+                    <meshStandardMaterial color={colors.accent} roughness={0.65} flatShading />
+                </mesh>
+            );
+            break;
+        case 'cannon': // Squat wide
+            top = (
+                <mesh position={[0, TOWER_SIZE * 1.0, 0]}>
+                    <boxGeometry args={[TOWER_SIZE * 1.2, TOWER_SIZE * 0.8, TOWER_SIZE * 1.2]} />
+                    <meshStandardMaterial color={colors.accent} roughness={0.6} flatShading />
+                </mesh>
+            );
+            break;
+        case 'frost': // Crystal shape
+            top = (
+                <mesh position={[0, TOWER_SIZE * 1.3, 0]} rotation={[0, Math.PI / 4, 0]}>
+                    <boxGeometry args={[TOWER_SIZE * 0.8, TOWER_SIZE * 1.2, TOWER_SIZE * 0.8]} />
+                    <meshStandardMaterial color={colors.accent} roughness={0.3} metalness={0.3} flatShading />
+                </mesh>
+            );
+            break;
+        case 'lightning': // Tall spire
+            top = (
+                <mesh position={[0, TOWER_SIZE * 1.7, 0]}>
+                    <boxGeometry args={[TOWER_SIZE * 0.5, TOWER_SIZE * 2.0, TOWER_SIZE * 0.5]} />
+                    <meshStandardMaterial color={colors.accent} roughness={0.5} metalness={0.2} flatShading />
+                </mesh>
+            );
+            break;
+        case 'sniper': // Narrow tall
+            top = (
+                <mesh position={[0, TOWER_SIZE * 1.6, 0]}>
+                    <boxGeometry args={[TOWER_SIZE * 0.4, TOWER_SIZE * 1.8, TOWER_SIZE * 0.4]} />
+                    <meshStandardMaterial color={colors.accent} roughness={0.7} flatShading />
+                </mesh>
+            );
+            break;
+        case 'flame': // Flickering top
+            top = (
+                <>
+                    <mesh position={[0, TOWER_SIZE * 1.1, 0]}>
+                        <boxGeometry args={[TOWER_SIZE * 1.0, TOWER_SIZE * 1.0, TOWER_SIZE * 1.0]} />
+                        <meshStandardMaterial color={colors.accent} roughness={0.6} flatShading />
+                    </mesh>
+                    <mesh position={[0, TOWER_SIZE * 1.8, 0]}>
+                        <boxGeometry args={[TOWER_SIZE * 0.5, TOWER_SIZE * 0.5, TOWER_SIZE * 0.5]} />
+                        <meshStandardMaterial color="#ff8844" emissive="#ff4422" emissiveIntensity={1.5} roughness={0.2} flatShading />
+                    </mesh>
+                </>
+            );
+            break;
+        case 'arcane': // Floating orb
+            top = (
+                <>
+                    <mesh position={[0, TOWER_SIZE * 1.2, 0]}>
+                        <boxGeometry args={[TOWER_SIZE * 0.8, TOWER_SIZE * 1.0, TOWER_SIZE * 0.8]} />
+                        <meshStandardMaterial color={colors.accent} roughness={0.5} flatShading />
+                    </mesh>
+                    <mesh position={[0, TOWER_SIZE * 2.2, 0]}>
+                        <boxGeometry args={[TOWER_SIZE * 0.45, TOWER_SIZE * 0.45, TOWER_SIZE * 0.45]} />
+                        <meshStandardMaterial color={colors.glow} emissive={colors.glow} emissiveIntensity={2} roughness={0.2} flatShading />
+                    </mesh>
+                </>
+            );
+            break;
+    }
+
+    return (
+        <>
+            {base}
+            {top}
+            {/* Crown for leveled towers */}
+            <mesh position={[0, TOWER_SIZE * 2.8, 0]}>
+                <boxGeometry args={[TOWER_SIZE * 1.2, TOWER_SIZE * 0.25, TOWER_SIZE * 1.2]} />
+                <meshStandardMaterial color={colors.accent} roughness={0.7} flatShading />
+            </mesh>
+            {/* Glow tip */}
+            <mesh position={[0, TOWER_SIZE * 3.2, 0]}>
+                <boxGeometry args={[TOWER_SIZE * 0.35, TOWER_SIZE * 0.4, TOWER_SIZE * 0.35]} />
+                <meshStandardMaterial color={colors.glow} emissive={colors.glow} emissiveIntensity={1.5} roughness={0.2} flatShading />
+            </mesh>
+            <pointLight position={[0, TOWER_SIZE * 3.4, 0]} color={colors.glow} intensity={0.5} distance={1.5} />
+            {level > 1 && (
+                <mesh position={[0, TOWER_SIZE * 3.0, 0]}>
+                    <boxGeometry args={[TOWER_SIZE * 1.0, TOWER_SIZE * 0.12, TOWER_SIZE * 1.0]} />
+                    <meshStandardMaterial color="#ffcc44" emissive="#ffcc44" emissiveIntensity={0.3} roughness={0.5} flatShading />
+                </mesh>
+            )}
+            {level > 2 && (
+                <mesh position={[0, TOWER_SIZE * 3.15, 0]}>
+                    <boxGeometry args={[TOWER_SIZE * 0.8, TOWER_SIZE * 0.08, TOWER_SIZE * 0.8]} />
+                    <meshStandardMaterial color="#ff8844" emissive="#ff8844" emissiveIntensity={0.5} roughness={0.5} flatShading />
+                </mesh>
+            )}
+        </>
+    );
+}
+
 // ===== Tower Mesh =====
-function GridTower({ side, index, charge, maxCharge, level, lineClearPulse }: {
-    side: string;
-    index: number;
-    charge: number;
-    maxCharge: number;
-    level: number;
+function GridTower({ tower, isSelected, lineClearPulse, onClick }: {
+    tower: RingTower;
+    isSelected: boolean;
     lineClearPulse: boolean;
+    onClick: (id: string) => void;
 }) {
     const groupRef = useRef<THREE.Group>(null);
-    const isCharged = charge > 0;
-    const chargeRatio = charge / maxCharge;
+    const colors = TOWER_TYPE_COLORS[tower.type];
 
-    const pos = useMemo(() => towerToWorld(side, index), [side, index]);
+    // The slot stores the per-side index; use tower.side + slot local index for positioning
+    const localIndex = useMemo(() => {
+        // Slots ordered: top(10), bottom(10), left(20), right(20)
+        let idx = tower.slotIndex;
+        const tb = GALAXY_TOWERS_PER_SIDE_TB;
+        const lr = GALAXY_TOWERS_PER_SIDE_LR;
+        if (tower.side === 'top') return idx;
+        idx -= tb;
+        if (tower.side === 'bottom') return idx;
+        idx -= tb;
+        if (tower.side === 'left') return idx;
+        idx -= lr;
+        return idx;
+    }, [tower.slotIndex, tower.side]);
+
+    const towerPos = useMemo(() => towerToWorld(tower.side, localIndex), [tower.side, localIndex]);
 
     useFrame(({ clock }) => {
         if (!groupRef.current) return;
-        groupRef.current.position.set(pos.x, BLOCK_H * 0.5, pos.z);
-        groupRef.current.rotation.y = pos.angle;
-        if (isCharged) {
-            groupRef.current.scale.setScalar(1 + Math.sin(clock.elapsedTime * 3) * 0.05);
+        groupRef.current.position.set(towerPos.x, BLOCK_H * 0.5, towerPos.z);
+        groupRef.current.rotation.y = towerPos.angle;
+        if (isSelected) {
+            groupRef.current.scale.setScalar(1 + Math.sin(clock.elapsedTime * 4) * 0.08);
         } else {
             groupRef.current.scale.setScalar(1);
         }
     });
 
-    const baseColor = isCharged ? TOWER_COLOR_CHARGED : TOWER_COLOR_IDLE;
+    const handleClick = useCallback((e: { stopPropagation: () => void }) => {
+        e.stopPropagation();
+        onClick(tower.id);
+    }, [tower.id, onClick]);
+
+    return (
+        <group ref={groupRef} onPointerDown={handleClick}>
+            <TowerAura active={lineClearPulse} color={colors.glow} />
+            <TowerBody type={tower.type} level={tower.level} />
+            {isSelected && (
+                <mesh position={[0, 0.02, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+                    <ringGeometry args={[TOWER_SIZE * 1.5, TOWER_SIZE * 2.0, 16]} />
+                    <meshBasicMaterial color="#ffffff" transparent opacity={0.3} side={THREE.DoubleSide} />
+                </mesh>
+            )}
+        </group>
+    );
+}
+
+// ===== Empty Tower Slot =====
+function TowerSlotMarker({ slot, highlighted, onSlotClick }: {
+    slot: TowerSlot;
+    highlighted: boolean;
+    onSlotClick: (index: number) => void;
+}) {
+    const groupRef = useRef<THREE.Group>(null);
+    const matRef = useRef<THREE.MeshStandardMaterial>(null);
+
+    // slot.index is the per-side local index
+    const slotPos = useMemo(() => towerToWorld(slot.side, slot.index), [slot.side, slot.index]);
+
+    useFrame(({ clock }) => {
+        if (!groupRef.current) return;
+        groupRef.current.position.set(slotPos.x, BLOCK_H * 0.5, slotPos.z);
+        if (matRef.current) {
+            if (highlighted) {
+                const pulse = 0.4 + Math.sin(clock.elapsedTime * 4) * 0.2;
+                matRef.current.opacity = pulse;
+                matRef.current.color = SLOT_COLOR_HIGHLIGHT;
+            } else {
+                matRef.current.opacity = 0.15;
+                matRef.current.color = SLOT_COLOR_EMPTY;
+            }
+        }
+    });
+
+    const globalIndex = useMemo(() => {
+        const tb = GALAXY_TOWERS_PER_SIDE_TB;
+        const lr = GALAXY_TOWERS_PER_SIDE_LR;
+        switch (slot.side) {
+            case 'top': return slot.index;
+            case 'bottom': return tb + slot.index;
+            case 'left': return 2 * tb + slot.index;
+            case 'right': return 2 * tb + lr + slot.index;
+        }
+    }, [slot.side, slot.index]);
+
+    const handleClick = useCallback((e: { stopPropagation: () => void }) => {
+        e.stopPropagation();
+        onSlotClick(globalIndex);
+    }, [globalIndex, onSlotClick]);
+
+    return (
+        <group ref={groupRef} onPointerDown={handleClick}>
+            <mesh position={[0, SLOT_SIZE * 0.5, 0]}>
+                <boxGeometry args={[SLOT_SIZE, SLOT_SIZE * 0.3, SLOT_SIZE]} />
+                <meshStandardMaterial ref={matRef} color={SLOT_COLOR_EMPTY} transparent opacity={0.15} roughness={0.8} flatShading />
+            </mesh>
+        </group>
+    );
+}
+
+// ===== Projectile =====
+function RingProjectile3D({ projectile }: { projectile: RingProjectile }) {
+    const groupRef = useRef<THREE.Group>(null);
+    const smoothRef = useRef({ x: 0, z: 0, init: false });
+    const colors = TOWER_TYPE_COLORS[projectile.towerType];
+
+    useFrame((_, delta) => {
+        if (!groupRef.current) return;
+        const target = pathToWorld(projectile.pathFraction);
+        const y = BLOCK_H * 0.5 + TOWER_SIZE * 2;
+        const s = smoothRef.current;
+        if (!s.init) {
+            s.x = target.x; s.z = target.z; s.init = true;
+        } else {
+            const t = 1 - Math.exp(-LERP_SPEED * 2 * delta);
+            s.x += (target.x - s.x) * t;
+            s.z += (target.z - s.z) * t;
+        }
+        groupRef.current.position.set(s.x, y, s.z);
+    });
 
     return (
         <group ref={groupRef}>
-            <TowerAura active={lineClearPulse && isCharged} />
-            <mesh position={[0, TOWER_SIZE * 0.35, 0]}>
-                <boxGeometry args={[TOWER_SIZE * 1.4, TOWER_SIZE * 0.7, TOWER_SIZE * 1.4]} />
-                <meshStandardMaterial color={baseColor} roughness={0.75} flatShading />
+            <mesh>
+                <boxGeometry args={[0.06, 0.06, 0.06]} />
+                <meshStandardMaterial
+                    color={colors.glow}
+                    emissive={colors.glow}
+                    emissiveIntensity={3}
+                    roughness={0.2}
+                    flatShading
+                />
             </mesh>
-            <mesh position={[0, TOWER_SIZE * 1.2, 0]}>
-                <boxGeometry args={[TOWER_SIZE * 0.9, TOWER_SIZE * 1.2, TOWER_SIZE * 0.9]} />
-                <meshStandardMaterial color={baseColor} roughness={0.65} flatShading />
-            </mesh>
-            <mesh position={[0, TOWER_SIZE * 2.1, 0]}>
-                <boxGeometry args={[TOWER_SIZE * 1.2, TOWER_SIZE * 0.25, TOWER_SIZE * 1.2]} />
-                <meshStandardMaterial color={isCharged ? '#bb99ff' : '#776699'} roughness={0.7} flatShading />
-            </mesh>
-            {isCharged && (
-                <>
-                    <mesh position={[0, TOWER_SIZE * 2.6, 0]}>
-                        <boxGeometry args={[TOWER_SIZE * 0.35, TOWER_SIZE * 0.5, TOWER_SIZE * 0.35]} />
-                        <meshStandardMaterial
-                            color={TOWER_GLOW_COLOR}
-                            emissive={TOWER_GLOW_COLOR}
-                            emissiveIntensity={chargeRatio * 2.5}
-                            roughness={0.2}
-                            flatShading
-                        />
-                    </mesh>
-                    <pointLight position={[0, TOWER_SIZE * 2.8, 0]} color={TOWER_GLOW_COLOR} intensity={chargeRatio * 0.6} distance={1.5} />
-                </>
-            )}
-            {level > 1 && (
-                <mesh position={[0, TOWER_SIZE * 2.35, 0]}>
-                    <boxGeometry args={[TOWER_SIZE * 1.0, TOWER_SIZE * 0.12, TOWER_SIZE * 1.0]} />
-                    <meshStandardMaterial color="#ffcc44" emissive="#ffcc44" emissiveIntensity={0.3} roughness={0.5} flatShading />
-                </mesh>
-            )}
+            <pointLight color={colors.glow} intensity={0.3} distance={0.8} />
         </group>
     );
 }
@@ -695,18 +807,28 @@ function GalaxyRingScene({
     enemies,
     towers,
     gates,
+    projectiles,
+    towerSlots,
+    selectedTowerType,
+    selectedTowerId,
     lineClearPulse,
+    onSlotClick,
+    onTowerClick,
 }: {
-    enemies: GalaxyRingEnemy[];
-    towers: GalaxyTower[];
+    enemies: RingEnemy[];
+    towers: RingTower[];
     gates: GalaxyGate[];
-    waveNumber: number;
+    projectiles: RingProjectile[];
+    towerSlots: TowerSlot[];
+    selectedTowerType: TowerType | null;
+    selectedTowerId: string | null;
     lineClearPulse: boolean;
+    onSlotClick: (slotIndex: number) => void;
+    onTowerClick: (towerId: string) => void;
 }) {
     return (
         <>
             <PixelFilterSetup />
-
             <ambientLight intensity={0.7} color="#ccccff" />
             <directionalLight position={[5, 10, 5]} intensity={0.9} color="#ffffff" />
             <directionalLight position={[-4, 6, -6]} intensity={0.25} color="#8888cc" />
@@ -719,26 +841,43 @@ function GalaxyRingScene({
                 <TerrainDecorations />
                 <GateMarkers gates={gates} />
 
-                {enemies.filter(e => e.alive).map(enemy => (
-                    <PixelEnemy
-                        key={enemy.id}
-                        pathPosition={enemy.pathPosition}
-                        index={enemy.id}
-                        health={enemy.health}
-                        maxHealth={enemy.maxHealth}
+                {/* Empty tower slots */}
+                {towerSlots.filter(s => !s.occupied).map((slot) => (
+                    <TowerSlotMarker
+                        key={`slot-${slot.side}-${slot.index}`}
+                        slot={slot}
+                        highlighted={selectedTowerType !== null}
+                        onSlotClick={onSlotClick}
                     />
                 ))}
 
+                {/* Placed towers */}
                 {towers.map(tower => (
                     <GridTower
                         key={tower.id}
-                        side={tower.side}
-                        index={tower.index}
-                        charge={tower.charge}
-                        maxCharge={tower.maxCharge}
-                        level={tower.level}
+                        tower={tower}
+                        isSelected={tower.id === selectedTowerId}
                         lineClearPulse={lineClearPulse}
+                        onClick={onTowerClick}
                     />
+                ))}
+
+                {/* Enemies */}
+                {enemies.filter(e => !e.dead).map(enemy => (
+                    <PixelEnemy
+                        key={enemy.id}
+                        pathPosition={enemy.pathFraction}
+                        enemyType={enemy.type}
+                        id={enemy.id}
+                        health={enemy.hp}
+                        maxHealth={enemy.maxHp}
+                        effects={enemy.effects}
+                    />
+                ))}
+
+                {/* Projectiles */}
+                {projectiles.map(proj => (
+                    <RingProjectile3D key={proj.id} projectile={proj} />
                 ))}
             </group>
         </>
@@ -747,14 +886,25 @@ function GalaxyRingScene({
 
 // ===== Exported Canvas wrapper =====
 export interface GalaxyRing3DProps {
-    enemies: GalaxyRingEnemy[];
-    towers: GalaxyTower[];
+    enemies: RingEnemy[];
+    towers: RingTower[];
     gates: GalaxyGate[];
+    projectiles: RingProjectile[];
+    towerSlots: TowerSlot[];
     waveNumber: number;
+    selectedTowerType: TowerType | null;
+    selectedTowerId: string | null;
     lineClearPulse?: boolean;
+    onSlotClick: (slotIndex: number) => void;
+    onTowerClick: (towerId: string) => void;
 }
 
-export function GalaxyRing3D({ enemies, towers, gates, waveNumber, lineClearPulse = false }: GalaxyRing3DProps) {
+export function GalaxyRing3D({
+    enemies, towers, gates, projectiles, towerSlots,
+    selectedTowerType, selectedTowerId,
+    lineClearPulse = false, onSlotClick, onTowerClick,
+}: GalaxyRing3DProps) {
+    const hasInteraction = selectedTowerType !== null || selectedTowerId !== null;
     return (
         <Canvas
             gl={{ antialias: true, alpha: true }}
@@ -764,7 +914,7 @@ export function GalaxyRing3D({ enemies, towers, gates, waveNumber, lineClearPuls
                 inset: 0,
                 width: '100vw',
                 height: '100vh',
-                pointerEvents: 'none',
+                pointerEvents: hasInteraction ? 'auto' : 'none',
                 zIndex: 2,
             }}
         >
@@ -772,8 +922,13 @@ export function GalaxyRing3D({ enemies, towers, gates, waveNumber, lineClearPuls
                 enemies={enemies}
                 towers={towers}
                 gates={gates}
-                waveNumber={waveNumber}
+                projectiles={projectiles}
+                towerSlots={towerSlots}
+                selectedTowerType={selectedTowerType}
+                selectedTowerId={selectedTowerId}
                 lineClearPulse={lineClearPulse}
+                onSlotClick={onSlotClick}
+                onTowerClick={onTowerClick}
             />
         </Canvas>
     );
@@ -788,4 +943,13 @@ function mulberry32(seed: number): () => number {
         t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
         return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
     };
+}
+
+// ===== Simple string hash for stable random =====
+function hashString(s: string): number {
+    let hash = 0;
+    for (let i = 0; i < s.length; i++) {
+        hash = ((hash << 5) - hash + s.charCodeAt(i)) | 0;
+    }
+    return Math.abs(hash);
 }

--- a/src/components/rhythmia/tetris/components/GalaxyRing3D.tsx
+++ b/src/components/rhythmia/tetris/components/GalaxyRing3D.tsx
@@ -1167,7 +1167,10 @@ export function GalaxyRing3D({
                 width: '100vw',
                 height: '100vh',
                 pointerEvents: hasInteraction ? 'auto' : 'none',
-                zIndex: 2,
+                // When interacting (tower placement/selection), raise above game UI (z-index: 3)
+                // so clicks reach the 3D ring instead of being blocked by HTML elements.
+                // When not interacting, stay behind game UI for normal tetris controls.
+                zIndex: hasInteraction ? 4 : 2,
             }}
         >
             <GalaxyRingScene

--- a/src/components/rhythmia/tetris/components/GalaxyRing3D.tsx
+++ b/src/components/rhythmia/tetris/components/GalaxyRing3D.tsx
@@ -67,7 +67,6 @@ const DEPTH = GALAXY_RING_DEPTH;                 // 3
 // ===== 3D sizing =====
 const CELL = 0.32;
 const CELL_GAP = 0.02;
-const BLOCK_H = 0.18;
 const LERP_SPEED = 8;
 const SLOT_SIZE = 0.18;
 
@@ -85,13 +84,28 @@ const TOWER_TYPE_COLORS: Record<TowerType, { main: string; accent: string; glow:
     arcane:    { main: '#c084fc', accent: '#a855f7', glow: '#dd99ff' },
 };
 
-// ===== Path/Terrain colors =====
-const PATH_COLORS = [new THREE.Color('#3a6a4a'), new THREE.Color('#4a7a5a'), new THREE.Color('#3a5a4a'), new THREE.Color('#4a7a5a')];
-const TOWER_LAYER_COLORS = [new THREE.Color('#4a3a6a'), new THREE.Color('#5a4a7a'), new THREE.Color('#3a2a5a')];
-const BUFFER_COLORS = [new THREE.Color('#2a1a4a'), new THREE.Color('#3a2a5a')];
-const CORNER_COLOR = new THREE.Color('#1a1030');
-const SLOT_COLOR_EMPTY = new THREE.Color('#554488');
-const SLOT_COLOR_HIGHLIGHT = new THREE.Color('#8866dd');
+// ===== Terrain colors (matching TD page style) =====
+// Path layer: tan/sandy path tiles (checkerboard pair)
+const PATH_COLOR_A = new THREE.Color('#c4a35a');
+const PATH_COLOR_B = new THREE.Color('#b8944d');
+// Tower layer: grass tiles for tower placement (checkerboard pair)
+const GRASS_COLOR_A = new THREE.Color('#3a7d44');
+const GRASS_COLOR_B = new THREE.Color('#348a3e');
+// Buffer layer: slightly darker grass
+const BUFFER_COLOR_A = new THREE.Color('#2e6836');
+const BUFFER_COLOR_B = new THREE.Color('#296030');
+// Corner cells: mountain/rock
+const CORNER_COLOR_A = new THREE.Color('#6b7280');
+const CORNER_COLOR_B = new THREE.Color('#5f6670');
+// Slot marker colors
+const SLOT_COLOR_EMPTY = new THREE.Color('#88aa66');
+const SLOT_COLOR_HIGHLIGHT = new THREE.Color('#22d3ee');
+
+// Cell heights by type (matching TD page style)
+const HEIGHT_PATH = 0.12;
+const HEIGHT_GRASS = 0.2;
+const HEIGHT_BUFFER = 0.2;
+const HEIGHT_CORNER = 0.35;
 
 // ===== Pixel filter setup =====
 function PixelFilterSetup() {
@@ -171,36 +185,53 @@ function towerToWorld(side: string, index: number): { x: number; z: number; angl
     return { x: pathWorld.x + dx, z: pathWorld.z + dz, angle: pathWorld.angle };
 }
 
-// ===== Terrain Grid =====
+// ===== Terrain Grid (TD-style with checkerboard + varying heights) =====
 function TerrainGrid() {
     const meshRef = useRef<THREE.InstancedMesh>(null);
     const { count, matrices, colors } = useMemo(() => {
         const rng = mulberry32(42);
-        const cells: { x: number; z: number; color: THREE.Color; heightVar: number }[] = [];
+        const cells: { x: number; z: number; color: THREE.Color; height: number }[] = [];
         for (let row = 0; row < GRID_H; row++) {
             for (let col = 0; col < GRID_W; col++) {
                 const kind = getCellKind(col, row);
                 if (kind === 'empty') continue;
                 const wx = ORIGIN_X + col * CELL;
                 const wz = ORIGIN_Z + row * CELL;
-                const hv = (rng() - 0.5) * 0.04;
+                const checker = (col + row) % 2 === 0;
                 let color: THREE.Color;
+                let height: number;
                 switch (kind) {
-                    case 'path': color = PATH_COLORS[Math.floor(rng() * PATH_COLORS.length)]; break;
-                    case 'tower': color = TOWER_LAYER_COLORS[Math.floor(rng() * TOWER_LAYER_COLORS.length)]; break;
-                    case 'buffer': color = BUFFER_COLORS[Math.floor(rng() * BUFFER_COLORS.length)]; break;
-                    default: color = CORNER_COLOR.clone();
+                    case 'path':
+                        color = checker ? PATH_COLOR_A : PATH_COLOR_B;
+                        height = HEIGHT_PATH;
+                        break;
+                    case 'tower':
+                        color = checker ? GRASS_COLOR_A : GRASS_COLOR_B;
+                        height = HEIGHT_GRASS;
+                        break;
+                    case 'buffer':
+                        color = checker ? BUFFER_COLOR_A : BUFFER_COLOR_B;
+                        height = HEIGHT_BUFFER;
+                        break;
+                    default:
+                        color = checker ? CORNER_COLOR_A : CORNER_COLOR_B;
+                        height = HEIGHT_CORNER + rng() * 0.05;
+                        break;
                 }
-                cells.push({ x: wx, z: wz, color, heightVar: hv });
+                cells.push({ x: wx, z: wz, color, height });
             }
         }
         const totalBlocks = cells.length;
         const mat = new Float32Array(totalBlocks * 16);
         const col = new Float32Array(totalBlocks * 3);
         const dummy = new THREE.Matrix4();
+        const scale = new THREE.Matrix4();
+        const blockSize = CELL - CELL_GAP;
         for (let i = 0; i < totalBlocks; i++) {
             const c = cells[i];
-            dummy.makeTranslation(c.x, c.heightVar, c.z);
+            dummy.makeTranslation(c.x, c.height * 0.5, c.z);
+            scale.makeScale(blockSize, c.height, blockSize);
+            dummy.multiply(scale);
             dummy.toArray(mat, i * 16);
             col[i * 3] = c.color.r; col[i * 3 + 1] = c.color.g; col[i * 3 + 2] = c.color.b;
         }
@@ -219,11 +250,10 @@ function TerrainGrid() {
         mesh.instanceMatrix.needsUpdate = true;
     }, [count, matrices, colors]);
 
-    const blockSize = CELL - CELL_GAP;
     return (
         <instancedMesh ref={meshRef} args={[undefined, undefined, count]} castShadow={false} receiveShadow={false}>
-            <boxGeometry args={[blockSize, BLOCK_H, blockSize]} />
-            <meshStandardMaterial vertexColors roughness={0.85} metalness={0.05} flatShading />
+            <boxGeometry args={[1, 1, 1]} />
+            <meshStandardMaterial vertexColors roughness={0.8} metalness={0.05} flatShading />
         </instancedMesh>
     );
 }
@@ -242,7 +272,7 @@ function TerrainUnderside() {
         const mat = new Float32Array(cells.length * 16);
         const dummy = new THREE.Matrix4();
         for (let i = 0; i < cells.length; i++) {
-            dummy.makeTranslation(cells[i].x, -BLOCK_H * 0.6, cells[i].z);
+            dummy.makeTranslation(cells[i].x, -0.06, cells[i].z);
             dummy.toArray(mat, i * 16);
         }
         return { count: cells.length, matrices: mat };
@@ -262,8 +292,8 @@ function TerrainUnderside() {
     const blockSize = CELL - CELL_GAP;
     return (
         <instancedMesh ref={meshRef} args={[undefined, undefined, count]}>
-            <boxGeometry args={[blockSize, BLOCK_H * 0.5, blockSize]} />
-            <meshStandardMaterial color="#1a0e30" roughness={0.95} flatShading />
+            <boxGeometry args={[blockSize, 0.08, blockSize]} />
+            <meshStandardMaterial color="#3d2b1a" roughness={0.95} flatShading />
         </instancedMesh>
     );
 }
@@ -275,7 +305,7 @@ function GroundPlane() {
         canvas.width = 16; canvas.height = 16;
         const ctx = canvas.getContext('2d')!;
         const rng = mulberry32(99);
-        const cs = ['#0e0818', '#120c20', '#160e28', '#0e0a1a', '#100c1e'];
+        const cs = ['#2a4a2a', '#1e3a1e', '#243e24', '#1a361a', '#223c22'];
         for (let x = 0; x < 16; x++) {
             for (let y = 0; y < 16; y++) {
                 ctx.fillStyle = cs[Math.floor(rng() * cs.length)];
@@ -288,9 +318,9 @@ function GroundPlane() {
     }, []);
     const size = Math.max(GRID_W, GRID_H) * CELL * 2;
     return (
-        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -BLOCK_H, 0]}>
+        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.05, 0]}>
             <planeGeometry args={[size, size]} />
-            <meshStandardMaterial map={texture} roughness={0.95} transparent opacity={0.45} />
+            <meshStandardMaterial map={texture} roughness={0.95} transparent opacity={0.6} />
         </mesh>
     );
 }
@@ -298,7 +328,7 @@ function GroundPlane() {
 // ===== Path outline =====
 function PathOutline() {
     const points = useMemo(() => {
-        const y = BLOCK_H * 0.5 + 0.01;
+        const y = HEIGHT_PATH + 0.01;
         const halfW = (GRID_W - 1) * CELL * 0.5 + CELL * 0.5;
         const topZ = ORIGIN_Z - CELL * 0.5;
         const botZ = ORIGIN_Z + (GRID_H - 1) * CELL + CELL * 0.5;
@@ -312,7 +342,7 @@ function PathOutline() {
     return (
         <line>
             <bufferGeometry attach="geometry" {...lineGeo} />
-            <lineBasicMaterial color="#9977ee" transparent opacity={0.5} />
+            <lineBasicMaterial color="#fbbf24" transparent opacity={0.5} />
         </line>
     );
 }
@@ -326,7 +356,7 @@ function TerrainDecorations() {
         const mat = new Float32Array(decoCount * 16);
         const col = new Float32Array(decoCount * 3);
         const dummy = new THREE.Matrix4();
-        const crystalColors = [new THREE.Color('#8866cc'), new THREE.Color('#66aacc'), new THREE.Color('#aa77dd'), new THREE.Color('#5588aa')];
+        const crystalColors = [new THREE.Color('#6b8e23'), new THREE.Color('#8b7355'), new THREE.Color('#556b2f'), new THREE.Color('#8fbc8f')];
         let placed = 0;
         for (let attempt = 0; attempt < decoCount * 3 && placed < decoCount; attempt++) {
             const gCol = Math.floor(rng() * GRID_W);
@@ -337,7 +367,7 @@ function TerrainDecorations() {
             const wx = ORIGIN_X + gCol * CELL + (rng() - 0.5) * CELL * 0.4;
             const wz = ORIGIN_Z + gRow * CELL + (rng() - 0.5) * CELL * 0.4;
             dummy.identity();
-            dummy.makeTranslation(wx, BLOCK_H * 0.5 + scale * hScale * 0.5, wz);
+            dummy.makeTranslation(wx, HEIGHT_GRASS + scale * hScale * 0.5, wz);
             dummy.multiply(new THREE.Matrix4().makeScale(scale, scale * hScale, scale));
             dummy.toArray(mat, placed * 16);
             const c = crystalColors[Math.floor(rng() * crystalColors.length)];
@@ -514,8 +544,8 @@ function MobEnemy({ pathPosition, enemyType, id, health, maxHealth, effects, fly
         if (!groupRef.current) return;
         const target = pathToWorld(pathPosition);
         const bobY = flying
-            ? BLOCK_H * 0.5 + 0.3 + Math.sin(clock.elapsedTime * 2 + idHash) * 0.08
-            : BLOCK_H * 0.5 + Math.sin(clock.elapsedTime * 4 + idHash) * 0.02;
+            ? HEIGHT_PATH + 0.3 + Math.sin(clock.elapsedTime * 2 + idHash) * 0.08
+            : HEIGHT_PATH + Math.sin(clock.elapsedTime * 4 + idHash) * 0.02;
         const s = smoothRef.current;
         if (!s.init) {
             s.x = target.x; s.z = target.z; s.angle = target.angle; s.init = true;
@@ -765,7 +795,7 @@ function MobTower({ tower, isSelected, lineClearPulse, onClick }: {
 
     useFrame(({ clock }) => {
         if (!groupRef.current) return;
-        groupRef.current.position.set(towerPos.x, BLOCK_H * 0.5, towerPos.z);
+        groupRef.current.position.set(towerPos.x, HEIGHT_GRASS * 0.5, towerPos.z);
 
         if (isSelected) {
             groupRef.current.scale.setScalar(1 + Math.sin(clock.elapsedTime * 4) * 0.08);
@@ -875,7 +905,7 @@ function TowerSlotMarker({ slot, highlighted, onSlotClick }: {
 
     useFrame(({ clock }) => {
         if (!groupRef.current) return;
-        groupRef.current.position.set(slotPos.x, BLOCK_H * 0.5, slotPos.z);
+        groupRef.current.position.set(slotPos.x, HEIGHT_GRASS * 0.5, slotPos.z);
         if (matRef.current) {
             if (highlighted) {
                 const pulse = 0.4 + Math.sin(clock.elapsedTime * 4) * 0.2;
@@ -904,16 +934,15 @@ function TowerSlotMarker({ slot, highlighted, onSlotClick }: {
         onSlotClick(globalIndex);
     }, [globalIndex, onSlotClick]);
 
-    const HIT_SIZE = 0.4; // Larger invisible hitbox for reliable raycasting
     return (
         <group ref={groupRef}>
-            {/* Invisible larger hitbox for click detection */}
-            <mesh position={[0, SLOT_SIZE * 0.5 + 0.05, 0]} onPointerDown={handleClick}>
-                <boxGeometry args={[HIT_SIZE, HIT_SIZE, HIT_SIZE]} />
+            {/* Invisible hitbox for reliable click detection */}
+            <mesh position={[0, 0.12, 0]} onPointerDown={handleClick}>
+                <boxGeometry args={[0.28, 0.24, 0.28]} />
                 <meshBasicMaterial visible={false} />
             </mesh>
             {/* Visible slot marker */}
-            <mesh position={[0, SLOT_SIZE * 0.5, 0]}>
+            <mesh position={[0, HEIGHT_GRASS * 0.5 + 0.02, 0]}>
                 <boxGeometry args={[SLOT_SIZE, SLOT_SIZE * 0.3, SLOT_SIZE]} />
                 <meshStandardMaterial ref={matRef} color={SLOT_COLOR_EMPTY} transparent opacity={0.15} roughness={0.8} flatShading />
             </mesh>
@@ -944,7 +973,7 @@ function RingProjectile3D({ projectile }: { projectile: RingProjectile }) {
     useFrame((state, delta) => {
         if (!groupRef.current || !projRef.current) return;
         const target = pathToWorld(projectile.pathFraction);
-        const y = BLOCK_H * 0.5 + 0.25;
+        const y = HEIGHT_GRASS * 0.5 + 0.25;
         const s = smoothRef.current;
         if (!s.init) {
             s.x = target.x; s.z = target.z; s.init = true;
@@ -991,7 +1020,7 @@ function GateMarkers({ gates }: { gates: GalaxyGate[] }) {
             {positions.map(({ x, z, angle, ratio, side }) => {
                 const gateColor = ratio > 0.5 ? '#44ff88' : ratio > 0.25 ? '#ffaa44' : '#ff4444';
                 return (
-                    <group key={side} position={[x, BLOCK_H * 0.5, z]} rotation={[0, angle, 0]}>
+                    <group key={side} position={[x, HEIGHT_PATH, z]} rotation={[0, angle, 0]}>
                         <mesh position={[-0.12, 0.2, 0]}>
                             <boxGeometry args={[0.08, 0.4, 0.08]} />
                             <meshStandardMaterial color={gateColor} emissive={gateColor} emissiveIntensity={0.6} roughness={0.4} flatShading />

--- a/src/components/rhythmia/tetris/components/GalaxyTDPanel.module.css
+++ b/src/components/rhythmia/tetris/components/GalaxyTDPanel.module.css
@@ -1,0 +1,242 @@
+/* ===== Galaxy TD Panel — HUD overlay ===== */
+
+.panel {
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: 15;
+    font-family: 'Inter', sans-serif;
+}
+
+/* ===== Top Bar: Gold, Lives, Wave ===== */
+.topBar {
+    position: absolute;
+    top: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    pointer-events: auto;
+}
+
+.pill {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    border-radius: 20px;
+    background: rgba(30, 15, 60, 0.85);
+    border: 1px solid rgba(140, 100, 255, 0.3);
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: rgba(220, 200, 255, 0.9);
+    backdrop-filter: blur(6px);
+    white-space: nowrap;
+}
+
+.pillIcon {
+    font-size: 0.85rem;
+}
+
+.goldPill {
+    color: #ffd700;
+    border-color: rgba(255, 215, 0, 0.3);
+}
+
+.livesPill {
+    color: #ff6b6b;
+    border-color: rgba(255, 107, 107, 0.3);
+}
+
+.wavePill {
+    color: rgba(180, 140, 255, 0.9);
+}
+
+/* ===== Bottom Tower Bar ===== */
+.towerBar {
+    position: absolute;
+    bottom: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 6px;
+    pointer-events: auto;
+}
+
+.towerCard {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 6px 8px;
+    border-radius: 8px;
+    background: rgba(30, 15, 60, 0.85);
+    border: 1px solid rgba(140, 100, 255, 0.2);
+    cursor: pointer;
+    transition: border-color 0.15s, transform 0.1s;
+    backdrop-filter: blur(6px);
+    min-width: 56px;
+    user-select: none;
+}
+
+.towerCard:hover {
+    border-color: rgba(140, 100, 255, 0.6);
+    transform: translateY(-2px);
+}
+
+.towerCardSelected {
+    border-color: rgba(140, 100, 255, 0.9);
+    background: rgba(60, 30, 120, 0.9);
+    box-shadow: 0 0 12px rgba(140, 100, 255, 0.3);
+}
+
+.towerCardDisabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.towerCardDisabled:hover {
+    border-color: rgba(140, 100, 255, 0.2);
+    transform: none;
+}
+
+.towerSwatch {
+    width: 20px;
+    height: 20px;
+    border-radius: 4px;
+    margin-bottom: 2px;
+}
+
+.towerName {
+    font-size: 0.55rem;
+    font-weight: 600;
+    color: rgba(220, 200, 255, 0.8);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.towerCost {
+    font-size: 0.55rem;
+    color: #ffd700;
+    font-weight: 700;
+}
+
+.towerHotkey {
+    font-size: 0.5rem;
+    color: rgba(160, 140, 200, 0.5);
+    margin-top: 1px;
+}
+
+/* ===== Selected Tower Side Panel ===== */
+.selectedPanel {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+    border-radius: 10px;
+    background: rgba(30, 15, 60, 0.9);
+    border: 1px solid rgba(140, 100, 255, 0.3);
+    backdrop-filter: blur(6px);
+    pointer-events: auto;
+    min-width: 140px;
+}
+
+.selectedName {
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: rgba(220, 200, 255, 0.95);
+}
+
+.selectedLevel {
+    font-size: 0.6rem;
+    color: rgba(180, 140, 255, 0.7);
+    font-weight: 600;
+}
+
+.selectedStat {
+    font-size: 0.6rem;
+    color: rgba(200, 180, 240, 0.7);
+}
+
+.selectedSpecial {
+    font-size: 0.55rem;
+    color: rgba(140, 200, 255, 0.7);
+    font-style: italic;
+}
+
+.selectedButtons {
+    display: flex;
+    gap: 6px;
+    margin-top: 4px;
+}
+
+.upgradeBtn, .sellBtn {
+    flex: 1;
+    padding: 4px 8px;
+    border-radius: 6px;
+    border: 1px solid rgba(140, 100, 255, 0.3);
+    font-size: 0.6rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.upgradeBtn {
+    background: rgba(60, 140, 60, 0.6);
+    color: #88ff88;
+}
+
+.upgradeBtn:hover {
+    background: rgba(60, 140, 60, 0.8);
+}
+
+.upgradeBtn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.sellBtn {
+    background: rgba(140, 60, 60, 0.6);
+    color: #ff8888;
+}
+
+.sellBtn:hover {
+    background: rgba(140, 60, 60, 0.8);
+}
+
+/* ===== Mobile: simplify layout ===== */
+@media (max-width: 768px) {
+    .topBar {
+        top: 4px;
+        gap: 6px;
+    }
+
+    .pill {
+        padding: 3px 8px;
+        font-size: 0.65rem;
+    }
+
+    .towerBar {
+        bottom: 4px;
+        gap: 4px;
+    }
+
+    .towerCard {
+        padding: 4px 6px;
+        min-width: 44px;
+    }
+
+    .towerName {
+        display: none;
+    }
+
+    .selectedPanel {
+        right: 4px;
+        padding: 8px;
+        min-width: 110px;
+    }
+}

--- a/src/components/rhythmia/tetris/components/GalaxyTDPanel.tsx
+++ b/src/components/rhythmia/tetris/components/GalaxyTDPanel.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import React, { useCallback, useEffect } from 'react';
+import type { TowerType, RingTower } from '../galaxy-types';
+import { TOWER_DEFS } from '@/types/tower-defense';
+import styles from './GalaxyTDPanel.module.css';
+
+const TOWER_TYPES: TowerType[] = ['archer', 'cannon', 'frost', 'lightning', 'sniper', 'flame', 'arcane'];
+
+interface GalaxyTDPanelProps {
+    gold: number;
+    lives: number;
+    waveNumber: number;
+    totalWaves: number;
+    selectedTowerType: TowerType | null;
+    selectedTowerId: string | null;
+    towers: RingTower[];
+    onSelectTowerType: (type: TowerType | null) => void;
+    onUpgradeTower: (towerId: string) => void;
+    onSellTower: (towerId: string) => void;
+}
+
+export function GalaxyTDPanel({
+    gold,
+    lives,
+    waveNumber,
+    totalWaves,
+    selectedTowerType,
+    selectedTowerId,
+    towers,
+    onSelectTowerType,
+    onUpgradeTower,
+    onSellTower,
+}: GalaxyTDPanelProps) {
+    const selectedTower = selectedTowerId ? towers.find(t => t.id === selectedTowerId) : null;
+    const selectedDef = selectedTower ? TOWER_DEFS[selectedTower.type] : null;
+
+    // Hotkeys 1-7 for tower selection
+    useEffect(() => {
+        function handleKeyDown(e: KeyboardEvent) {
+            const num = parseInt(e.key);
+            if (num >= 1 && num <= 7) {
+                const type = TOWER_TYPES[num - 1];
+                onSelectTowerType(selectedTowerType === type ? null : type);
+            }
+            if (e.key === 'Escape') {
+                onSelectTowerType(null);
+            }
+        }
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [selectedTowerType, onSelectTowerType]);
+
+    const handleCardClick = useCallback((type: TowerType) => {
+        const def = TOWER_DEFS[type];
+        if (gold < def.cost) return;
+        onSelectTowerType(selectedTowerType === type ? null : type);
+    }, [gold, selectedTowerType, onSelectTowerType]);
+
+    return (
+        <div className={styles.panel}>
+            {/* Top bar: Gold, Lives, Wave */}
+            <div className={styles.topBar}>
+                <div className={`${styles.pill} ${styles.goldPill}`}>
+                    <span className={styles.pillIcon}>&#x2B50;</span>
+                    {gold}
+                </div>
+                <div className={`${styles.pill} ${styles.livesPill}`}>
+                    <span className={styles.pillIcon}>&#x2764;</span>
+                    {lives}
+                </div>
+                <div className={`${styles.pill} ${styles.wavePill}`}>
+                    W{waveNumber}/{totalWaves}
+                </div>
+            </div>
+
+            {/* Bottom tower bar */}
+            <div className={styles.towerBar}>
+                {TOWER_TYPES.map((type, i) => {
+                    const def = TOWER_DEFS[type];
+                    const canAfford = gold >= def.cost;
+                    const isSelected = selectedTowerType === type;
+                    return (
+                        <div
+                            key={type}
+                            className={`${styles.towerCard} ${isSelected ? styles.towerCardSelected : ''} ${!canAfford ? styles.towerCardDisabled : ''}`}
+                            onClick={() => handleCardClick(type)}
+                        >
+                            <div
+                                className={styles.towerSwatch}
+                                style={{ background: def.color }}
+                            />
+                            <span className={styles.towerName}>{type}</span>
+                            <span className={styles.towerCost}>{def.cost}</span>
+                            <span className={styles.towerHotkey}>{i + 1}</span>
+                        </div>
+                    );
+                })}
+            </div>
+
+            {/* Selected tower info panel */}
+            {selectedTower && selectedDef && (
+                <div className={styles.selectedPanel}>
+                    <div className={styles.selectedName}>{selectedDef.name}</div>
+                    <div className={styles.selectedLevel}>Lv.{selectedTower.level}/{selectedDef.maxLevel}</div>
+                    <div className={styles.selectedStat}>
+                        DMG: {selectedDef.damagePerLevel[selectedTower.level - 1] ?? selectedDef.damage}
+                    </div>
+                    <div className={styles.selectedStat}>
+                        Kills: {selectedTower.kills}
+                    </div>
+                    {selectedDef.special && (
+                        <div className={styles.selectedSpecial}>{selectedDef.special}</div>
+                    )}
+                    <div className={styles.selectedButtons}>
+                        {selectedTower.level < selectedDef.maxLevel && (
+                            <button
+                                className={styles.upgradeBtn}
+                                disabled={gold < selectedDef.upgradeCosts[selectedTower.level - 1]}
+                                onClick={() => onUpgradeTower(selectedTower.id)}
+                            >
+                                UP {selectedDef.upgradeCosts[selectedTower.level - 1]}
+                            </button>
+                        )}
+                        <button
+                            className={styles.sellBtn}
+                            onClick={() => onSellTower(selectedTower.id)}
+                        >
+                            SELL
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/rhythmia/tetris/galaxy-constants.ts
+++ b/src/components/rhythmia/tetris/galaxy-constants.ts
@@ -17,42 +17,50 @@ export const GALAXY_SIDE_HEIGHT = VISIBLE_HEIGHT;                       // 20
 export const GALAXY_PATH_LENGTH =
     GALAXY_TOP_WIDTH + GALAXY_SIDE_HEIGHT + GALAXY_TOP_WIDTH + GALAXY_SIDE_HEIGHT;
 
-// ===== Tower Settings =====
-export const GALAXY_TOWER_MAX_CHARGE = 5;
-export const GALAXY_TOWER_DAMAGE = 1;
-export const GALAXY_TOWER_FIRE_INTERVAL = 2000;  // ms between auto-fires
-export const GALAXY_TOWER_RANGE = 0.15;           // Path-fraction range for targeting
-
+// ===== Tower Slot Layout =====
 // Number of tower slots per side
 export const GALAXY_TOWERS_PER_SIDE_TB = BOARD_WIDTH;   // 10 towers on top/bottom
 export const GALAXY_TOWERS_PER_SIDE_LR = VISIBLE_HEIGHT; // 20 towers on left/right
 
-// ===== Enemy Settings =====
-export const GALAXY_ENEMY_BASE_SPEED = 0.02;   // Path-fraction per beat
-export const GALAXY_ENEMY_BASE_HP = 3;
-export const GALAXY_ENEMIES_PER_WAVE = 4;
-export const GALAXY_WAVE_SPAWN_INTERVAL = 2;    // Beats between enemy spawns within a wave
-export const GALAXY_WAVE_COOLDOWN = 6;          // Beats between waves
+// ===== Gold Economy (replaces old charge system) =====
+export const GALAXY_INITIAL_GOLD = 200;
+export const GALAXY_INITIAL_LIVES = 10;
+
+export const GALAXY_GOLD_PER_SINGLE = 25;
+export const GALAXY_GOLD_PER_DOUBLE = 60;
+export const GALAXY_GOLD_PER_TRIPLE = 100;
+export const GALAXY_GOLD_PER_TETRIS = 175;
+
+export const GALAXY_TETRIS_AOE_DAMAGE = 50;  // Scaled for real HP pools
+
+// ===== Wave Timing =====
+export const GALAXY_WAVE_PREP_BEATS = 8;     // Build phase between waves
+export const GALAXY_RING_TOTAL_WAVES = 30;
+
+// ===== Speed Conversion =====
+// Enemy speeds from ENEMY_DEFS are in cells/second on a 2D grid.
+// Ring path is 72 cells. Divisor converts to path-fraction/second.
+// Using 24 instead of 72 for faster ring traversal (~16s for grunts).
+export const GALAXY_SPEED_DIVISOR = 24;
+
+// ===== Range Conversion =====
+// Tower ranges from TOWER_DEFS are in grid cells.
+// Convert to path-fraction: range / GALAXY_PATH_LENGTH
+export const GALAXY_RANGE_DIVISOR = GALAXY_PATH_LENGTH; // 72
+
+// ===== Sell Refund =====
+export const GALAXY_SELL_REFUND_RATE = 0.7;  // 70% of total invested
 
 // ===== Gate Settings =====
 export const GALAXY_GATE_HP = 50;
 
 // Gate positions on the ring (path-fraction) — midpoint of each side
-// Top midpoint: 0.5 * (GALAXY_TOP_WIDTH / GALAXY_PATH_LENGTH)
-// Right midpoint: (GALAXY_TOP_WIDTH + 0.5 * GALAXY_SIDE_HEIGHT) / GALAXY_PATH_LENGTH
-// etc.
 export const GALAXY_GATE_POSITIONS = {
     top:    (GALAXY_TOP_WIDTH * 0.5) / GALAXY_PATH_LENGTH,
     right:  (GALAXY_TOP_WIDTH + GALAXY_SIDE_HEIGHT * 0.5) / GALAXY_PATH_LENGTH,
     bottom: (GALAXY_TOP_WIDTH + GALAXY_SIDE_HEIGHT + GALAXY_TOP_WIDTH * 0.5) / GALAXY_PATH_LENGTH,
     left:   (GALAXY_TOP_WIDTH + GALAXY_SIDE_HEIGHT + GALAXY_TOP_WIDTH + GALAXY_SIDE_HEIGHT * 0.5) / GALAXY_PATH_LENGTH,
 } as const;
-
-// ===== Line Clear → Tower Effects =====
-export const GALAXY_CHARGE_PER_SINGLE = 1;
-export const GALAXY_CHARGE_PER_DOUBLE = 2;
-export const GALAXY_CHARGE_PER_TRIPLE = 3;     // Also triggers burst fire on all charged towers
-export const GALAXY_TETRIS_AOE_DAMAGE = 2;     // Damages all alive enemies on the ring
 
 // ===== Path Segment Boundaries =====
 // Maps path-fraction ranges to ring sides (clockwise starting from top-left)

--- a/src/components/rhythmia/tetris/galaxy-types.ts
+++ b/src/components/rhythmia/tetris/galaxy-types.ts
@@ -1,43 +1,87 @@
 // ===== Galaxy Architecture Types =====
 // The "Galaxy" layout wraps the Tetris board with a square TD ring.
-// Enemies travel clockwise along the outer path; towers sit on the inner ring.
+// Rich tower defense mechanics: 7 tower types, 8 enemy types, status effects.
+
+import type { TowerType, EnemyType, StatusEffect, SpawnTracker } from '@/types/tower-defense';
+
+// Re-export for convenience
+export type { TowerType, EnemyType, StatusEffect };
 
 export type GalaxyRingSide = 'top' | 'bottom' | 'left' | 'right';
 
-// A tower placed on the inner ring of one side
-export type GalaxyTower = {
-    id: number;
+// A tower placed on the ring
+export interface RingTower {
+    id: string;
+    type: TowerType;
     side: GalaxyRingSide;
-    index: number;         // position along that side's tower row (0-based)
-    charge: number;        // 0–maxCharge, increases from tetris line clears
-    maxCharge: number;
-    lastFireTime: number;
-    level: number;         // increments when charge overflows maxCharge
-};
+    slotIndex: number;
+    pathFraction: number;
+    level: number;
+    cooldown: number;
+    kills: number;
+    totalDamage: number;
+    targetId: string | null;
+}
 
 // An enemy traveling along the outer ring path
-export type GalaxyRingEnemy = {
-    id: number;
-    pathPosition: number;  // 0.0–1.0 along the full ring loop (clockwise)
-    speed: number;         // path-fraction per tick
-    health: number;
-    maxHealth: number;
-    alive: boolean;
-    spawnTime: number;
-};
+export interface RingEnemy {
+    id: string;
+    type: EnemyType;
+    pathFraction: number;   // 0.0–1.0 along the full ring loop (clockwise)
+    hp: number;
+    maxHp: number;
+    speed: number;           // path-fraction per second
+    armor: number;
+    effects: StatusEffect[];
+    flying: boolean;
+    dead: boolean;
+}
+
+// A projectile traveling from tower to enemy
+export interface RingProjectile {
+    id: string;
+    towerId: string;
+    towerType: TowerType;
+    targetId: string;
+    pathFraction: number;
+    damage: number;
+    speed: number;           // path-fraction per second
+    effects?: StatusEffect[];
+}
+
+// A slot on the ring where a tower can be placed
+export interface TowerSlot {
+    side: GalaxyRingSide;
+    index: number;
+    pathFraction: number;
+    occupied: boolean;
+    towerId: string | null;
+}
 
 // A gate at the midpoint of each side — enemies loop past gates
-export type GalaxyGate = {
+export interface GalaxyGate {
     side: GalaxyRingSide;
     health: number;
     maxHealth: number;
-};
+}
+
+// Ring TD game phase
+export type RingTDPhase = 'build' | 'wave' | 'won' | 'lost';
 
 // Full galaxy TD state snapshot
-export type GalaxyTDState = {
-    enemies: GalaxyRingEnemy[];
-    towers: GalaxyTower[];
+export interface GalaxyTDState {
+    phase: RingTDPhase;
+    gold: number;
+    lives: number;
+    score: number;
+    currentWave: number;
+    totalWaves: number;
+    towers: RingTower[];
+    enemies: RingEnemy[];
+    projectiles: RingProjectile[];
     gates: GalaxyGate[];
-    waveNumber: number;
-    beatsSinceLastSpawn: number;
-};
+    towerSlots: TowerSlot[];
+    selectedTowerType: TowerType | null;
+    selectedTowerId: string | null;
+    spawnTracker: SpawnTracker | null;
+}

--- a/src/components/rhythmia/tetris/hooks/useGalaxyTD.ts
+++ b/src/components/rhythmia/tetris/hooks/useGalaxyTD.ts
@@ -1,352 +1,149 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
-import type { GalaxyRingEnemy, GalaxyTower, GalaxyGate, GalaxyRingSide } from '../galaxy-types';
+import type { TowerType, GalaxyTDState } from '../galaxy-types';
 import {
-    GALAXY_ENEMY_BASE_SPEED,
-    GALAXY_ENEMY_BASE_HP,
-    GALAXY_ENEMIES_PER_WAVE,
-    GALAXY_WAVE_SPAWN_INTERVAL,
-    GALAXY_WAVE_COOLDOWN,
-    GALAXY_GATE_HP,
-    GALAXY_TOWER_MAX_CHARGE,
-    GALAXY_TOWER_DAMAGE,
-    GALAXY_TOWER_RANGE,
-    GALAXY_CHARGE_PER_SINGLE,
-    GALAXY_CHARGE_PER_DOUBLE,
-    GALAXY_CHARGE_PER_TRIPLE,
+    GALAXY_GOLD_PER_SINGLE,
+    GALAXY_GOLD_PER_DOUBLE,
+    GALAXY_GOLD_PER_TRIPLE,
+    GALAXY_GOLD_PER_TETRIS,
     GALAXY_TETRIS_AOE_DAMAGE,
-    GALAXY_TOWERS_PER_SIDE_TB,
-    GALAXY_TOWERS_PER_SIDE_LR,
-    GALAXY_SIDE_BOUNDARIES,
 } from '../galaxy-constants';
-
-let nextEnemyId = 1;
-let nextTowerId = 1;
-
-// ===== Initial tower layout (pre-placed at fixed positions) =====
-function createInitialTowers(): GalaxyTower[] {
-    const towers: GalaxyTower[] = [];
-    const sides: { side: GalaxyRingSide; count: number }[] = [
-        { side: 'top', count: GALAXY_TOWERS_PER_SIDE_TB },
-        { side: 'bottom', count: GALAXY_TOWERS_PER_SIDE_TB },
-        { side: 'left', count: GALAXY_TOWERS_PER_SIDE_LR },
-        { side: 'right', count: GALAXY_TOWERS_PER_SIDE_LR },
-    ];
-
-    for (const { side, count } of sides) {
-        for (let i = 0; i < count; i++) {
-            towers.push({
-                id: nextTowerId++,
-                side,
-                index: i,
-                charge: 0,
-                maxCharge: GALAXY_TOWER_MAX_CHARGE,
-                lastFireTime: 0,
-                level: 1,
-            });
-        }
-    }
-    return towers;
-}
-
-// ===== Initial gates =====
-function createInitialGates(): GalaxyGate[] {
-    return (['top', 'right', 'bottom', 'left'] as GalaxyRingSide[]).map(side => ({
-        side,
-        health: GALAXY_GATE_HP,
-        maxHealth: GALAXY_GATE_HP,
-    }));
-}
-
-// Get the path-fraction position for a tower based on its side and index
-function getTowerPathPosition(tower: GalaxyTower): number {
-    const bounds = GALAXY_SIDE_BOUNDARIES[tower.side];
-    const count = (tower.side === 'top' || tower.side === 'bottom')
-        ? GALAXY_TOWERS_PER_SIDE_TB
-        : GALAXY_TOWERS_PER_SIDE_LR;
-    // Offset by ring depth (3 cells) so towers align with the board, not the corners
-    const sideLength = bounds.end - bounds.start;
-    const padding = (tower.side === 'top' || tower.side === 'bottom')
-        ? sideLength * (3 / 16)  // skip 3 corner cells out of 16 total
-        : 0;
-    const usableLength = sideLength - 2 * padding;
-    return bounds.start + padding + (tower.index + 0.5) * (usableLength / count);
-}
+import {
+    createInitialState,
+    updateRingGame,
+    placeTower as enginePlaceTower,
+    sellTower as engineSellTower,
+    upgradeTower as engineUpgradeTower,
+    startWave as engineStartWave,
+    applyTetrisAoE,
+} from '@/lib/tower-defense/ring-engine';
 
 interface UseGalaxyTDProps {
-    isPlaying: boolean;
     isPaused: boolean;
     gameOver: boolean;
     terrainPhase: string;
 }
 
 export function useGalaxyTD({
-    isPlaying,
     isPaused,
     gameOver,
     terrainPhase,
 }: UseGalaxyTDProps) {
-    const [enemies, setEnemies] = useState<GalaxyRingEnemy[]>([]);
-    const [towers, setTowers] = useState<GalaxyTower[]>(() => createInitialTowers());
-    const [gates, setGates] = useState<GalaxyGate[]>(() => createInitialGates());
-    const [waveNumber, setWaveNumber] = useState(0);
+    const [state, setState] = useState<GalaxyTDState>(() => createInitialState());
 
-    // Beat tracking for wave spawning
-    const beatCountRef = useRef(0);
-    const spawnsRemainingRef = useRef(0);
-    const waveCooldownRef = useRef(0);
-
-    // Refs for stable access in callbacks
-    const enemiesRef = useRef(enemies);
-    const towersRef = useRef(towers);
-    const gatesRef = useRef(gates);
     const isPausedRef = useRef(isPaused);
     const gameOverRef = useRef(gameOver);
-
-    useEffect(() => { enemiesRef.current = enemies; }, [enemies]);
-    useEffect(() => { towersRef.current = towers; }, [towers]);
-    useEffect(() => { gatesRef.current = gates; }, [gates]);
     useEffect(() => { isPausedRef.current = isPaused; }, [isPaused]);
     useEffect(() => { gameOverRef.current = gameOver; }, [gameOver]);
 
-    // ===== Spawn a single enemy at a random start position =====
-    const spawnEnemy = useCallback(() => {
-        // Enemies spawn at position 0 (top-left corner) with slight random offset
-        const offset = Math.random() * 0.02;
-        const enemy: GalaxyRingEnemy = {
-            id: nextEnemyId++,
-            pathPosition: offset,
-            speed: GALAXY_ENEMY_BASE_SPEED * (1 + Math.random() * 0.3),
-            health: GALAXY_ENEMY_BASE_HP,
-            maxHealth: GALAXY_ENEMY_BASE_HP,
-            alive: true,
-            spawnTime: Date.now(),
-        };
-        setEnemies(prev => [...prev, enemy]);
-    }, []);
-
-    // ===== Move all enemies along the path =====
-    const moveEnemies = useCallback(() => {
-        setEnemies(prev => {
-            let gatesDamaged = false;
-            const updated = prev.map(e => {
-                if (!e.alive) return e;
-                const newPos = e.pathPosition + e.speed;
-                if (newPos >= 1.0) {
-                    // Enemy completed the loop — damage a gate and despawn
-                    gatesDamaged = true;
-                    return { ...e, pathPosition: 1.0, alive: false };
-                }
-                return { ...e, pathPosition: newPos };
-            });
-
-            // Damage gates for enemies that completed the loop
-            if (gatesDamaged) {
-                const looped = updated.filter(e => !e.alive && e.pathPosition >= 1.0);
-                if (looped.length > 0) {
-                    setGates(prevGates => prevGates.map(g => ({
-                        ...g,
-                        health: Math.max(0, g.health - looped.length * 5),
-                    })));
-                }
-            }
-
-            // Remove dead enemies
-            return updated.filter(e => e.alive);
-        });
-    }, []);
-
-    // ===== Fire towers at nearby enemies =====
-    // burst: if true, skip cooldown check (used for triple/tetris burst fire)
-    const fireTowers = useCallback((burst = false) => {
-        const now = Date.now();
-        const currentEnemies = enemiesRef.current;
-        const aliveEnemies = currentEnemies.filter(e => e.alive);
-        if (aliveEnemies.length === 0) return;
-
-        setTowers(prev => {
-            const updatedTowers = prev.map(tower => {
-                if (tower.charge <= 0) return tower;
-                if (!burst && now - tower.lastFireTime < 500) return tower; // Minimum fire cooldown
-
-                const towerPos = getTowerPathPosition(tower);
-
-                // Find nearest enemy within range
-                let nearestEnemy: GalaxyRingEnemy | null = null;
-                let nearestDist = Infinity;
-
-                for (const enemy of aliveEnemies) {
-                    if (!enemy.alive) continue;
-                    // Calculate shortest path distance (wrapping around 0/1 boundary)
-                    const rawDist = Math.abs(enemy.pathPosition - towerPos);
-                    const dist = Math.min(rawDist, 1 - rawDist);
-                    if (dist < GALAXY_TOWER_RANGE && dist < nearestDist) {
-                        nearestDist = dist;
-                        nearestEnemy = enemy;
-                    }
-                }
-
-                if (!nearestEnemy) return tower;
-
-                // Fire! Reduce charge and damage enemy
-                return {
-                    ...tower,
-                    charge: tower.charge - 1,
-                    lastFireTime: now,
-                };
-            });
-
-            // Apply damage to enemies from towers that fired
-            const firedTowers = updatedTowers.filter((t, i) =>
-                t.lastFireTime === now && prev[i].lastFireTime !== now
-            );
-
-            if (firedTowers.length > 0) {
-                setEnemies(prevEnemies => {
-                    const updated = [...prevEnemies];
-                    for (const tower of firedTowers) {
-                        const towerPos = getTowerPathPosition(tower);
-                        // Find and damage the nearest enemy
-                        let bestIdx = -1;
-                        let bestDist = Infinity;
-                        for (let i = 0; i < updated.length; i++) {
-                            if (!updated[i].alive) continue;
-                            const rawDist = Math.abs(updated[i].pathPosition - towerPos);
-                            const dist = Math.min(rawDist, 1 - rawDist);
-                            if (dist < GALAXY_TOWER_RANGE && dist < bestDist) {
-                                bestDist = dist;
-                                bestIdx = i;
-                            }
-                        }
-                        if (bestIdx >= 0) {
-                            const e = updated[bestIdx];
-                            const newHp = e.health - GALAXY_TOWER_DAMAGE * tower.level;
-                            updated[bestIdx] = {
-                                ...e,
-                                health: newHp,
-                                alive: newHp > 0,
-                            };
-                        }
-                    }
-                    return updated.filter(e => e.alive);
-                });
-            }
-
-            return updatedTowers;
-        });
-    }, []);
-
-    // ===== Tick (called each beat during dig phase) =====
-    const tick = useCallback(() => {
+    // ===== Tick (called each beat with dt in seconds) =====
+    const tick = useCallback((dt: number) => {
         if (isPausedRef.current || gameOverRef.current) return;
 
-        beatCountRef.current++;
-
-        // Wave spawning logic
-        if (spawnsRemainingRef.current > 0) {
-            if (beatCountRef.current % GALAXY_WAVE_SPAWN_INTERVAL === 0) {
-                spawnEnemy();
-                spawnsRemainingRef.current--;
+        setState(prev => {
+            // Auto-start wave if in build phase
+            let s = prev;
+            if (s.phase === 'build' && s.currentWave < s.totalWaves) {
+                s = engineStartWave(s);
             }
-        } else if (waveCooldownRef.current > 0) {
-            waveCooldownRef.current--;
-        } else {
-            // Start new wave
-            setWaveNumber(prev => prev + 1);
-            spawnsRemainingRef.current = GALAXY_ENEMIES_PER_WAVE;
-            waveCooldownRef.current = GALAXY_WAVE_COOLDOWN;
-        }
-
-        // Move enemies
-        moveEnemies();
-
-        // Fire charged towers
-        fireTowers();
-    }, [spawnEnemy, moveEnemies, fireTowers]);
-
-    // ===== Line clear handler (charges towers) =====
-    const onLineClear = useCallback((lineCount: number) => {
-        // Determine charge amount
-        let chargeAmount: number;
-        if (lineCount >= 4) {
-            chargeAmount = GALAXY_CHARGE_PER_TRIPLE; // Tetris also gives max charge
-        } else if (lineCount === 3) {
-            chargeAmount = GALAXY_CHARGE_PER_TRIPLE;
-        } else if (lineCount === 2) {
-            chargeAmount = GALAXY_CHARGE_PER_DOUBLE;
-        } else {
-            chargeAmount = GALAXY_CHARGE_PER_SINGLE;
-        }
-
-        // Charge towers — distribute charge to towers with lowest charge first
-        setTowers(prev => {
-            const sorted = [...prev].sort((a, b) => a.charge - b.charge);
-            let remaining = chargeAmount;
-            const updated = new Map<number, GalaxyTower>();
-
-            for (const tower of sorted) {
-                if (remaining <= 0) break;
-                const spaceAvailable = tower.maxCharge - tower.charge;
-                if (spaceAvailable <= 0) continue;
-                const given = Math.min(remaining, spaceAvailable);
-                updated.set(tower.id, {
-                    ...tower,
-                    charge: tower.charge + given,
-                    level: tower.charge + given >= tower.maxCharge ? tower.level + 1 : tower.level,
-                });
-                remaining -= given;
-            }
-
-            return prev.map(t => updated.get(t.id) || t);
+            return updateRingGame(s, dt);
         });
+    }, []);
 
-        // Tetris (4 lines) also deals AOE damage to all enemies
+    // ===== Line clear handler (grants gold, Tetris = AoE) =====
+    const onLineClear = useCallback((lineCount: number) => {
+        let goldAmount: number;
         if (lineCount >= 4) {
-            setEnemies(prev =>
-                prev.map(e => {
-                    if (!e.alive) return e;
-                    const newHp = e.health - GALAXY_TETRIS_AOE_DAMAGE;
-                    return { ...e, health: newHp, alive: newHp > 0 };
-                }).filter(e => e.alive)
-            );
+            goldAmount = GALAXY_GOLD_PER_TETRIS;
+        } else if (lineCount === 3) {
+            goldAmount = GALAXY_GOLD_PER_TRIPLE;
+        } else if (lineCount === 2) {
+            goldAmount = GALAXY_GOLD_PER_DOUBLE;
+        } else {
+            goldAmount = GALAXY_GOLD_PER_SINGLE;
         }
 
-        // Triple (3 lines) triggers burst fire — all charged towers fire, bypassing cooldown
-        if (lineCount >= 3) {
-            fireTowers(true);
-        }
-    }, [fireTowers]);
+        setState(prev => {
+            let s = { ...prev, gold: prev.gold + goldAmount };
+            if (lineCount >= 4) {
+                s = applyTetrisAoE(s, GALAXY_TETRIS_AOE_DAMAGE);
+            }
+            return s;
+        });
+    }, []);
+
+    // ===== Tower placement =====
+    const placeTower = useCallback((type: TowerType, slotIndex: number) => {
+        setState(prev => enginePlaceTower(prev, type, slotIndex));
+    }, []);
+
+    // ===== Tower sell =====
+    const sellTower = useCallback((towerId: string) => {
+        setState(prev => engineSellTower(prev, towerId));
+    }, []);
+
+    // ===== Tower upgrade =====
+    const upgradeTower = useCallback((towerId: string) => {
+        setState(prev => engineUpgradeTower(prev, towerId));
+    }, []);
+
+    // ===== Select tower type for placement =====
+    const selectTowerType = useCallback((type: TowerType | null) => {
+        setState(prev => ({ ...prev, selectedTowerType: type, selectedTowerId: null }));
+    }, []);
+
+    // ===== Select existing tower =====
+    const selectTower = useCallback((towerId: string | null) => {
+        setState(prev => ({ ...prev, selectedTowerId: towerId, selectedTowerType: null }));
+    }, []);
+
+    // ===== Manually start wave =====
+    const triggerStartWave = useCallback(() => {
+        setState(prev => engineStartWave(prev));
+    }, []);
 
     // ===== Reset =====
     const reset = useCallback(() => {
-        nextEnemyId = 1;
-        nextTowerId = 1;
-        setEnemies([]);
-        setTowers(createInitialTowers());
-        setGates(createInitialGates());
-        setWaveNumber(0);
-        beatCountRef.current = 0;
-        spawnsRemainingRef.current = 0;
-        waveCooldownRef.current = 0;
+        setState(createInitialState());
     }, []);
 
-    // Reset when entering non-dig phases or game over
-    useEffect(() => {
+    // Clear enemies on phase change (keep towers)
+    const [prevPhase, setPrevPhase] = useState(terrainPhase);
+    const [prevGameOver, setPrevGameOver] = useState(gameOver);
+    if (prevPhase !== terrainPhase || prevGameOver !== gameOver) {
+        setPrevPhase(terrainPhase);
+        setPrevGameOver(gameOver);
         if (terrainPhase !== 'dig' || gameOver) {
-            // Don't fully reset towers on phase change — keep levels earned
-            setEnemies([]);
-            spawnsRemainingRef.current = 0;
-            waveCooldownRef.current = 0;
-            beatCountRef.current = 0;
+            setState(prev => ({
+                ...prev,
+                enemies: [],
+                projectiles: [],
+                spawnTracker: null,
+                phase: 'build' as const,
+            }));
         }
-    }, [terrainPhase, gameOver]);
+    }
 
     return {
-        enemies,
-        towers,
-        gates,
-        waveNumber,
+        state,
+        enemies: state.enemies,
+        towers: state.towers,
+        projectiles: state.projectiles,
+        gates: state.gates,
+        towerSlots: state.towerSlots,
+        waveNumber: state.currentWave,
+        gold: state.gold,
+        lives: state.lives,
+        selectedTowerType: state.selectedTowerType,
+        selectedTowerId: state.selectedTowerId,
+        phase: state.phase,
         tick,
         onLineClear,
+        placeTower,
+        sellTower,
+        upgradeTower,
+        selectTowerType,
+        selectTower,
+        startWave: triggerStartWave,
         reset,
     };
 }

--- a/src/components/rhythmia/tetris/hooks/useGalaxyTD.ts
+++ b/src/components/rhythmia/tetris/hooks/useGalaxyTD.ts
@@ -35,6 +35,9 @@ export function useGalaxyTD({
     useEffect(() => { isPausedRef.current = isPaused; }, [isPaused]);
     useEffect(() => { gameOverRef.current = gameOver; }, [gameOver]);
 
+    // Kill tracking for item drops (compare alive count before/after tick)
+    const recentKillsRef = useRef(0);
+
     // ===== Tick (called each beat with dt in seconds) =====
     const tick = useCallback((dt: number) => {
         if (isPausedRef.current || gameOverRef.current) return;
@@ -45,7 +48,11 @@ export function useGalaxyTD({
             if (s.phase === 'build' && s.currentWave < s.totalWaves) {
                 s = engineStartWave(s);
             }
-            return updateRingGame(s, dt);
+            const aliveBefore = s.enemies.filter(e => !e.dead).length;
+            s = updateRingGame(s, dt);
+            const aliveAfter = s.enemies.filter(e => !e.dead).length;
+            recentKillsRef.current = Math.max(0, aliveBefore - aliveAfter);
+            return s;
         });
     }, []);
 
@@ -106,13 +113,11 @@ export function useGalaxyTD({
         setState(createInitialState());
     }, []);
 
-    // Clear enemies on phase change (keep towers)
-    const [prevPhase, setPrevPhase] = useState(terrainPhase);
+    // Clear enemies on game over only (ring stays active across phases)
     const [prevGameOver, setPrevGameOver] = useState(gameOver);
-    if (prevPhase !== terrainPhase || prevGameOver !== gameOver) {
-        setPrevPhase(terrainPhase);
+    if (prevGameOver !== gameOver) {
         setPrevGameOver(gameOver);
-        if (terrainPhase !== 'dig' || gameOver) {
+        if (gameOver) {
             setState(prev => ({
                 ...prev,
                 enemies: [],
@@ -136,6 +141,7 @@ export function useGalaxyTD({
         selectedTowerType: state.selectedTowerType,
         selectedTowerId: state.selectedTowerId,
         phase: state.phase,
+        recentKillsRef,
         tick,
         onLineClear,
         placeTower,

--- a/src/components/rhythmia/tetris/tetris.tsx
+++ b/src/components/rhythmia/tetris/tetris.tsx
@@ -441,6 +441,13 @@ export default function Rhythmia({ onQuit, onGameEnd }: RhythmiaProps) {
   const galaxyTDPlaceTowerRef = useRef(galaxyTD.placeTower);
   galaxyTDPlaceTowerRef.current = galaxyTD.placeTower;
 
+  // Galaxy TD game over — trigger main game over when TD lives reach 0
+  useEffect(() => {
+    if (galaxyTD.lives <= 0 && terrainPhase === 'dig' && !gameOver) {
+      setGameOver(true);
+    }
+  }, [galaxyTD.lives, terrainPhase, gameOver, setGameOver]);
+
   // Line clear pulse for tower aura visual
   const [galaxyLineClearPulse, setGalaxyLineClearPulse] = useState(false);
   const galaxyPulseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/src/components/rhythmia/tetris/tetris.tsx
+++ b/src/components/rhythmia/tetris/tetris.tsx
@@ -443,10 +443,10 @@ export default function Rhythmia({ onQuit, onGameEnd }: RhythmiaProps) {
 
   // Galaxy TD game over — trigger main game over when TD lives reach 0
   useEffect(() => {
-    if (galaxyTD.lives <= 0 && terrainPhase === 'dig' && !gameOver) {
+    if (galaxyTD.lives <= 0 && !gameOver) {
       setGameOver(true);
     }
-  }, [galaxyTD.lives, terrainPhase, gameOver, setGameOver]);
+  }, [galaxyTD.lives, gameOver, setGameOver]);
 
   // Line clear pulse for tower aura visual
   const [galaxyLineClearPulse, setGalaxyLineClearPulse] = useState(false);
@@ -500,6 +500,12 @@ export default function Rhythmia({ onQuit, onGameEnd }: RhythmiaProps) {
     }
     return { x: window.innerWidth / 2, y: window.innerHeight / 2 };
   }, []);
+
+  // Stable refs for Galaxy ring kill → item drop + SE in beat timer
+  const spawnItemDropsRef = useRef(spawnItemDrops);
+  spawnItemDropsRef.current = spawnItemDrops;
+  const getBoardCenterRef = useRef(getBoardCenter);
+  getBoardCenterRef.current = getBoardCenter;
 
   // Move piece in given direction
   const movePiece = useCallback((dx: number, dy: number): boolean => {
@@ -915,6 +921,14 @@ export default function Rhythmia({ onQuit, onGameEnd }: RhythmiaProps) {
 
       const center = getBoardCenter();
 
+      // Galaxy TD: line clears grant gold + Tetris AoE (both phases)
+      galaxyTDOnLineClearRef.current(clearedLines);
+
+      // Flash tower aura pulse
+      setGalaxyLineClearPulse(true);
+      if (galaxyPulseTimerRef.current) clearTimeout(galaxyPulseTimerRef.current);
+      galaxyPulseTimerRef.current = setTimeout(() => setGalaxyLineClearPulse(false), 600);
+
       if (phase === 'td') {
         // === TD PHASE: Kill enemies when lines are cleared ===
         const killCount = Math.ceil(clearedLines * ENEMIES_KILLED_PER_LINE * mult * amplifiedCombo);
@@ -928,14 +942,6 @@ export default function Rhythmia({ onQuit, onGameEnd }: RhythmiaProps) {
         const surgeBonus = timing === 'perfect' ? activeEffectsRef.current.terrainSurgeBonus : 0;
         const damage = Math.ceil(clearedLines * TERRAIN_DAMAGE_PER_LINE * mult * amplifiedCombo * (1 + surgeBonus));
         const remaining = destroyTerrain(damage);
-
-        // Galaxy TD: line clears power up towers on the ring
-        galaxyTDOnLineClearRef.current(clearedLines);
-
-        // Flash tower aura pulse
-        setGalaxyLineClearPulse(true);
-        if (galaxyPulseTimerRef.current) clearTimeout(galaxyPulseTimerRef.current);
-        galaxyPulseTimerRef.current = setTimeout(() => setGalaxyLineClearPulse(false), 600);
 
         // Item drops from terrain
         spawnItemDrops(damage, center.x, center.y);
@@ -1260,9 +1266,17 @@ export default function Rhythmia({ onQuit, onGameEnd }: RhythmiaProps) {
             completeWaveRef.current();
           }
         }
-      } else {
-        // === Dig phase: Galaxy TD ring tick ===
-        galaxyTDTickRef.current(interval / 1000);
+      }
+
+      // Galaxy TD ring tick — runs every beat (both phases)
+      galaxyTDTickRef.current(interval / 1000);
+
+      // Ring enemy kills → item drops + SE
+      const ringKills = galaxyTD.recentKillsRef.current;
+      if (ringKills > 0) {
+        playKillSoundRef.current();
+        const c = getBoardCenterRef.current();
+        spawnItemDropsRef.current(ringKills, c.x, c.y);
       }
 
       // VFX: beat pulse ring — intensity scales with BPM (both modes)
@@ -1737,42 +1751,38 @@ export default function Rhythmia({ onQuit, onGameEnd }: RhythmiaProps) {
       {/* Game */}
       {(isPlaying || gameOver) && (
         <div className={styles.game}>
-          {/* Galaxy TD 3D ring — fullscreen behind game UI, only during dig phase */}
-          {terrainPhase === 'dig' && (
-            <>
-              <GalaxyRing3D
-                enemies={galaxyTD.enemies}
-                towers={galaxyTD.towers}
-                gates={galaxyTD.gates}
-                projectiles={galaxyTD.projectiles}
-                towerSlots={galaxyTD.towerSlots}
-                waveNumber={galaxyTD.waveNumber}
-                selectedTowerType={galaxyTD.selectedTowerType}
-                selectedTowerId={galaxyTD.selectedTowerId}
-                lineClearPulse={galaxyLineClearPulse}
-                onSlotClick={(slotIndex) => {
-                  if (galaxyTD.selectedTowerType) {
-                    galaxyTD.placeTower(galaxyTD.selectedTowerType, slotIndex);
-                  }
-                }}
-                onTowerClick={(towerId) => {
-                  galaxyTD.selectTower(towerId);
-                }}
-              />
-              <GalaxyTDPanel
-                gold={galaxyTD.gold}
-                lives={galaxyTD.lives}
-                waveNumber={galaxyTD.waveNumber}
-                totalWaves={30}
-                selectedTowerType={galaxyTD.selectedTowerType}
-                selectedTowerId={galaxyTD.selectedTowerId}
-                towers={galaxyTD.towers}
-                onSelectTowerType={galaxyTD.selectTowerType}
-                onUpgradeTower={galaxyTD.upgradeTower}
-                onSellTower={galaxyTD.sellTower}
-              />
-            </>
-          )}
+          {/* Galaxy TD 3D ring — fullscreen behind game UI (always active) */}
+          <GalaxyRing3D
+            enemies={galaxyTD.enemies}
+            towers={galaxyTD.towers}
+            gates={galaxyTD.gates}
+            projectiles={galaxyTD.projectiles}
+            towerSlots={galaxyTD.towerSlots}
+            waveNumber={galaxyTD.waveNumber}
+            selectedTowerType={galaxyTD.selectedTowerType}
+            selectedTowerId={galaxyTD.selectedTowerId}
+            lineClearPulse={galaxyLineClearPulse}
+            onSlotClick={(slotIndex) => {
+              if (galaxyTD.selectedTowerType) {
+                galaxyTD.placeTower(galaxyTD.selectedTowerType, slotIndex);
+              }
+            }}
+            onTowerClick={(towerId) => {
+              galaxyTD.selectTower(towerId);
+            }}
+          />
+          <GalaxyTDPanel
+            gold={galaxyTD.gold}
+            lives={galaxyTD.lives}
+            waveNumber={galaxyTD.waveNumber}
+            totalWaves={30}
+            selectedTowerType={galaxyTD.selectedTowerType}
+            selectedTowerId={galaxyTD.selectedTowerId}
+            towers={galaxyTD.towers}
+            onSelectTowerType={galaxyTD.selectTowerType}
+            onUpgradeTower={galaxyTD.upgradeTower}
+            onSellTower={galaxyTD.sellTower}
+          />
 
           {/* Game phase indicator */}
           <GamePhaseIndicator
@@ -1815,7 +1825,7 @@ export default function Rhythmia({ onQuit, onGameEnd }: RhythmiaProps) {
             <div className={styles.centerColumn}>
               <div className={styles.boardActionArea}>
               <GalaxyBoard
-                galaxyActive={terrainPhase === 'dig'}
+                galaxyActive={true}
                 waveNumber={galaxyTD.waveNumber}
                 gold={galaxyTD.gold}
                 lives={galaxyTD.lives}

--- a/src/components/rhythmia/tetris/tetris.tsx
+++ b/src/components/rhythmia/tetris/tetris.tsx
@@ -26,6 +26,9 @@ const GalaxyRing3D = dynamic(
   { ssr: false }
 );
 
+// Galaxy TD HUD panel
+import { GalaxyTDPanel } from './components/GalaxyTDPanel';
+
 // Hooks
 import { useAudio, useGameState, useDeviceType, getResponsiveCSSVars, useRhythmVFX } from './hooks';
 import { useKeybinds } from './hooks/useKeybinds';
@@ -427,7 +430,6 @@ export default function Rhythmia({ onQuit, onGameEnd }: RhythmiaProps) {
 
   // ===== Galaxy TD System (ring around board during dig phase) =====
   const galaxyTD = useGalaxyTD({
-    isPlaying,
     isPaused,
     gameOver,
     terrainPhase,
@@ -436,6 +438,8 @@ export default function Rhythmia({ onQuit, onGameEnd }: RhythmiaProps) {
   galaxyTDTickRef.current = galaxyTD.tick;
   const galaxyTDOnLineClearRef = useRef(galaxyTD.onLineClear);
   galaxyTDOnLineClearRef.current = galaxyTD.onLineClear;
+  const galaxyTDPlaceTowerRef = useRef(galaxyTD.placeTower);
+  galaxyTDPlaceTowerRef.current = galaxyTD.placeTower;
 
   // Line clear pulse for tower aura visual
   const [galaxyLineClearPulse, setGalaxyLineClearPulse] = useState(false);
@@ -1251,7 +1255,7 @@ export default function Rhythmia({ onQuit, onGameEnd }: RhythmiaProps) {
         }
       } else {
         // === Dig phase: Galaxy TD ring tick ===
-        galaxyTDTickRef.current();
+        galaxyTDTickRef.current(interval / 1000);
       }
 
       // VFX: beat pulse ring — intensity scales with BPM (both modes)
@@ -1728,13 +1732,39 @@ export default function Rhythmia({ onQuit, onGameEnd }: RhythmiaProps) {
         <div className={styles.game}>
           {/* Galaxy TD 3D ring — fullscreen behind game UI, only during dig phase */}
           {terrainPhase === 'dig' && (
-            <GalaxyRing3D
-              enemies={galaxyTD.enemies}
-              towers={galaxyTD.towers}
-              gates={galaxyTD.gates}
-              waveNumber={galaxyTD.waveNumber}
-              lineClearPulse={galaxyLineClearPulse}
-            />
+            <>
+              <GalaxyRing3D
+                enemies={galaxyTD.enemies}
+                towers={galaxyTD.towers}
+                gates={galaxyTD.gates}
+                projectiles={galaxyTD.projectiles}
+                towerSlots={galaxyTD.towerSlots}
+                waveNumber={galaxyTD.waveNumber}
+                selectedTowerType={galaxyTD.selectedTowerType}
+                selectedTowerId={galaxyTD.selectedTowerId}
+                lineClearPulse={galaxyLineClearPulse}
+                onSlotClick={(slotIndex) => {
+                  if (galaxyTD.selectedTowerType) {
+                    galaxyTD.placeTower(galaxyTD.selectedTowerType, slotIndex);
+                  }
+                }}
+                onTowerClick={(towerId) => {
+                  galaxyTD.selectTower(towerId);
+                }}
+              />
+              <GalaxyTDPanel
+                gold={galaxyTD.gold}
+                lives={galaxyTD.lives}
+                waveNumber={galaxyTD.waveNumber}
+                totalWaves={30}
+                selectedTowerType={galaxyTD.selectedTowerType}
+                selectedTowerId={galaxyTD.selectedTowerId}
+                towers={galaxyTD.towers}
+                onSelectTowerType={galaxyTD.selectTowerType}
+                onUpgradeTower={galaxyTD.upgradeTower}
+                onSellTower={galaxyTD.sellTower}
+              />
+            </>
           )}
 
           {/* Game phase indicator */}
@@ -1780,6 +1810,8 @@ export default function Rhythmia({ onQuit, onGameEnd }: RhythmiaProps) {
               <GalaxyBoard
                 galaxyActive={terrainPhase === 'dig'}
                 waveNumber={galaxyTD.waveNumber}
+                gold={galaxyTD.gold}
+                lives={galaxyTD.lives}
                 board={board}
                 currentPiece={currentPiece}
                 boardBeat={boardBeat}

--- a/src/lib/tower-defense/ring-engine.ts
+++ b/src/lib/tower-defense/ring-engine.ts
@@ -1,0 +1,668 @@
+// ===== Ring-Adapted TD Engine =====
+// Maps standalone TD mechanics (7 tower types, 8 enemy types, status effects,
+// 30 waves) onto the Galaxy ring coordinate system around the Tetris board.
+
+import type { TowerType, EnemyType, StatusEffect, SpawnTracker } from '@/types/tower-defense';
+import { TOWER_DEFS, ENEMY_DEFS } from '@/types/tower-defense';
+import { WAVES } from './waves';
+import type {
+    GalaxyRingSide, RingTower, RingEnemy, RingProjectile,
+    TowerSlot, GalaxyGate, GalaxyTDState,
+} from '@/components/rhythmia/tetris/galaxy-types';
+import {
+    GALAXY_SIDE_BOUNDARIES,
+    GALAXY_TOWERS_PER_SIDE_TB,
+    GALAXY_TOWERS_PER_SIDE_LR,
+    GALAXY_INITIAL_GOLD,
+    GALAXY_INITIAL_LIVES,
+    GALAXY_RING_TOTAL_WAVES,
+    GALAXY_SPEED_DIVISOR,
+    GALAXY_RANGE_DIVISOR,
+    GALAXY_SELL_REFUND_RATE,
+    GALAXY_GATE_HP,
+    GALAXY_RING_DEPTH,
+    GALAXY_TOP_WIDTH,
+} from '@/components/rhythmia/tetris/galaxy-constants';
+
+let nextId = 1;
+function uid(): string {
+    return `r${nextId++}`;
+}
+
+// ===== Ring distance (wrapping) =====
+export function ringDistance(a: number, b: number): number {
+    const raw = Math.abs(a - b);
+    return Math.min(raw, 1 - raw);
+}
+
+// ===== Slot path-fraction computation =====
+function computeSlotPathFraction(side: GalaxyRingSide, index: number): number {
+    const bounds = GALAXY_SIDE_BOUNDARIES[side];
+    const count = (side === 'top' || side === 'bottom')
+        ? GALAXY_TOWERS_PER_SIDE_TB
+        : GALAXY_TOWERS_PER_SIDE_LR;
+    const sideLength = bounds.end - bounds.start;
+    const padding = (side === 'top' || side === 'bottom')
+        ? sideLength * (GALAXY_RING_DEPTH / GALAXY_TOP_WIDTH)
+        : 0;
+    const usableLength = sideLength - 2 * padding;
+    return bounds.start + padding + (index + 0.5) * (usableLength / count);
+}
+
+// ===== Create tower slots =====
+function createTowerSlots(): TowerSlot[] {
+    const slots: TowerSlot[] = [];
+    const sides: { side: GalaxyRingSide; count: number }[] = [
+        { side: 'top', count: GALAXY_TOWERS_PER_SIDE_TB },
+        { side: 'bottom', count: GALAXY_TOWERS_PER_SIDE_TB },
+        { side: 'left', count: GALAXY_TOWERS_PER_SIDE_LR },
+        { side: 'right', count: GALAXY_TOWERS_PER_SIDE_LR },
+    ];
+    for (const { side, count } of sides) {
+        for (let i = 0; i < count; i++) {
+            slots.push({
+                side,
+                index: i,
+                pathFraction: computeSlotPathFraction(side, i),
+                occupied: false,
+                towerId: null,
+            });
+        }
+    }
+    return slots;
+}
+
+// ===== Create initial gates =====
+function createInitialGates(): GalaxyGate[] {
+    return (['top', 'right', 'bottom', 'left'] as GalaxyRingSide[]).map(side => ({
+        side,
+        health: GALAXY_GATE_HP,
+        maxHealth: GALAXY_GATE_HP,
+    }));
+}
+
+// ===== Create initial state =====
+export function createInitialState(): GalaxyTDState {
+    nextId = 1;
+    return {
+        phase: 'build',
+        gold: GALAXY_INITIAL_GOLD,
+        lives: GALAXY_INITIAL_LIVES,
+        score: 0,
+        currentWave: 0,
+        totalWaves: GALAXY_RING_TOTAL_WAVES,
+        towers: [],
+        enemies: [],
+        projectiles: [],
+        gates: createInitialGates(),
+        towerSlots: createTowerSlots(),
+        selectedTowerType: null,
+        selectedTowerId: null,
+        spawnTracker: null,
+    };
+}
+
+// ===== Tower stat helpers =====
+function getTowerRange(tower: RingTower): number {
+    const def = TOWER_DEFS[tower.type];
+    const gridRange = def.rangePerLevel[tower.level - 1] ?? def.range;
+    return gridRange / GALAXY_RANGE_DIVISOR;
+}
+
+function getTowerDamage(tower: RingTower): number {
+    const def = TOWER_DEFS[tower.type];
+    return def.damagePerLevel[tower.level - 1] ?? def.damage;
+}
+
+function getTowerFireRate(tower: RingTower): number {
+    const def = TOWER_DEFS[tower.type];
+    return def.fireRate * (1 + (tower.level - 1) * 0.1);
+}
+
+// ===== Enemy speed helpers =====
+function getBaseRingSpeed(enemySpeed: number): number {
+    return enemySpeed / GALAXY_SPEED_DIVISOR;
+}
+
+function getEffectiveSpeed(enemy: RingEnemy): number {
+    let speed = enemy.speed;
+    for (const eff of enemy.effects) {
+        if (eff.type === 'slow') speed *= (1 - eff.magnitude);
+        if (eff.type === 'stun') speed = 0;
+    }
+    return Math.max(speed, 0);
+}
+
+function hasAmplify(enemy: RingEnemy): number {
+    for (const eff of enemy.effects) {
+        if (eff.type === 'amplify') return 1 + eff.magnitude;
+    }
+    return 1;
+}
+
+// ===== Place tower =====
+export function placeTower(state: GalaxyTDState, type: TowerType, slotIndex: number): GalaxyTDState {
+    const slot = state.towerSlots[slotIndex];
+    if (!slot || slot.occupied) return state;
+
+    const def = TOWER_DEFS[type];
+    if (state.gold < def.cost) return state;
+
+    const tower: RingTower = {
+        id: uid(),
+        type,
+        side: slot.side,
+        slotIndex,
+        pathFraction: slot.pathFraction,
+        level: 1,
+        cooldown: 0,
+        kills: 0,
+        totalDamage: 0,
+        targetId: null,
+    };
+
+    const newSlots = state.towerSlots.map((s, i) =>
+        i === slotIndex ? { ...s, occupied: true, towerId: tower.id } : s
+    );
+
+    return {
+        ...state,
+        gold: state.gold - def.cost,
+        towers: [...state.towers, tower],
+        towerSlots: newSlots,
+        selectedTowerId: tower.id,
+    };
+}
+
+// ===== Sell tower =====
+export function sellTower(state: GalaxyTDState, towerId: string): GalaxyTDState {
+    const tower = state.towers.find(t => t.id === towerId);
+    if (!tower) return state;
+
+    const def = TOWER_DEFS[tower.type];
+    const totalInvested = def.cost + def.upgradeCosts.slice(0, tower.level - 1).reduce((a, b) => a + b, 0);
+    const refund = Math.floor(totalInvested * GALAXY_SELL_REFUND_RATE);
+
+    const newSlots = state.towerSlots.map(s =>
+        s.towerId === towerId ? { ...s, occupied: false, towerId: null } : s
+    );
+
+    return {
+        ...state,
+        gold: state.gold + refund,
+        towers: state.towers.filter(t => t.id !== towerId),
+        towerSlots: newSlots,
+        selectedTowerId: state.selectedTowerId === towerId ? null : state.selectedTowerId,
+    };
+}
+
+// ===== Upgrade tower =====
+export function upgradeTower(state: GalaxyTDState, towerId: string): GalaxyTDState {
+    const tower = state.towers.find(t => t.id === towerId);
+    if (!tower) return state;
+
+    const def = TOWER_DEFS[tower.type];
+    if (tower.level >= def.maxLevel) return state;
+
+    const cost = def.upgradeCosts[tower.level - 1];
+    if (state.gold < cost) return state;
+
+    return {
+        ...state,
+        gold: state.gold - cost,
+        towers: state.towers.map(t =>
+            t.id === towerId ? { ...t, level: t.level + 1 } : t
+        ),
+    };
+}
+
+// ===== Start wave =====
+export function startWave(state: GalaxyTDState): GalaxyTDState {
+    if (state.phase !== 'build') return state;
+    const waveIndex = state.currentWave;
+    if (waveIndex >= WAVES.length || waveIndex >= state.totalWaves) return state;
+
+    const waveDef = WAVES[waveIndex];
+    const tracker: SpawnTracker = {
+        groups: waveDef.groups.map(g => ({
+            group: g,
+            spawned: 0,
+            nextSpawn: 0,
+            startTimer: g.startDelay,
+            done: false,
+        })),
+        allDone: false,
+    };
+
+    return {
+        ...state,
+        phase: 'wave',
+        currentWave: waveIndex + 1,
+        spawnTracker: tracker,
+    };
+}
+
+// ===== Spawn enemy =====
+function spawnEnemy(type: EnemyType, hpMult: number = 1, speedMult: number = 1): RingEnemy {
+    const def = ENEMY_DEFS[type];
+    return {
+        id: uid(),
+        type,
+        pathFraction: Math.random() * 0.01, // slight offset
+        hp: Math.round(def.hp * hpMult),
+        maxHp: Math.round(def.hp * hpMult),
+        speed: getBaseRingSpeed(def.speed * speedMult),
+        armor: def.armor,
+        effects: [],
+        flying: def.flying,
+        dead: false,
+    };
+}
+
+// ===== Main update tick =====
+export function updateRingGame(state: GalaxyTDState, dt: number): GalaxyTDState {
+    if (state.phase !== 'wave' && state.phase !== 'build') return state;
+    if (state.phase === 'build') return state;
+
+    let s = { ...state };
+    s = tickSpawning(s, dt);
+    s = tickEnemyMovement(s, dt);
+    s = tickTowerTargeting(s);
+    s = tickAuraDamage(s, dt);
+    s = tickTowerFiring(s, dt);
+    s = tickProjectiles(s, dt);
+    s = tickStatusEffects(s, dt);
+    s = tickHealerAbility(s, dt);
+    s = cleanupDead(s);
+    s = checkWaveComplete(s);
+    return s;
+}
+
+// ===== Spawning =====
+function tickSpawning(state: GalaxyTDState, dt: number): GalaxyTDState {
+    const tracker = state.spawnTracker;
+    if (!tracker || tracker.allDone) return state;
+
+    const newEnemies: RingEnemy[] = [];
+
+    for (const gt of tracker.groups) {
+        if (gt.done) continue;
+        if (gt.startTimer > 0) {
+            gt.startTimer -= dt;
+            continue;
+        }
+        gt.nextSpawn -= dt;
+        while (gt.nextSpawn <= 0 && gt.spawned < gt.group.count) {
+            newEnemies.push(spawnEnemy(
+                gt.group.enemyType,
+                gt.group.hpMultiplier ?? 1,
+                gt.group.speedMultiplier ?? 1,
+            ));
+            gt.spawned++;
+            gt.nextSpawn += gt.group.spawnDelay;
+        }
+        if (gt.spawned >= gt.group.count) gt.done = true;
+    }
+
+    tracker.allDone = tracker.groups.every(g => g.done);
+
+    if (newEnemies.length > 0) {
+        return { ...state, enemies: [...state.enemies, ...newEnemies] };
+    }
+    return state;
+}
+
+// ===== Enemy movement =====
+function tickEnemyMovement(state: GalaxyTDState, dt: number): GalaxyTDState {
+    let lives = state.lives;
+
+    const enemies = state.enemies.map(enemy => {
+        if (enemy.dead) return enemy;
+        const speed = getEffectiveSpeed(enemy);
+        if (speed === 0) return enemy;
+
+        const newPos = enemy.pathFraction + speed * dt;
+        if (newPos >= 1.0) {
+            lives -= 1;
+            return { ...enemy, pathFraction: 1.0, dead: true };
+        }
+        return { ...enemy, pathFraction: newPos };
+    });
+
+    return { ...state, enemies, lives };
+}
+
+// ===== Tower targeting =====
+function tickTowerTargeting(state: GalaxyTDState): GalaxyTDState {
+    const towers = state.towers.map(tower => {
+        const range = getTowerRange(tower);
+        let bestTarget: string | null = null;
+        let bestDist = Infinity;
+
+        for (const enemy of state.enemies) {
+            if (enemy.dead) continue;
+            if (enemy.flying && tower.type === 'flame') continue;
+            const d = ringDistance(tower.pathFraction, enemy.pathFraction);
+            if (d <= range) {
+                const priority = enemy.type === 'boss' ? 0 : enemy.type === 'tank' ? 1 : 2;
+                const effectiveDist = d + priority * 0.001;
+                if (effectiveDist < bestDist) {
+                    bestDist = effectiveDist;
+                    bestTarget = enemy.id;
+                }
+            }
+        }
+
+        return { ...tower, targetId: bestTarget };
+    });
+
+    return { ...state, towers };
+}
+
+// ===== Aura damage (Cannon/Magma tower) =====
+function tickAuraDamage(state: GalaxyTDState, dt: number): GalaxyTDState {
+    const auraTowers = state.towers.filter(t => t.type === 'cannon');
+    if (auraTowers.length === 0) return state;
+
+    let enemies = [...state.enemies];
+    const towers = [...state.towers];
+    let gold = state.gold;
+    let score = state.score;
+
+    for (const tower of auraTowers) {
+        const range = getTowerRange(tower);
+        const dps = getTowerDamage(tower);
+        const dmgThisTick = dps * dt;
+
+        enemies = enemies.map(e => {
+            if (e.dead) return e;
+            const d = ringDistance(tower.pathFraction, e.pathFraction);
+            if (d > range) return e;
+
+            const amplify = hasAmplify(e);
+            const damage = Math.max(0.5, (dmgThisTick - e.armor * dt) * amplify);
+
+            const tIdx = towers.findIndex(t => t.id === tower.id);
+            if (tIdx >= 0) towers[tIdx] = { ...towers[tIdx], totalDamage: towers[tIdx].totalDamage + damage };
+
+            const newHp = e.hp - damage;
+            if (newHp <= 0 && !e.dead) {
+                const reward = ENEMY_DEFS[e.type].reward;
+                gold += reward;
+                score += reward * 2;
+                if (tIdx >= 0) towers[tIdx] = { ...towers[tIdx], kills: towers[tIdx].kills + 1 };
+                return { ...e, hp: 0, dead: true };
+            }
+            return { ...e, hp: newHp };
+        });
+    }
+
+    return { ...state, enemies, towers, gold, score };
+}
+
+// ===== Tower firing =====
+function tickTowerFiring(state: GalaxyTDState, dt: number): GalaxyTDState {
+    const newProjectiles: RingProjectile[] = [];
+    const towers = state.towers.map(tower => {
+        const newTower = { ...tower, cooldown: Math.max(0, tower.cooldown - dt) };
+        if (newTower.cooldown > 0 || !newTower.targetId) return newTower;
+
+        // Cannon (magma) deals aura damage, no projectiles
+        if (tower.type === 'cannon') return newTower;
+
+        const target = state.enemies.find(e => e.id === newTower.targetId && !e.dead);
+        if (!target) return newTower;
+
+        const range = getTowerRange(tower);
+        if (ringDistance(tower.pathFraction, target.pathFraction) > range) return newTower;
+
+        const damage = getTowerDamage(tower);
+        const fireRate = getTowerFireRate(tower);
+        const def = TOWER_DEFS[tower.type];
+
+        const effects: StatusEffect[] = [];
+        if (tower.type === 'frost') {
+            effects.push({ type: 'slow', duration: 2, remaining: 2, magnitude: 0.4 });
+        }
+        if (tower.type === 'flame') {
+            effects.push({ type: 'burn', duration: 3, remaining: 3, magnitude: 5 });
+        }
+        if (tower.type === 'arcane') {
+            effects.push({ type: 'amplify', duration: 4, remaining: 4, magnitude: 0.25 });
+        }
+
+        newProjectiles.push({
+            id: uid(),
+            towerId: tower.id,
+            towerType: tower.type,
+            targetId: target.id,
+            pathFraction: tower.pathFraction,
+            damage,
+            speed: def.projectileSpeed / GALAXY_SPEED_DIVISOR,
+            effects: effects.length > 0 ? effects : undefined,
+        });
+
+        return { ...newTower, cooldown: 1 / fireRate };
+    });
+
+    return {
+        ...state,
+        towers,
+        projectiles: [...state.projectiles, ...newProjectiles],
+    };
+}
+
+// ===== Projectile movement and impact =====
+function tickProjectiles(state: GalaxyTDState, dt: number): GalaxyTDState {
+    let enemies = [...state.enemies];
+    const towers = [...state.towers];
+    let gold = state.gold;
+    let score = state.score;
+
+    const projectiles = state.projectiles.map(proj => {
+        const target = enemies.find(e => e.id === proj.targetId);
+        if (!target || target.dead) return null;
+
+        const dist = ringDistance(proj.pathFraction, target.pathFraction);
+
+        if (dist < 0.005) {
+            // Hit!
+            const amplify = hasAmplify(target);
+            const isSniper = proj.towerType === 'sniper';
+            const armor = isSniper ? 0 : target.armor;
+            const damage = Math.max(1, Math.round((proj.damage - armor) * amplify));
+
+            enemies = enemies.map(e => {
+                if (e.id !== target.id) return e;
+                let newE = { ...e, hp: e.hp - damage };
+                const tIdx = towers.findIndex(t => t.id === proj.towerId);
+                if (tIdx >= 0) towers[tIdx] = { ...towers[tIdx], totalDamage: towers[tIdx].totalDamage + damage };
+
+                // Apply effects
+                if (proj.effects) {
+                    const newEffects = [...newE.effects];
+                    for (const eff of proj.effects) {
+                        const existing = newEffects.findIndex(x => x.type === eff.type);
+                        if (existing >= 0) {
+                            newEffects[existing] = { ...eff };
+                        } else {
+                            newEffects.push({ ...eff });
+                        }
+                    }
+                    newE = { ...newE, effects: newEffects };
+                }
+
+                if (newE.hp <= 0) {
+                    const reward = ENEMY_DEFS[e.type].reward;
+                    gold += reward;
+                    score += reward * 2;
+                    if (tIdx >= 0) towers[tIdx] = { ...towers[tIdx], kills: towers[tIdx].kills + 1 };
+                    return { ...newE, hp: 0, dead: true };
+                }
+                return newE;
+            });
+
+            // Lightning chain
+            if (proj.towerType === 'lightning') {
+                const chainCount = 2;
+                let lastPos = target.pathFraction;
+                const hit = new Set<string>([target.id]);
+                for (let c = 0; c < chainCount; c++) {
+                    let closest: RingEnemy | null = null;
+                    let closestDist = 3 / GALAXY_RANGE_DIVISOR; // chain range
+                    for (const e of enemies) {
+                        if (e.dead || hit.has(e.id)) continue;
+                        const cd = ringDistance(lastPos, e.pathFraction);
+                        if (cd < closestDist) {
+                            closestDist = cd;
+                            closest = e;
+                        }
+                    }
+                    if (!closest) break;
+                    hit.add(closest.id);
+                    const chainDmg = Math.round(damage * 0.6);
+                    enemies = enemies.map(e => {
+                        if (e.id !== closest!.id) return e;
+                        const newHp = e.hp - chainDmg;
+                        if (newHp <= 0) {
+                            gold += ENEMY_DEFS[e.type].reward;
+                            score += ENEMY_DEFS[e.type].reward * 2;
+                            return { ...e, hp: 0, dead: true };
+                        }
+                        return { ...e, hp: newHp };
+                    });
+                    lastPos = closest.pathFraction;
+                }
+            }
+
+            return null; // remove projectile
+        }
+
+        // Move projectile toward target
+        const moveAmount = proj.speed * dt;
+        // Determine direction (shortest path on ring)
+        let diff = target.pathFraction - proj.pathFraction;
+        if (diff > 0.5) diff -= 1;
+        if (diff < -0.5) diff += 1;
+        const sign = diff >= 0 ? 1 : -1;
+        let newPos = proj.pathFraction + sign * Math.min(moveAmount, Math.abs(diff));
+        // Wrap around
+        newPos = ((newPos % 1) + 1) % 1;
+        return { ...proj, pathFraction: newPos };
+    }).filter(Boolean) as RingProjectile[];
+
+    return { ...state, enemies, towers, projectiles, gold, score };
+}
+
+// ===== Status effects =====
+function tickStatusEffects(state: GalaxyTDState, dt: number): GalaxyTDState {
+    let gold = state.gold;
+    let score = state.score;
+
+    const enemies = state.enemies.map((enemy) => {
+        if (enemy.dead || enemy.effects.length === 0) return enemy;
+
+        let hp = enemy.hp;
+        const effects = enemy.effects
+            .map(eff => {
+                if (eff.type === 'burn') hp -= eff.magnitude * dt;
+                if (eff.type === 'poison') hp -= eff.magnitude * dt;
+                return { ...eff, remaining: eff.remaining - dt };
+            })
+            .filter(eff => eff.remaining > 0);
+
+        if (hp <= 0) {
+            gold += ENEMY_DEFS[enemy.type].reward;
+            score += ENEMY_DEFS[enemy.type].reward * 2;
+            return { ...enemy, hp: 0, dead: true, effects };
+        }
+
+        return { ...enemy, hp, effects };
+    });
+
+    return { ...state, enemies, gold, score };
+}
+
+// ===== Healer ability =====
+function tickHealerAbility(state: GalaxyTDState, dt: number): GalaxyTDState {
+    const healers = state.enemies.filter(e => !e.dead && e.type === 'healer');
+    if (healers.length === 0) return state;
+
+    const healRange = 2 / GALAXY_RANGE_DIVISOR;
+    const enemies = state.enemies.map(enemy => {
+        if (enemy.dead || enemy.type === 'healer') return enemy;
+        for (const healer of healers) {
+            if (ringDistance(healer.pathFraction, enemy.pathFraction) < healRange) {
+                const healAmount = enemy.maxHp * 0.02 * dt;
+                return { ...enemy, hp: Math.min(enemy.maxHp, enemy.hp + healAmount) };
+            }
+        }
+        return enemy;
+    });
+
+    return { ...state, enemies };
+}
+
+// ===== Cleanup dead =====
+function cleanupDead(state: GalaxyTDState): GalaxyTDState {
+    const enemies = state.enemies.filter(e => !e.dead);
+    const projectiles = state.projectiles.filter(p =>
+        enemies.some(e => e.id === p.targetId)
+    );
+    const selectedTowerId = state.selectedTowerId && state.towers.some(t => t.id === state.selectedTowerId)
+        ? state.selectedTowerId
+        : null;
+    return { ...state, enemies, projectiles, selectedTowerId };
+}
+
+// ===== Check wave complete =====
+function checkWaveComplete(state: GalaxyTDState): GalaxyTDState {
+    if (state.lives <= 0) {
+        return { ...state, phase: 'lost', lives: 0, spawnTracker: null };
+    }
+
+    const spawningDone = !state.spawnTracker || state.spawnTracker.allDone;
+    const allDead = state.enemies.length === 0;
+
+    if (spawningDone && allDead) {
+        const waveDef = WAVES[state.currentWave - 1];
+        const reward = waveDef?.reward ?? 0;
+
+        if (state.currentWave >= state.totalWaves) {
+            return {
+                ...state,
+                phase: 'won',
+                gold: state.gold + reward,
+                score: state.score + reward * 5,
+                spawnTracker: null,
+            };
+        }
+
+        return {
+            ...state,
+            phase: 'build',
+            gold: state.gold + reward,
+            score: state.score + reward * 5,
+            spawnTracker: null,
+        };
+    }
+
+    return state;
+}
+
+// ===== AOE damage from Tetris line clear =====
+export function applyTetrisAoE(state: GalaxyTDState, damage: number): GalaxyTDState {
+    let gold = state.gold;
+    let score = state.score;
+    const enemies = state.enemies.map(e => {
+        if (e.dead) return e;
+        const newHp = e.hp - damage;
+        if (newHp <= 0) {
+            gold += ENEMY_DEFS[e.type].reward;
+            score += ENEMY_DEFS[e.type].reward * 2;
+            return { ...e, hp: 0, dead: true };
+        }
+        return { ...e, hp: newHp };
+    }).filter(e => !e.dead);
+    return { ...state, enemies, gold, score };
+}


### PR DESCRIPTION
Replace the simple auto-placed tower system with full tower defense mechanics from the standalone TD page: 7 tower types (archer, cannon, frost, lightning, sniper, flame, arcane), 8 enemy types with abilities, 30 waves, gold economy, status effects, and strategic tower placement.

- Create ring-engine.ts adapting standalone TD to ring coordinates
- Add gold economy (line clears grant gold instead of charge)
- Add GalaxyTDPanel HUD with tower selection bar and upgrade/sell UI
- Update GalaxyRing3D with type-specific tower/enemy visuals, projectiles, slot highlighting, and click interaction for tower placement
- Rewrite useGalaxyTD hook wrapping the new ring engine