### PR TITLE
Fix ranked battle board layout and add AI HOLD/NEXT previews

### DIFF
--- a/src/components/rhythmia/MultiplayerBattle.module.css
+++ b/src/components/rhythmia/MultiplayerBattle.module.css
@@ -40,7 +40,8 @@
     justify-content: center;
 }
 
-.rankedArena .playerSide {
+.rankedArena .playerSide,
+.rankedArena .opponentSide {
     display: grid;
     grid-template-columns: var(--ranked-rail-width) var(--ranked-board-width) var(--ranked-rail-width);
     align-items: start;
@@ -65,9 +66,6 @@
     width: var(--ranked-board-width);
 }
 
-.rankedArena .opponentSide .boardSection {
-    width: var(--ranked-board-width);
-}
 
 .rankedArena .holdBox,
 .rankedArena .nextBox {
@@ -756,17 +754,16 @@
         gap: 10px;
     }
 
-    .rankedArena .playerSide {
+    .rankedArena .playerSide,
+    .rankedArena .opponentSide {
         display: grid;
         grid-template-columns: var(--ranked-rail-width) var(--ranked-board-width) var(--ranked-rail-width);
         width: auto;
     }
 
     .rankedArena .opponentSide .boardSection {
-        width: var(--ranked-board-width);
-        transform: scale(0.72);
-        transform-origin: top center;
-        margin-bottom: calc(var(--ranked-board-width) * -0.56);
+        transform: none;
+        margin-bottom: 0;
     }
 }
 

--- a/src/components/rhythmia/MultiplayerBattle.tsx
+++ b/src/components/rhythmia/MultiplayerBattle.tsx
@@ -139,6 +139,8 @@ export const MultiplayerBattle: React.FC<Props> = ({
     const opponentScoreRef = useRef(0);
     const opponentLinesRef = useRef(0);
     const opponentComboRef = useRef(0);
+    const opponentHoldRef = useRef<PieceType | null>(null);
+    const opponentNextQueueRef = useRef<PieceType[]>([]);
 
     // For re-rendering
     const [, forceRender] = useState(0);
@@ -332,6 +334,7 @@ export const MultiplayerBattle: React.FC<Props> = ({
             combo: comboRef.current,
             piece: pieceRef.current?.type,
             hold: holdRef.current,
+            nextQueue: nextQueueRef.current.slice(0, 3),
         });
     }, [sendRelay]);
 
@@ -794,6 +797,8 @@ export const MultiplayerBattle: React.FC<Props> = ({
                         opponentScoreRef.current = payload.score;
                         opponentLinesRef.current = payload.lines;
                         opponentComboRef.current = payload.combo ?? 0;
+                        opponentHoldRef.current = (payload.hold as PieceType | null | undefined) ?? null;
+                        opponentNextQueueRef.current = (payload.nextQueue as PieceType[] | undefined) ?? [];
                         render();
                     } else if (payload.event === 'garbage') {
                         pendingGarbageRef.current += payload.lines;
@@ -864,6 +869,8 @@ export const MultiplayerBattle: React.FC<Props> = ({
         liveNotifiedRef.current = new Set();
         setToastIds([]);
         opponentBoardRef.current = createEmptyBoard();
+        opponentHoldRef.current = null;
+        opponentNextQueueRef.current = [];
         opponentScoreRef.current = 0;
         opponentLinesRef.current = 0;
         opponentComboRef.current = 0;
@@ -1121,6 +1128,8 @@ export const MultiplayerBattle: React.FC<Props> = ({
     const opponentScore = opponentScoreRef.current;
     const opponentLines = opponentLinesRef.current;
     const opponentCombo = opponentComboRef.current;
+    const opponentHold = opponentHoldRef.current;
+    const opponentNextQueue = opponentNextQueueRef.current;
 
     // Beat phase indicator position (0 = start of beat, 1 = end)
     const beatIndicatorPos = beatPhaseDisplay;
@@ -1363,6 +1372,22 @@ export const MultiplayerBattle: React.FC<Props> = ({
 
                 {/* Opponent Side */}
                 <div className={styles.opponentSide}>
+                    {/* AI/Opponent Hold + Next */}
+                    <div className={styles.sidePanel}>
+                        <div className={styles.holdBox}>
+                            <div className={styles.panelLabel}>HOLD</div>
+                            {opponentHold ? renderPreview(opponentHold) : <div className={styles.emptyPreview} />}
+                        </div>
+                        <div className={styles.nextBox}>
+                            <div className={styles.panelLabel}>NEXT</div>
+                            {opponentNextQueue.slice(0, 3).map((type, i) => (
+                                <div key={i} className={styles.nextItem}>
+                                    {renderPreview(type)}
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+
                     <div className={styles.boardSection}>
                         <div className={styles.opponentHeader}>
                             <div className={styles.opponentName}>{opponent?.name || 'Opponent'}</div>

--- a/src/types/multiplayer.ts
+++ b/src/types/multiplayer.ts
@@ -512,6 +512,7 @@ export interface BoardUpdatePayload {
   combo: number;
   piece?: string;
   hold?: string | null;
+  nextQueue?: string[];
 }
 
 export interface GarbagePayload {


### PR DESCRIPTION
### Motivation
- Ranked matches rendered the AI/opponent playfield at a different size and layout than the player, and the AI side lacked HOLD/NEXT previews, causing inconsistent UI during ranked matches.

### Description
- Unify the ranked three-column grid so both `.playerSide` and `.opponentSide` use the same column layout and configured board width in `src/components/rhythmia/MultiplayerBattle.module.css`.
- Remove the opponent-side scaling/margin overrides so the opponent playfield aligns and matches the player board size and top/bottom edges.
- Add opponent hold/next state tracking (`opponentHoldRef`, `opponentNextQueueRef`), send the local `nextQueue` with `board_update` relays, and parse incoming `hold`/`nextQueue` to render HOLD and NEXT previews for the AI/opponent side in `src/components/rhythmia/MultiplayerBattle.tsx`.
- Extend the relay payload type by adding `nextQueue?: string[]` to `BoardUpdatePayload` in `src/types/multiplayer.ts`.

### Testing
- Ran `npm run lint`, which completed successfully (only pre-existing warnings reported).
- Ran `npm run build`, which completed successfully though the build emitted unrelated i18n/metadata warnings but returned without errors.
- Started a local dev server (`next dev`) and verified the ranked layout now keeps both boards the same size and that the AI/opponent side displays HOLD and NEXT previews as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72ec10f8cc832bb9bc2c4d14389301)