### PR TITLE
Use player battle rules for ranked AI rivals

### DIFF
--- a/src/components/rhythmia/MultiplayerBattle.tsx
+++ b/src/components/rhythmia/MultiplayerBattle.tsx
@@ -17,7 +17,7 @@ import { playWorldDrum, WORLD_LINE_CLEAR_CHIMES } from '@/lib/rhythmia/stageSoun
 import type { TerrainParticle, FloatingItem } from './tetris/types';
 import { TerrainParticles } from './tetris/components/TerrainParticles';
 import { FloatingItems } from './tetris/components/FloatingItems';
-import { getBeatJudgment, getBeatMultiplier } from './tetris/utils';
+import { getBeatJudgment } from './tetris/utils';
 import { trackEvent } from '@/lib/analytics';
 import type { PieceType, Piece } from './multiplayer-battle-engine';
 import {
@@ -25,6 +25,7 @@ import {
     createRNG, create7Bag, getShape, createEmptyBoard, isValid,
     tryRotate, lockPiece, clearLines, getGhostY, addGarbageLines, detectTSpin,
 } from './multiplayer-battle-engine';
+import { resolveBattlePlacement } from './multiplayer-battle-rules';
 
 // Dynamically import VoxelWorldBackground (Three.js requires client-side only)
 const VoxelWorldBackground = dynamic(() => import('./VoxelWorldBackground'), {
@@ -493,10 +494,17 @@ export const MultiplayerBattle: React.FC<Props> = ({
         // Beat judgment
         const phase = beatPhaseRef.current;
         const timing = getBeatJudgment(phase);
-        const mult = getBeatMultiplier(timing);
+        const previousCombo = comboRef.current;
+
+        const placementResult = resolveBattlePlacement(
+            0,
+            'none',
+            timing,
+            comboRef.current,
+        );
+        comboRef.current = placementResult.combo;
 
         if (timing !== 'miss') {
-            comboRef.current++;
             const judgmentConfig = {
                 perfect: { text: 'PERFECT', color: '#00FFFF' },
                 great:   { text: 'GREAT',   color: '#76FF03' },
@@ -513,10 +521,9 @@ export const MultiplayerBattle: React.FC<Props> = ({
                 vfx.emit({ type: 'feverStart', combo: comboRef.current });
             }
         } else {
-            if (comboRef.current >= 10) {
+            if (previousCombo >= 10) {
                 vfx.emit({ type: 'feverEnd' });
             }
-            comboRef.current = 0;
         }
 
         // T-Spin tracking
@@ -600,27 +607,10 @@ export const MultiplayerBattle: React.FC<Props> = ({
             const boardCenterY = window.innerHeight / 2;
             spawnTerrainParticles(clearedRows, boardCenterX, boardCenterY);
 
-            // Base scoring with T-Spin bonuses
-            let base = [0, 100, 300, 500, 800][cleared];
-            if (tSpin === 'full') {
-                base += 400 + 400 * cleared;
-            } else if (tSpin === 'mini') {
-                base += 100 + 200 * cleared;
-            }
-
-            const pts = base * mult * Math.max(1, comboRef.current);
-            scoreRef.current += pts;
+            const clearResult = resolveBattlePlacement(cleared, tSpin, timing, previousCombo);
+            scoreRef.current += clearResult.score;
             linesRef.current += cleared;
-
-            // Enhanced garbage calculation with T-Spin bonus
-            let garbageToSend = [0, 0, 1, 2, 4][cleared];
-            if (tSpin === 'full') {
-                garbageToSend += [0, 2, 4, 6, 6][cleared]; // T-Spin bonus garbage
-            } else if (tSpin === 'mini') {
-                garbageToSend += 1;
-            }
-            garbageToSend += Math.floor(comboRef.current / 3);
-            sendGarbage(garbageToSend);
+            sendGarbage(clearResult.garbage);
             playLineClear(cleared, worldIdx);
 
             // VFX: line clear (offset rows by BUFFER_ZONE for VFX hook coordinate system)

--- a/src/components/rhythmia/__tests__/multiplayer-battle-rules.test.ts
+++ b/src/components/rhythmia/__tests__/multiplayer-battle-rules.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { resolveBattlePlacement } from '../multiplayer-battle-rules';
+
+describe('resolveBattlePlacement', () => {
+    it('uses beat timing for combo and score', () => {
+        expect(resolveBattlePlacement(2, 'none', 'perfect', 2)).toEqual({
+            combo: 3,
+            score: 1800,
+            garbage: 2,
+        });
+        expect(resolveBattlePlacement(2, 'none', 'miss', 8)).toEqual({
+            combo: 0,
+            score: 300,
+            garbage: 1,
+        });
+    });
+
+    it('applies the same T-spin and combo garbage bonuses', () => {
+        expect(resolveBattlePlacement(2, 'full', 'great', 5)).toEqual({
+            combo: 6,
+            score: 13500,
+            garbage: 7,
+        });
+    });
+
+    it('updates rhythm combo even when no line is cleared', () => {
+        expect(resolveBattlePlacement(0, 'none', 'great', 3)).toEqual({
+            combo: 4,
+            score: 0,
+            garbage: 0,
+        });
+    });
+});

--- a/src/components/rhythmia/multiplayer-battle-rules.ts
+++ b/src/components/rhythmia/multiplayer-battle-rules.ts
@@ -1,0 +1,48 @@
+import { getBeatMultiplier, type BeatJudgment } from './tetris/utils';
+
+export type TSpinResult = 'none' | 'mini' | 'full';
+
+export interface BattlePlacementResult {
+    combo: number;
+    score: number;
+    garbage: number;
+}
+
+/**
+ * Resolve the competitive consequences of locking a piece. Keeping this pure
+ * lets human and AI competitors use exactly the same rhythm, scoring, combo,
+ * T-spin, and garbage rules.
+ */
+export function resolveBattlePlacement(
+    cleared: number,
+    tSpin: TSpinResult,
+    timing: BeatJudgment,
+    previousCombo: number,
+): BattlePlacementResult {
+    const combo = timing === 'miss' ? 0 : previousCombo + 1;
+
+    if (cleared === 0) {
+        return { combo, score: 0, garbage: 0 };
+    }
+
+    let base = [0, 100, 300, 500, 800][cleared] ?? 0;
+    if (tSpin === 'full') {
+        base += 400 + 400 * cleared;
+    } else if (tSpin === 'mini') {
+        base += 100 + 200 * cleared;
+    }
+
+    let garbage = [0, 0, 1, 2, 4][cleared] ?? 0;
+    if (tSpin === 'full') {
+        garbage += [0, 2, 4, 6, 6][cleared] ?? 0;
+    } else if (tSpin === 'mini') {
+        garbage += 1;
+    }
+    garbage += Math.floor(combo / 3);
+
+    return {
+        combo,
+        score: base * getBeatMultiplier(timing) * Math.max(1, combo),
+        garbage,
+    };
+}

--- a/src/lib/ranked/TetrisAI.ts
+++ b/src/lib/ranked/TetrisAI.ts
@@ -2,7 +2,9 @@
 // Smart AI opponent for ranked matches
 // Uses heuristic-based evaluation with configurable difficulty
 
-import { ARR, DAS } from '@/components/rhythmia/multiplayer-battle-engine';
+import { ARR, BPM, DAS, addGarbageLines } from '@/components/rhythmia/multiplayer-battle-engine';
+import { resolveBattlePlacement } from '@/components/rhythmia/multiplayer-battle-rules';
+import { getBeatJudgment } from '@/components/rhythmia/tetris/utils';
 import type { BoardCell } from '@/types/multiplayer';
 
 type PieceType = 'I' | 'O' | 'T' | 'S' | 'Z' | 'L' | 'J';
@@ -762,6 +764,7 @@ export class TetrisAIGame {
   private nextQueue: PieceType[] = [];
   private visibleRows: number;
   private hiddenRows: number;
+  private beatStartedAt = 0;
 
   constructor(
     seed: number,
@@ -813,6 +816,7 @@ export class TetrisAIGame {
 
   start(): void {
     this.paused = false;
+    this.beatStartedAt = Date.now();
     this.playNextPiece();
   }
 
@@ -930,13 +934,6 @@ export class TetrisAIGame {
 
   private beginPieceExecution(pieceType: PieceType): void {
     if (this.gameOver) return;
-
-    // Apply pending garbage before placing
-    if (this.pendingGarbage > 0) {
-      this.applyGarbage(this.pendingGarbage);
-      this.pendingGarbage = 0;
-      if (this.gameOver) return;
-    }
 
     const sourcePiece = createSpawnPiece(pieceType, this.hiddenRows);
     if (!isValid(sourcePiece, this.board)) {
@@ -1084,29 +1081,30 @@ export class TetrisAIGame {
       return;
     }
 
-    // Lock piece
+    const lastMovement = executionPlan.move.inputPlan.actions
+      .filter(action => action !== 'hardDrop' && action !== 'hold')
+      .at(-1);
+    const wasRotation = lastMovement === 'rotateCW' || lastMovement === 'rotateCCW';
+
+    // Lock piece, then receive pending garbage before clearing just like the player.
     const boardBeforeLock = this.board.map(row => [...row]);
     this.board = lockPiece(landedPiece, this.board);
+    if (this.pendingGarbage > 0) {
+      this.applyGarbage(this.pendingGarbage);
+      this.pendingGarbage = 0;
+    }
 
     // Clear lines
     const { board: clearedBoard, cleared } = clearLines(this.board);
     this.board = clearedBoard;
-    const tSpin = detectTSpin(landedPiece, boardBeforeLock, landedPiece.type === 'T');
-
-    if (cleared > 0) {
-      this.combo++;
-      const base = [0, 100, 300, 500, 800][cleared];
-      this.score += base * Math.max(1, this.combo);
-      this.lines += cleared;
-
-      // Send garbage
-      const garbageToSend = [0, 0, 1, 2, 4][cleared] + Math.floor(this.combo / 3);
-      if (garbageToSend > 0) {
-        this.callbacks.onGarbage(garbageToSend);
-      }
-    } else {
-      this.combo = 0;
-    }
+    const tSpin = detectTSpin(landedPiece, boardBeforeLock, wasRotation);
+    const beatInterval = 60000 / BPM;
+    const beatPhase = ((Date.now() - this.beatStartedAt) % beatInterval) / beatInterval;
+    const result = resolveBattlePlacement(cleared, tSpin, getBeatJudgment(beatPhase), this.combo);
+    this.combo = result.combo;
+    this.score += result.score;
+    this.lines += cleared;
+    if (result.garbage > 0) this.callbacks.onGarbage(result.garbage);
 
     // Emit board update
     this.callbacks.onBoardUpdate(
@@ -1149,13 +1147,6 @@ export class TetrisAIGame {
         return;
       }
     }
-    const newBoard = this.board.slice(rowsToRaise);
-    for (let i = 0; i < rowsToRaise; i++) {
-      const row: (BoardCell | null)[] = Array(W).fill({ color: '#555555' } as BoardCell);
-      const gap = Math.floor(this.garbageRng() * W);
-      row[gap] = null;
-      newBoard.push(row);
-    }
-    this.board = newBoard;
+    this.board = addGarbageLines(this.board, rowsToRaise, this.garbageRng);
   }
 }


### PR DESCRIPTION
### Motivation

- Ensure ranked AI rivals follow the exact same rhythm/combo, scoring, T‑spin, and garbage rules as human players so ranked matches are fair and deterministic.
- Fix a bug where the AI used a different timing/garbage/rotation flow than the player, causing mismatched behavior in ranked matches.

### Description

- Add a pure resolver `resolveBattlePlacement` in `src/components/rhythmia/multiplayer-battle-rules.ts` that centralizes combo progression, beat multipliers, base scoring, T‑spin bonuses, and garbage calculation for a placement. 
- Update the player code in `src/components/rhythmia/MultiplayerBattle.tsx` to consume `resolveBattlePlacement` for per-placement combo, scoring, and garbage while preserving UI judgments, VFX, and fever logic.
- Update the ranked AI in `src/lib/ranked/TetrisAI.ts` to use the same rules: compute beat judgment, detect rotation‑based T‑spins from the AI input plan, apply pending garbage at the same point in the lock cycle, and send garbage using the shared rules; also unify garbage application by calling `addGarbageLines`.
- Add unit tests `src/components/rhythmia/__tests__/multiplayer-battle-rules.test.ts` to cover beat timing, combo progression, T‑spin scoring, and garbage outcomes.

### Testing

- Ran `npm test` and all test suites passed (68 tests total). 
- Ran the new test file with `npx vitest run src/components/rhythmia/__tests__/multiplayer-battle-rules.test.ts` and the 3 tests passed. 
- Type checks passed with `npx tsc --noEmit --pretty false`. 
- Linting passed with `npx eslint` on the modified files and `git diff --check` produced no issues. 
- Attempted `npm run build` (Next.js/Turbopack): compilation produced build artifacts but the Turbopack process did not terminate within the environment and was stopped after the timeout (build artifacts were generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71929419ac832b9fa65ecbec810c4b)