### PR TITLE
Ranked: symmetric battle layout with HOLD on left and NEXT on right

### DIFF
--- a/src/components/rhythmia/MultiplayerBattle.module.css
+++ b/src/components/rhythmia/MultiplayerBattle.module.css
@@ -22,6 +22,65 @@
     margin-top: 8px;
 }
 
+/* Ranked play uses a tournament-style, symmetrical stage. The local board is
+   framed by HOLD on the left and NEXT on the right, while both playfields stay
+   the same size and align along their top and bottom edges. */
+.rankedArena {
+    --ranked-board-width: clamp(220px, calc((100vh - 190px) / 2), 310px);
+    --ranked-rail-width: 72px;
+    max-width: 1080px;
+    gap: 20px;
+    align-items: flex-start;
+}
+
+.rankedArena .playerSide,
+.rankedArena .opponentSide {
+    flex: 1 1 0;
+    max-width: none;
+    justify-content: center;
+}
+
+.rankedArena .playerSide {
+    display: grid;
+    grid-template-columns: var(--ranked-rail-width) var(--ranked-board-width) var(--ranked-rail-width);
+    align-items: start;
+    gap: 10px;
+}
+
+.rankedArena .sidePanel {
+    display: contents;
+}
+
+.rankedArena .holdBox {
+    grid-column: 1;
+}
+
+.rankedArena .nextBox {
+    grid-column: 3;
+}
+
+.rankedArena .boardSection {
+    grid-column: 2;
+    grid-row: 1;
+    width: var(--ranked-board-width);
+}
+
+.rankedArena .opponentSide .boardSection {
+    width: var(--ranked-board-width);
+}
+
+.rankedArena .holdBox,
+.rankedArena .nextBox {
+    width: var(--ranked-rail-width);
+    box-sizing: border-box;
+    background: rgba(0, 0, 0, 0.52);
+    border-color: rgba(255, 255, 255, 0.12);
+}
+
+.rankedArena .nextBox {
+    min-height: 192px;
+}
+
 /* Player Sides */
 .playerSide,
 .opponentSide {
@@ -689,6 +748,25 @@
     .previewCell {
         width: 10px;
         height: 10px;
+    }
+
+    .rankedArena {
+        --ranked-board-width: min(58vw, 270px);
+        --ranked-rail-width: 52px;
+        gap: 10px;
+    }
+
+    .rankedArena .playerSide {
+        display: grid;
+        grid-template-columns: var(--ranked-rail-width) var(--ranked-board-width) var(--ranked-rail-width);
+        width: auto;
+    }
+
+    .rankedArena .opponentSide .boardSection {
+        width: var(--ranked-board-width);
+        transform: scale(0.72);
+        transform-origin: top center;
+        margin-bottom: calc(var(--ranked-board-width) * -0.56);
     }
 }
 

--- a/src/components/rhythmia/MultiplayerBattle.tsx
+++ b/src/components/rhythmia/MultiplayerBattle.tsx
@@ -41,6 +41,7 @@ interface Props {
     gameSeed: number;
     onGameEnd: (winnerId: string) => void;
     onBackToLobby: () => void;
+    rankedLayout?: boolean;
 }
 
 // ===== Component =====
@@ -53,6 +54,7 @@ export const MultiplayerBattle: React.FC<Props> = ({
     gameSeed,
     onGameEnd,
     onBackToLobby,
+    rankedLayout = false,
 }) => {
     const opponent = opponents[0];
     const { awardGamePoints, awardMultiplayerWinPoints } = useSkillTree();
@@ -1231,7 +1233,7 @@ export const MultiplayerBattle: React.FC<Props> = ({
             {/* Floating item drops from terrain */}
             <FloatingItems items={floatingItems} />
 
-            <div className={styles.battleArena}>
+            <div className={`${styles.battleArena} ${rankedLayout ? styles.rankedArena : ''}`}>
                 {/* Player Side */}
                 <div className={styles.playerSide}>
                     {/* Hold + Next */}

--- a/src/components/rhythmia/RankedMatch.tsx
+++ b/src/components/rhythmia/RankedMatch.tsx
@@ -384,6 +384,7 @@ export default function RankedMatch({ playerName, onBack, ws, connectionStatus, 
             gameSeed={gameSeed}
             onGameEnd={handleGameEnd}
             onBackToLobby={handleBackToLobby}
+            rankedLayout
           />
           {connectionStatus !== 'connected' && (
             <div className={styles.reconnectingOverlay}>


### PR DESCRIPTION
### Motivation

- Improve ranked-match visual clarity by placing the `HOLD` panel on the left and the `NEXT` panel on the right and by adjusting playfield framing so both competitors' boards are visually balanced and aligned.

### Description

- Add an optional `rankedLayout?: boolean` prop to `MultiplayerBattle` and apply it to the local match instance used for ranked play so the layout changes are opt-in and non-breaking.
- Apply a conditional class to the battle container (`${styles.battleArena} ${rankedLayout ? styles.rankedArena : ''}`) and wire `rankedLayout` from `RankedMatch` when launching ranked games.
- Introduce a `.rankedArena` stylesheet in `MultiplayerBattle.module.css` that uses a 3-column grid to place `HOLD` (left), the playfield (center), and `NEXT` (right), keeps both playfields the same size, and includes responsive sizing rules for smaller viewports.

### Testing

- Type-checked the project with `npx tsc --noEmit`, which completed successfully. 
- Ran linting for the changed files with `npx eslint src/components/rhythmia/MultiplayerBattle.tsx src/components/rhythmia/RankedMatch.tsx`, which passed without errors. 
- Executed the multiplayer rules unit test with `npm test -- --run src/components/rhythmia/__tests__/multiplayer-battle-rules.test.ts`, and all tests passed (`3 passed`). 
- Verified code style and diff checks via `git diff --check`, which produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71c4121c2c832b8fbaf5ed0c821432)