### PR TITLE
Implement B2B and Perfect Clear garbage rules and fix garbage calculation

### DIFF
--- a/src/components/rhythmia/MultiplayerBattle.tsx
+++ b/src/components/rhythmia/MultiplayerBattle.tsx
@@ -586,6 +586,7 @@ export const MultiplayerBattle: React.FC<Props> = ({
         // cancellation caused ranked AI matches to top out even when the clear fully offset it.
         const { board: clearedBoard, cleared, clearedRows } = clearLines(newBoard);
         boardRef.current = clearedBoard;
+        const wasBackToBack = lastClearWasDifficultRef.current;
 
         // Compose and show action messages (T-spin, Tetris, Back-to-Back)
         {
@@ -646,7 +647,17 @@ export const MultiplayerBattle: React.FC<Props> = ({
             const boardCenterY = window.innerHeight / 2;
             spawnTerrainParticles(clearedRows, boardCenterX, boardCenterY);
 
-            const clearResult = resolveBattlePlacement(cleared, tSpin, timing, previousCombo);
+            const isDifficultClear = cleared === 4 || tSpin !== 'none';
+            const isBackToBack = isDifficultClear && wasBackToBack;
+            const isPerfectClear = clearedBoard.every(row => row.every(cell => cell === null));
+            const clearResult = resolveBattlePlacement(
+                cleared,
+                tSpin,
+                timing,
+                previousCombo,
+                isBackToBack,
+                isPerfectClear,
+            );
             scoreRef.current += clearResult.score;
             linesRef.current += cleared;
 

--- a/src/components/rhythmia/__tests__/multiplayer-battle-rules.test.ts
+++ b/src/components/rhythmia/__tests__/multiplayer-battle-rules.test.ts
@@ -6,7 +6,7 @@ describe('resolveBattlePlacement', () => {
         expect(resolveBattlePlacement(2, 'none', 'perfect', 2)).toEqual({
             combo: 3,
             score: 1800,
-            garbage: 2,
+            garbage: 1,
         });
         expect(resolveBattlePlacement(2, 'none', 'miss', 8)).toEqual({
             combo: 0,
@@ -15,12 +15,33 @@ describe('resolveBattlePlacement', () => {
         });
     });
 
-    it('applies the same T-spin and combo garbage bonuses', () => {
+    it('does not add a garbage bonus for rhythm combos', () => {
         expect(resolveBattlePlacement(2, 'full', 'great', 5)).toEqual({
             combo: 6,
             score: 13500,
-            garbage: 7,
+            garbage: 4,
         });
+    });
+
+    it.each([
+        [1, 'none', 0], [2, 'none', 1], [3, 'none', 2], [4, 'none', 4],
+        [1, 'mini', 0], [2, 'mini', 1],
+        [1, 'full', 2], [2, 'full', 4], [3, 'full', 6],
+    ] as const)('sends guideline garbage for %i cleared with %s T-spin', (cleared, tSpin, garbage) => {
+        expect(resolveBattlePlacement(cleared, tSpin, 'good', 0).garbage).toBe(garbage);
+    });
+
+    it('adds the guideline back-to-back bonus for each difficult clear', () => {
+        expect(resolveBattlePlacement(1, 'mini', 'good', 0, true).garbage).toBe(1);
+        expect(resolveBattlePlacement(1, 'full', 'good', 0, true).garbage).toBe(3);
+        expect(resolveBattlePlacement(2, 'full', 'good', 0, true).garbage).toBe(6);
+        expect(resolveBattlePlacement(3, 'full', 'good', 0, true).garbage).toBe(9);
+        expect(resolveBattlePlacement(4, 'none', 'good', 0, true).garbage).toBe(6);
+    });
+
+    it('adds ten garbage rows for a perfect clear', () => {
+        expect(resolveBattlePlacement(1, 'none', 'good', 0, false, true).garbage).toBe(10);
+        expect(resolveBattlePlacement(4, 'none', 'good', 0, false, true).garbage).toBe(14);
     });
 
     it('updates rhythm combo even when no line is cleared', () => {

--- a/src/components/rhythmia/multiplayer-battle-rules.ts
+++ b/src/components/rhythmia/multiplayer-battle-rules.ts
@@ -18,6 +18,8 @@ export function resolveBattlePlacement(
     tSpin: TSpinResult,
     timing: BeatJudgment,
     previousCombo: number,
+    backToBack = false,
+    perfectClear = false,
 ): BattlePlacementResult {
     const combo = timing === 'miss' ? 0 : previousCombo + 1;
 
@@ -32,13 +34,26 @@ export function resolveBattlePlacement(
         base += 100 + 200 * cleared;
     }
 
-    let garbage = [0, 0, 1, 2, 4][cleared] ?? 0;
+    let garbage: number;
     if (tSpin === 'full') {
-        garbage += [0, 2, 4, 6, 6][cleared] ?? 0;
+        garbage = [0, 2, 4, 6][cleared] ?? 0;
     } else if (tSpin === 'mini') {
-        garbage += 1;
+        garbage = [0, 0, 1][cleared] ?? 0;
+    } else {
+        garbage = [0, 0, 1, 2, 4][cleared] ?? 0;
     }
-    garbage += Math.floor(combo / 3);
+
+    if (backToBack) {
+        if (tSpin === 'full' && cleared === 3) {
+            garbage += 3;
+        } else if ((tSpin === 'full' && cleared === 2) || (tSpin === 'none' && cleared === 4)) {
+            garbage += 2;
+        } else {
+            garbage += 1;
+        }
+    }
+
+    if (perfectClear) garbage += 10;
 
     return {
         combo,

--- a/src/lib/ranked/TetrisAI.ts
+++ b/src/lib/ranked/TetrisAI.ts
@@ -737,6 +737,7 @@ export class TetrisAIGame {
   private score = 0;
   private lines = 0;
   private combo = 0;
+  private lastClearWasDifficult = false;
   private gameOver = false;
   private difficulty: AIDifficulty;
   private speedMultiplier = 1;
@@ -1114,7 +1115,18 @@ export class TetrisAIGame {
     const tSpin = detectTSpin(landedPiece, boardBeforeLock, wasRotation);
     const beatInterval = 60000 / BPM;
     const beatPhase = ((Date.now() - this.beatStartedAt) % beatInterval) / beatInterval;
-    const result = resolveBattlePlacement(cleared, tSpin, getBeatJudgment(beatPhase), this.combo);
+    const isDifficultClear = cleared > 0 && (cleared === 4 || tSpin !== 'none');
+    const isBackToBack = isDifficultClear && this.lastClearWasDifficult;
+    const isPerfectClear = cleared > 0 && this.board.every(row => row.every(cell => cell === null));
+    const result = resolveBattlePlacement(
+      cleared,
+      tSpin,
+      getBeatJudgment(beatPhase),
+      this.combo,
+      isBackToBack,
+      isPerfectClear,
+    );
+    if (cleared > 0) this.lastClearWasDifficult = isDifficultClear;
     this.combo = result.combo;
     this.score += result.score;
     this.lines += cleared;


### PR DESCRIPTION
### Motivation
- Align outgoing garbage calculation with guideline rules by adding Back-to-Back and Perfect Clear handling to battle resolution.
- Remove unintended rhythm-combo garbage bonus so combo no longer directly increases sent garbage.
- Ensure both player and AI follow the same garbage logic for fair multiplayer behavior.

### Description
- Change `resolveBattlePlacement` signature to accept `backToBack` and `perfectClear` flags and rewrite its garbage computation to use corrected guideline tables, apply B2B bonuses, and add `+10` garbage for perfect clears while removing the combo-based garbage increment.
- Update `MultiplayerBattle.tsx` to detect `wasBackToBack` and compute `isBackToBack`/`isPerfectClear` when calling `resolveBattlePlacement` and retain B2B state updates as before.
- Update `TetrisAIGame` in `TetrisAI.ts` by adding `lastClearWasDifficult` state, computing `isBackToBack`/`isPerfectClear` for AI placements, passing those flags into `resolveBattlePlacement`, and updating the B2B tracker.
- Update unit tests in `__tests__/multiplayer-battle-rules.test.ts` to reflect the corrected garbage values and add cases covering guideline garbage amounts, B2B behavior, and perfect clear garbage.

### Testing
- Ran unit tests in `__tests__/multiplayer-battle-rules.test.ts` with `vitest` after updates, and all tests passed.
- Executed the repository test suite (`vitest`) to validate integration with AI and multiplayer rule changes, and the suite passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73c212b988832ba7d891d45eb5a7c1)