### PR TITLE
Stabilize single-player tower defense gameplay

### DIFF
--- a/src/components/rhythmia/tetris/VanillaGame.module.css
+++ b/src/components/rhythmia/tetris/VanillaGame.module.css
@@ -10,6 +10,9 @@
 
 .body {
   min-height: 100vh;
+  min-height: 100dvh;
+  width: 100%;
+  max-width: 100vw;
   overflow: hidden;
   touch-action: manipulation;
   font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
@@ -56,6 +59,10 @@
 .game {
   width: 100%;
   height: 100vh;
+  height: 100dvh;
+  max-width: 100vw;
+  overflow: auto;
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -76,6 +83,8 @@
 /* Score display */
 .gameShell {
   width: min(1560px, 100%);
+  max-height: 100%;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 18px;
@@ -222,6 +231,40 @@
   grid-template-columns: minmax(250px, 320px) minmax(0, 1fr) minmax(250px, 320px);
   gap: 18px;
   align-items: start;
+  min-width: 0;
+}
+
+@media screen and (max-width: 1180px) {
+  .hudTopRail {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .gameArea {
+    grid-template-columns: minmax(180px, 240px) minmax(0, 1fr) minmax(180px, 240px);
+    gap: 10px;
+  }
+
+  .hudCard,
+  .supportPanel {
+    padding: 10px;
+  }
+}
+
+@media screen and (max-height: 760px) and (min-width: 1025px) {
+  .game {
+    justify-content: flex-start;
+    padding: 8px;
+  }
+
+  .gameShell,
+  .gameArea,
+  .sidePanel {
+    gap: 8px;
+  }
+
+  .hudTopRail {
+    display: none;
+  }
 }
 
 /* Side panels — flex column, content-sized */

--- a/src/components/rhythmia/tetris/__tests__/tdProjectilePhysics.test.ts
+++ b/src/components/rhythmia/tetris/__tests__/tdProjectilePhysics.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { distanceToSegment, selectProjectileTarget } from '../td-projectile-physics';
+import type { Enemy } from '../types';
+
+const enemy = (id: number, x: number, alive = true): Enemy => ({
+    id, x, y: 0, z: 0, gridX: x, gridZ: 0, speed: 1, health: 10,
+    maxHealth: 10, alive, spawnTime: 0, enemyType: 'zombie', armor: 0,
+    garbageRows: 0, abilities: [], statusEffects: [], stealthBeatsLeft: 0, isBoss: false,
+});
+
+describe('tower projectile physics', () => {
+    it('detects an enemy crossed between coarse simulation ticks', () => {
+        expect(distanceToSegment({ x: 5, y: 0.2, z: 0 }, { x: 0, y: 0, z: 0 }, { x: 10, y: 0, z: 0 })).toBeCloseTo(0.2);
+    });
+
+    it('retargets when the original target dies', () => {
+        expect(selectProjectileTarget([enemy(1, 1, false), enemy(2, 4), enemy(3, 8)], 1, { x: 3, y: 0, z: 0 }, [])?.id).toBe(2);
+    });
+
+    it('does not select an enemy already hit by a piercing projectile', () => {
+        expect(selectProjectileTarget([enemy(1, 1), enemy(2, 2)], 1, { x: 0, y: 0, z: 0 }, [1])?.id).toBe(2);
+    });
+});

--- a/src/components/rhythmia/tetris/components/GalaxyScene.tsx
+++ b/src/components/rhythmia/tetris/components/GalaxyScene.tsx
@@ -270,9 +270,11 @@ function MobEnemy({ pathPosition, enemyType, id, health, maxHealth, effects, fly
         prevPosRef.current = { x: s.x, z: s.z };
         groupRef.current.rotation.y = facingAngleRef.current;
 
-        // Animate mob limbs
+        // Animate only while interpolation is actually moving the mob. Stunned or
+        // stationary enemies now settle into their neutral pose between beats.
         if (mobRef.current) {
-            animateMob(mobRef.current, clock.elapsedTime, !isStunned);
+            const isMoving = !isStunned && (dx * dx + dz * dz > 0.000001);
+            animateMob(mobRef.current, clock.elapsedTime, isMoving);
         }
     });
 

--- a/src/components/rhythmia/tetris/hooks/useTowerDefense.ts
+++ b/src/components/rhythmia/tetris/hooks/useTowerDefense.ts
@@ -15,6 +15,7 @@ import {
 } from '../constants';
 import { generateWave, pickEnemyType, type TDWaveConfig } from '../td-waves';
 import { applyGarbageRise } from '../utils/boardUtils';
+import { distanceToSegment, selectProjectileTarget } from '../td-projectile-physics';
 
 let nextEnemyId = 0;
 let nextBulletId = 0;
@@ -393,6 +394,7 @@ export function useTowerDefense(deps: UseTowerDefenseDeps) {
             statusOnHit: rollStatusEffect(),
             pierce: effects.towerPierce,
             hitEnemyIds: [],
+            createdAt: Date.now(),
         };
         setBullets(prev => [...prev, bullet]);
 
@@ -518,6 +520,9 @@ export function useTowerDefense(deps: UseTowerDefenseDeps) {
         for (const b of currentBullets) {
             if (!b.alive) continue;
 
+            // Never leave a missed projectile in the world indefinitely.
+            if (now - b.createdAt > 5000) continue;
+
             const newVy = b.vy - BULLET_GRAVITY * dt;
             const newX = b.x + b.vx * dt;
             const newY = b.y + b.vy * dt - 0.5 * BULLET_GRAVITY * dt * dt;
@@ -539,14 +544,16 @@ export function useTowerDefense(deps: UseTowerDefenseDeps) {
                 continue;
             }
 
-            // Check collision with target enemy
+            // Swept collision prevents tunnelling between beat-sized physics updates.
             let bulletConsumed = false;
-            const targetEnemy = enemiesRef.current.find(
-                e => e.id === b.targetEnemyId && e.alive && !b.hitEnemyIds.includes(e.id)
+            const targetEnemy = selectProjectileTarget(
+                enemiesRef.current, b.targetEnemyId, b, b.hitEnemyIds,
             );
             if (targetEnemy) {
-                const targetDist = Math.sqrt(
-                    (targetEnemy.x - newX) ** 2 + (targetEnemy.y - newY) ** 2 + (targetEnemy.z - newZ) ** 2
+                const targetDist = distanceToSegment(
+                    targetEnemy,
+                    b,
+                    { x: newX, y: newY, z: newZ },
                 );
                 if (targetDist < BULLET_KILL_RADIUS) {
                     bulletConsumed = handleHit(b, targetEnemy);
@@ -554,17 +561,15 @@ export function useTowerDefense(deps: UseTowerDefenseDeps) {
                 }
             }
 
-            // If target dead/missing, check any nearby enemy
-            if (!targetEnemy && !bulletConsumed) {
+            // Piercing shots can hit another enemy along the remainder of the segment.
+            if (!bulletConsumed) {
                 const alive = enemiesRef.current.filter(
                     e => e.alive && !damagedEnemyIds.has(e.id) && !b.hitEnemyIds.includes(e.id)
                 );
                 let hitEnemy: Enemy | null = null;
                 let bestDist = Infinity;
                 for (const e of alive) {
-                    const ed = Math.sqrt(
-                        (e.x - newX) ** 2 + (e.y - newY) ** 2 + (e.z - newZ) ** 2
-                    );
+                    const ed = distanceToSegment(e, b, { x: newX, y: newY, z: newZ });
                     if (ed < bestDist) {
                         bestDist = ed;
                         hitEnemy = e;

--- a/src/components/rhythmia/tetris/minecraft-mobs.ts
+++ b/src/components/rhythmia/tetris/minecraft-mobs.ts
@@ -166,7 +166,8 @@ export function animateMob(mob: MobMeshData, time: number, isMoving: boolean): v
       if (mob.leftArm) mob.leftArm.rotation.z = -0.3 + wingFlap;
       if (mob.rightArm) mob.rightArm.rotation.z = 0.3 - wingFlap;
       // Gentle bob
-      mob.group.position.y = (mob.group.position.y || 0) + Math.sin(time * 4) * 0.03;
+      // Set an absolute offset: adding every frame caused bees to drift away.
+      mob.group.position.y = Math.sin(time * 4) * 0.03;
       break;
     }
   }
@@ -231,6 +232,7 @@ export function resetMobPose(mob: MobMeshData): void {
       if (mob.rightLeg) mob.rightLeg.rotation.x = 0;
       break;
     case 'bee':
+      mob.group.position.y = 0;
       if (mob.leftArm) mob.leftArm.rotation.z = 0;
       if (mob.rightArm) mob.rightArm.rotation.z = 0;
       break;

--- a/src/components/rhythmia/tetris/td-projectile-physics.ts
+++ b/src/components/rhythmia/tetris/td-projectile-physics.ts
@@ -1,0 +1,42 @@
+import type { Enemy } from './types';
+
+export type Point3 = { x: number; y: number; z: number };
+
+/** Distance from a point to a finite flight segment (not its infinite line). */
+export function distanceToSegment(point: Point3, start: Point3, end: Point3): number {
+    const abx = end.x - start.x;
+    const aby = end.y - start.y;
+    const abz = end.z - start.z;
+    const lengthSquared = abx * abx + aby * aby + abz * abz;
+    if (lengthSquared === 0) {
+        return Math.hypot(point.x - start.x, point.y - start.y, point.z - start.z);
+    }
+
+    const projection = Math.max(0, Math.min(1,
+        ((point.x - start.x) * abx + (point.y - start.y) * aby + (point.z - start.z) * abz) / lengthSquared,
+    ));
+    return Math.hypot(
+        point.x - (start.x + abx * projection),
+        point.y - (start.y + aby * projection),
+        point.z - (start.z + abz * projection),
+    );
+}
+
+/** Prefer the original target, then the living enemy closest to the projectile. */
+export function selectProjectileTarget(
+    enemies: Enemy[],
+    targetId: number,
+    position: Point3,
+    excludedIds: readonly number[],
+): Enemy | undefined {
+    const canHit = (enemy: Enemy) => enemy.alive && !excludedIds.includes(enemy.id);
+    const original = enemies.find(enemy => enemy.id === targetId && canHit(enemy));
+    if (original) return original;
+
+    return enemies.filter(canHit).reduce<Enemy | undefined>((best, enemy) => {
+        if (!best) return enemy;
+        const enemyDistance = Math.hypot(enemy.x - position.x, enemy.y - position.y, enemy.z - position.z);
+        const bestDistance = Math.hypot(best.x - position.x, best.y - position.y, best.z - position.z);
+        return enemyDistance < bestDistance ? enemy : best;
+    }, undefined);
+}

--- a/src/components/rhythmia/tetris/types.ts
+++ b/src/components/rhythmia/tetris/types.ts
@@ -303,6 +303,7 @@ export type Bullet = {
     statusOnHit: TDStatusEffect | null;
     pierce: number;       // remaining pierces (0 = dies on first hit)
     hitEnemyIds: number[]; // enemies already hit by this bullet (for pierce)
+    createdAt: number;
 };
 
 // ===== Terrain Particle =====


### PR DESCRIPTION
### Motivation
- Prevent missed or tunnelling tower projectiles and make TD phase more robust and deterministic across beat-sized physics ticks. 
- Fix visible mob animation glitches (bees drifting, limbs animating while stationary) so enemy motion looks consistent. 
- Make the single-player HUD/layout fit reliably on a wide range of viewport sizes including short screens and narrow widths.

### Description
- Add a dedicated projectile physics helper with swept-segment utilities and target-selection fallback in `src/components/rhythmia/tetris/td-projectile-physics.ts` and wire it into the TD loop. 
- Change bullet data and flight handling in `src/components/rhythmia/tetris/hooks/useTowerDefense.ts` to include `createdAt`, bounded lifetime, swept collision (`distanceToSegment`) and dead-target fallback (`selectProjectileTarget`), and keep consistent piercing/AoE behavior. 
- Fix mob animation logic: only animate limbs when the mob is actually moving and respect stun state in `src/components/rhythmia/tetris/components/GalaxyScene.tsx`, and stop cumulative vertical drift for bees in `src/components/rhythmia/tetris/minecraft-mobs.ts`. 
- Improve single-player responsive layout and short-screen behavior by adjusting `src/components/rhythmia/tetris/VanillaGame.module.css` (use `dvh` units, constrain widths, add compact media-query rules). 
- Add focused regression tests `src/components/rhythmia/tetris/__tests__/tdProjectilePhysics.test.ts` for swept collision, retargeting, and pierce-exclusion cases, and update `src/components/rhythmia/tetris/types.ts` for the new bullet field.

### Testing
- Ran unit tests: `npm test` — all tests passed (68 tests across project) and `npx vitest run src/components/rhythmia/tetris/__tests__/tdProjectilePhysics.test.ts` — 3 tests passed for the new physics tests. 
- Typecheck: `npx tsc --noEmit` completed successfully. 
- Lint: `npx eslint` targeted to modified files completed with no errors and one pre-existing `react-hooks/exhaustive-deps` warning reported in `src/components/rhythmia/tetris/hooks/useTowerDefense.ts`. 
- Smoke-verified runtime changes by executing the test suite; no regressions detected in the test run described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a719289d5d0832badbdcb2f2290c0d2)