### PR TITLE
Add fever rainbow cell coloring for ranked multiplayer boards

### DIFF
--- a/src/components/rhythmia/MultiplayerBattle.tsx
+++ b/src/components/rhythmia/MultiplayerBattle.tsx
@@ -32,6 +32,45 @@ const VoxelWorldBackground = dynamic(() => import('./VoxelWorldBackground'), {
     ssr: false,
 });
 
+
+const getFeverColor = (baseColor: string, cellIndex: number, combo: number, beatPhase: number) => {
+    if (combo < 10) return baseColor;
+
+    const comboVelocity = 1 + Math.min(1.5, (combo - 10) * 0.08);
+    const baseHue = (beatPhase * 360 * comboVelocity) % 360;
+    const row = Math.floor(cellIndex / W);
+    const col = cellIndex % W;
+    const boardWaveOffset = row * 13 + col * 23;
+
+    return `hsl(${(baseHue + boardWaveOffset) % 360}, 90%, 60%)`;
+};
+
+const getBattleCellStyle = (
+    cell: ({ color: string; ghost?: boolean } | null),
+    cellIndex: number,
+    combo: number,
+    beatPhase: number,
+    glowAlpha = '40'
+): React.CSSProperties => {
+    if (!cell) return {};
+
+    const color = getFeverColor(cell.color, cellIndex, combo, beatPhase);
+
+    if (cell.ghost) {
+        return {
+            borderColor: combo >= 10 ? `${color}CC` : `${color}40`,
+            boxShadow: combo >= 10 ? `0 0 12px ${color}80, inset 0 0 6px ${color}40` : 'none',
+        };
+    }
+
+    return {
+        backgroundColor: color,
+        boxShadow: combo >= 10
+            ? `0 0 12px ${color}, 0 0 4px ${color}`
+            : `0 0 8px ${color}${glowAlpha}`,
+    };
+};
+
 interface Props {
     ws: WebSocket;
     roomCode: string;
@@ -1304,7 +1343,7 @@ export const MultiplayerBattle: React.FC<Props> = ({
                                     <div
                                         key={i}
                                         className={`${styles.cell} ${cell && !cell.ghost ? styles.filled : ''} ${cell?.ghost ? styles.ghost : ''}`}
-                                        style={cell && !cell.ghost ? { backgroundColor: cell.color, boxShadow: `0 0 8px ${cell.color}40` } : cell?.ghost ? { borderColor: `${cell.color}40` } : {}}
+                                        style={getBattleCellStyle(cell, i, combo, beatPhaseDisplay)}
                                     />
                                 ))}
                             </div>
@@ -1382,7 +1421,7 @@ export const MultiplayerBattle: React.FC<Props> = ({
                                     <div
                                         key={i}
                                         className={`${styles.cell} ${cell ? styles.filled : ''}`}
-                                        style={cell ? { backgroundColor: cell.color, boxShadow: `0 0 6px ${cell.color}40` } : {}}
+                                        style={getBattleCellStyle(cell, i, opponentCombo, beatPhaseDisplay, '30')}
                                     />
                                 ))}
                             </div>


### PR DESCRIPTION
### Motivation
- Bring the same "fever" rainbow visual (currently present in singleplayer) to ranked/multiplayer boards when a player reaches 10+ combo so ranked matches visually match singleplayer fever behavior.

### Description
- Added `getFeverColor` to compute an HSL rainbow color based on the cell index, beat phase and combo velocity so fever colors animate as a wave across the board.
- Added `getBattleCellStyle` to centralize cell styling (normal, ghost and fever states) and produce the animated rainbow background/outline and glow when `combo >= 10`.
- Replaced the inline cell style generation for both the local player board and the opponent board with `getBattleCellStyle`, passing `combo` / `opponentCombo` and `beatPhaseDisplay` so both playfields show fever when their combo reaches 10+.
- File modified: `src/components/rhythmia/MultiplayerBattle.tsx` (added helpers and updated local/opponent cell rendering).

### Testing
- Ran `npx eslint src/components/rhythmia/MultiplayerBattle.tsx`, which completed successfully with no errors.
- Ran `npm run lint`, which completed and reported only existing warnings (no lint errors), therefore the change did not introduce lint failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72ec9dcba8832b893e8b2c016e748c)