### PR TITLE
Synchronize ranked AI with player's rhythm gameplay (colors, beat bar, board sizing)

### DIFF
--- a/src/components/rhythmia/MultiplayerBattle.module.css
+++ b/src/components/rhythmia/MultiplayerBattle.module.css
@@ -96,8 +96,14 @@
     display: flex;
     flex-direction: column;
     gap: 6px;
-    flex: 1;
+    /* Keep the two 10x20 playfields identical even though only the local
+       player has a hold/next side panel. */
+    flex: 0 1 360px;
+    width: min(360px, 100%);
 }
+
+.playerSide { justify-content: flex-end; }
+.opponentSide { justify-content: flex-end; }
 
 .playerHeader,
 .opponentHeader {

--- a/src/components/rhythmia/MultiplayerBattle.tsx
+++ b/src/components/rhythmia/MultiplayerBattle.tsx
@@ -1386,6 +1386,21 @@ export const MultiplayerBattle: React.FC<Props> = ({
                             </div>
                         </div>
 
+                        {/* Both competitors are judged against this same beat. */}
+                        <div className={styles.beatIndicator} aria-label="AI beat timing">
+                            <div className={styles.beatTrack}>
+                                <div className={styles.beatPerfectZoneLeft} />
+                                <div className={styles.beatPerfectZoneRight} />
+                                <div
+                                    className={`${styles.beatCursor} ${beatZone === 'perfect' ? styles.beatCursorPerfect : beatZone === 'great' ? styles.beatCursorGreat : beatZone === 'good' ? styles.beatCursorGood : ''}`}
+                                    style={{ left: `${beatIndicatorPos * 100}%` }}
+                                />
+                            </div>
+                            <div className={styles.beatLabel}>
+                                {beatZone !== 'miss' ? beatZone.toUpperCase() : 'BEAT'}
+                            </div>
+                        </div>
+
                         <div className={styles.statsRow}>
                             <span>Lines: {opponentLines}</span>
                             {opponentCombo >= 3 && <span>Combo: {opponentCombo}</span>}

--- a/src/lib/ranked/TetrisAI.ts
+++ b/src/lib/ranked/TetrisAI.ts
@@ -5,6 +5,7 @@
 import { ARR, BPM, DAS, addGarbageLines } from '@/components/rhythmia/multiplayer-battle-engine';
 import { resolveBattlePlacement } from '@/components/rhythmia/multiplayer-battle-rules';
 import { getBeatJudgment } from '@/components/rhythmia/tetris/utils';
+import { getThemedColor } from '@/components/rhythmia/tetris/constants';
 import type { BoardCell } from '@/types/multiplayer';
 
 type PieceType = 'I' | 'O' | 'T' | 'S' | 'Z' | 'L' | 'J';
@@ -78,11 +79,6 @@ const AI_ACTION_MS = 50;
 const HOLD_ADVANTAGE_THRESHOLD = 0.5;
 
 const PIECE_TYPES: PieceType[] = ['I', 'O', 'T', 'S', 'Z', 'L', 'J'];
-
-const COLORS: Record<PieceType, string> = {
-  I: '#00F0F0', O: '#F0F000', T: '#A000F0', S: '#00F000',
-  Z: '#F00000', J: '#0000F0', L: '#F0A000',
-};
 
 const SHAPES: Record<PieceType, number[][][]> = {
   I: [
@@ -371,7 +367,7 @@ function lockPiece(piece: Piece, board: (BoardCell | null)[][]): (BoardCell | nu
   const boardHeight = getBoardHeight(board);
   const newBoard = board.map(row => [...row]);
   const shape = getShape(piece.type, piece.rotation);
-  const color = COLORS[piece.type];
+  const color = getThemedColor(piece.type, 'stage', 0);
   for (let y = 0; y < shape.length; y++) {
     for (let x = 0; x < shape[y].length; x++) {
       if (shape[y][x]) {
@@ -874,8 +870,25 @@ export class TetrisAIGame {
   }
 
   private emitActivePieceUpdate(): void {
+    const displayBoard = this.board.map(row => row.map(cell => cell ? { ...cell } : null));
+    if (this.activePiece) {
+      const shape = getShape(this.activePiece.type, this.activePiece.rotation);
+      const color = getThemedColor(this.activePiece.type, 'stage', 0);
+      for (let y = 0; y < shape.length; y++) {
+        for (let x = 0; x < shape[y].length; x++) {
+          const boardY = this.activePiece.y + y;
+          const boardX = this.activePiece.x + x;
+          if (shape[y][x] && boardY >= 0 && boardY < displayBoard.length && boardX >= 0 && boardX < W) {
+            displayBoard[boardY][boardX] = { color };
+          }
+        }
+      }
+    }
+    // Send every visible input step, not just locked pieces, so the rival uses
+    // the same live-moving board presentation as the player.
+    this.callbacks.onBoardUpdate(displayBoard, this.score, this.lines, this.combo, this.activePiece?.type, this.holdPiece);
     this.callbacks.onActivePieceUpdate?.(
-      this.board,
+      displayBoard,
       this.activePiece ? { ...this.activePiece } : null,
       this.holdPiece,
     );
@@ -1002,7 +1015,11 @@ export class TetrisAIGame {
         this.activePiece = { ...this.activePiece, y: getGhostY(this.activePiece, this.board) };
         this.inputStepIndex = executionPlan.move.inputPlan.steps.length;
         this.emitActivePieceUpdate();
-        this.scheduleInputPhase(executionPlan, AI_ACTION_MS);
+        // Wait for the next beat before locking, just like rhythm play rather
+        // than resolving immediately as ordinary Tetris would.
+        const beatInterval = 60000 / BPM;
+        const elapsedInBeat = (Date.now() - this.beatStartedAt) % beatInterval;
+        this.scheduleInputPhase(executionPlan, Math.max(AI_ACTION_MS, beatInterval - elapsedInBeat));
         return;
     }
 


### PR DESCRIPTION
### Motivation

- The ranked AI previously presented a different, non-rhythmic Tetris experience and used different colors/board visuals than the player, causing mismatched visuals and unfair/unsynced opponent display.

### Description

- Update AI board presentation so the rival publishes the live moving/active piece overlay (not just locked cells) by sending a `displayBoard` to the same `onBoardUpdate`/`onActivePieceUpdate` hooks as the player in `src/lib/ranked/TetrisAI.ts`.
- Use the same themed tetromino colors as the player by replacing the AI's fixed color table with `getThemedColor(...)` when locking and rendering pieces in `src/lib/ranked/TetrisAI.ts`.
- Make AI placements respect the rhythm by delaying hard-drop input phases to the next beat interval (uses the same `BPM` timing) so AI beat judgment and placement sync with the player's rhythm system in `src/lib/ranked/TetrisAI.ts`.
- Add a beat timing indicator under the opponent board so both sides visually show the same beat/zone cursor and judgment label in `src/components/rhythmia/MultiplayerBattle.tsx`.
- Fix board layout parity so AI and player playfields share the same visible dimensions (prevent AI board from appearing different size) by adjusting `boardSection` sizing and alignment in `src/components/rhythmia/MultiplayerBattle.module.css`.

### Testing

- Ran TypeScript build check with `npx tsc --noEmit` which completed successfully.
- Ran unit tests with `npx vitest run src/components/rhythmia/__tests__/multiplayer-battle-rules.test.ts` and all tests passed (`3 tests` passed).
- Ran linting with `npx eslint src/components/rhythmia/MultiplayerBattle.tsx src/lib/ranked/TetrisAI.ts`; there were no errors (one existing unused-variable warning remains).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71bb40ee08832ba0915ce4811c8d4f)