### PR TITLE
Fix ranked garbage cancellation topouts

### DIFF
--- a/src/components/rhythmia/MultiplayerBattle.tsx
+++ b/src/components/rhythmia/MultiplayerBattle.tsx
@@ -579,16 +579,11 @@ export const MultiplayerBattle: React.FC<Props> = ({
         gamePiecesPlacedRef.current++;
 
         // Lock to board
-        let newBoard = lockPiece(piece, boardRef.current, worldIdx);
+        const newBoard = lockPiece(piece, boardRef.current, worldIdx);
 
-        // Apply pending garbage before clearing
-        const garbage = pendingGarbageRef.current;
-        if (garbage > 0) {
-            newBoard = addGarbageLines(newBoard, garbage, garbageRngRef.current);
-            pendingGarbageRef.current = 0;
-        }
-
-        // Clear lines
+        // Clear lines before applying pending garbage so the outgoing attack from this
+        // placement can cancel incoming garbage. Applying lethal queued garbage before
+        // cancellation caused ranked AI matches to top out even when the clear fully offset it.
         const { board: clearedBoard, cleared, clearedRows } = clearLines(newBoard);
         boardRef.current = clearedBoard;
 
@@ -654,7 +649,11 @@ export const MultiplayerBattle: React.FC<Props> = ({
             const clearResult = resolveBattlePlacement(cleared, tSpin, timing, previousCombo);
             scoreRef.current += clearResult.score;
             linesRef.current += cleared;
-            sendGarbage(clearResult.garbage);
+
+            const canceledGarbage = Math.min(pendingGarbageRef.current, clearResult.garbage);
+            pendingGarbageRef.current -= canceledGarbage;
+            const outgoingGarbage = clearResult.garbage - canceledGarbage;
+            sendGarbage(outgoingGarbage);
             playLineClear(cleared, worldIdx);
 
             // VFX: line clear (offset rows by BUFFER_ZONE for VFX hook coordinate system)
@@ -665,6 +664,11 @@ export const MultiplayerBattle: React.FC<Props> = ({
                 onBeat: timing !== 'miss',
                 combo: comboRef.current,
             });
+        }
+
+        if (cleared === 0 && pendingGarbageRef.current > 0) {
+            boardRef.current = addGarbageLines(boardRef.current, pendingGarbageRef.current, garbageRngRef.current);
+            pendingGarbageRef.current = 0;
         }
 
         pieceRef.current = null;

--- a/src/lib/ranked/TetrisAI.ts
+++ b/src/lib/ranked/TetrisAI.ts
@@ -1103,13 +1103,10 @@ export class TetrisAIGame {
       .at(-1);
     const wasRotation = lastMovement === 'rotateCW' || lastMovement === 'rotateCCW';
 
-    // Lock piece, then receive pending garbage before clearing just like the player.
+    // Lock piece, then clear before applying pending garbage so outgoing garbage
+    // from this placement can cancel incoming garbage using the same rules as the player.
     const boardBeforeLock = this.board.map(row => [...row]);
     this.board = lockPiece(landedPiece, this.board);
-    if (this.pendingGarbage > 0) {
-      this.applyGarbage(this.pendingGarbage);
-      this.pendingGarbage = 0;
-    }
 
     // Clear lines
     const { board: clearedBoard, cleared } = clearLines(this.board);
@@ -1121,7 +1118,16 @@ export class TetrisAIGame {
     this.combo = result.combo;
     this.score += result.score;
     this.lines += cleared;
-    if (result.garbage > 0) this.callbacks.onGarbage(result.garbage);
+
+    const canceledGarbage = Math.min(this.pendingGarbage, result.garbage);
+    this.pendingGarbage -= canceledGarbage;
+    const outgoingGarbage = result.garbage - canceledGarbage;
+    if (outgoingGarbage > 0) this.callbacks.onGarbage(outgoingGarbage);
+
+    if (cleared === 0 && this.pendingGarbage > 0) {
+      this.applyGarbage(this.pendingGarbage);
+      this.pendingGarbage = 0;
+    }
 
     // Emit board update
     this.callbacks.onBoardUpdate(


### PR DESCRIPTION
### Motivation
- Ranked matches could top out when lethal pending garbage was applied before a placement's line clear could cancel it, causing unfair deaths especially against AI opponents.
- The intent is to make outgoing garbage from a placement able to cancel incoming pending garbage using the same rules the player expects.

### Description
- In `src/components/rhythmia/MultiplayerBattle.tsx` change the lock flow to `clearLines` before applying pending garbage so the placement's outgoing garbage can cancel incoming garbage. 
- Add explicit cancellation logic that computes `canceledGarbage = Math.min(pendingGarbageRef.current, clearResult.garbage)` and only `sendGarbage` for the remaining `outgoingGarbage`, and only apply queued garbage immediately when the placement clears zero lines. 
- Mirror the same change in the AI implementation in `src/lib/ranked/TetrisAI.ts` so the `TetrisAIGame` uses the same clear-then-cancel semantics and only applies pending garbage if no lines were cleared. 
- Small cleanup: make the locked board variable `const newBoard` to satisfy lint rules.

### Testing
- Ran lint with `npm run lint` and it completed successfully (only preexisting warnings remained). 
- Ran unit tests with `npm test` and all tests passed: 4 test files, 68 tests (all green). 
- Verified the modified gameplay paths locally by running the affected ranked/AI flows and ensuring clears cancel pending garbage instead of causing premature top-outs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73ab326d94832b9abf4a39384fb985)