### PR TITLE
Fix Tailwind CSS not applying on non-locale routes

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
-import "../globals.css";
 import React from 'react';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, getTranslations } from 'next-intl/server';

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 @import url('https://fonts.googleapis.com/css2?family=VT323&family=Press+Start+2P&family=Silkscreen:wght@400;700&family=Pixelify+Sans:wght@400;700&family=Inter:wght@400;700&family=Russo+One&display=swap');
 
 @font-face {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=VT323&family=Press+Start+2P&family=Silkscreen:wght@400;700&family=Pixelify+Sans:wght@400;700&family=Inter:wght@400;700&family=Russo+One&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import url('https://fonts.googleapis.com/css2?family=VT323&family=Press+Start+2P&family=Silkscreen:wght@400;700&family=Pixelify+Sans:wght@400;700&family=Inter:wght@400;700&family=Russo+One&display=swap');
 
 @font-face {
     font-family: 'Press Start 2P Local';

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,5 @@
+import "./globals.css";
+
 // This file is required by Next.js but the actual layout is in [locale]/layout.tsx
 // Keeping minimal for locale-based routing
 


### PR DESCRIPTION
### Motivation
- Some pages rendered with default/unstyled HTML because Tailwind utilities were not being generated or applied for routes outside the `/[locale]` layout. 
- Non-locale pages such as `src/app/blog/page.tsx` and `src/app/sns-widgets/page.tsx` use many Tailwind utility classes but were not guaranteed to load the global CSS entrypoint.

### Description
- Added Tailwind directives to the global stylesheet by inserting `@tailwind base;`, `@tailwind components;`, and `@tailwind utilities;` at the top of `src/app/globals.css` so utility classes are generated. 
- Imported `src/app/globals.css` from the root `src/app/layout.tsx` so non-locale routes always receive the global/Tailwind styles. 
- Removed the duplicate `globals.css` import from `src/app/[locale]/layout.tsx` to keep a single global CSS entrypoint.
- Affected example pages identified include `src/app/blog/page.tsx` and `src/app/sns-widgets/page.tsx` which rely on Tailwind utilities.

### Testing
- Ran a small Node script to detect non-`/[locale]` pages using Tailwind utility classes, which identified the affected pages successfully. 
- Ran `npm run lint`, which completed with no new errors (existing warnings remain). 
- Visual/browser verification was not executed in this environment (only automated checks listed above were run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef5beb954832bb84b9a351b5956ed)